### PR TITLE
generic.MeshScript rewritten to work under Windows

### DIFF
--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -47,5 +47,10 @@ class MeshScript:
     
     def __exit__(self, *args, **kwargs):
         # delete all the freaking temporary files
+        from os import remove
+        remove(self.script_out.name)
+        for f in self.mesh_pre:
+            remove(f)
+        remove(self.mesh_post)
         pass
 

--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -18,7 +18,7 @@ class MeshScript:
 
         # export the meshes to a temporary STL container
         for m, f in zip(self.meshes, self.mesh_pre):
-            m.export(file_type='stl', file_obj=f.name)
+            m.export(file_type='stl', file_obj=f)
 
         self.replacement = {'mesh_' + str(i) : m.name for i,m in enumerate(self.mesh_pre)}
         self.replacement['mesh_pre']  = str([i.name for i in self.mesh_pre])

--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -12,22 +12,27 @@ class MeshScript:
         self.script  = script
 
     def __enter__(self):
-        self.mesh_pre = [NamedTemporaryFile(suffix='.STL', mode='wb') for i in self.meshes]
-        self.mesh_post  = NamedTemporaryFile(suffix='.STL', mode='rb')
-        self.script_out = NamedTemporaryFile(mode='wb')
+        self.script_out = NamedTemporaryFile(mode='wb', delete=False)
+        tempname=self.script_out.name
+        
+        self.mesh_post  = '%s_out.STL'%tempname
 
         # export the meshes to a temporary STL container
-        for m, f in zip(self.meshes, self.mesh_pre):
+        self.replacement={}
+        self.mesh_pre = []
+        for i, m in enumerate(self.meshes):
+            f='%s_%d.STL'%(tempname,i+1)
+            self.mesh_pre.append(f)
+            self.replacement['mesh_%d'%i]=f
             m.export(file_type='stl', file_obj=f)
 
-        self.replacement = {'mesh_' + str(i) : m.name for i,m in enumerate(self.mesh_pre)}
-        self.replacement['mesh_pre']  = str([i.name for i in self.mesh_pre])
-        self.replacement['mesh_post'] = self.mesh_post.name
+        self.replacement['mesh_pre']  = str([f for f in self.mesh_pre])
+        self.replacement['mesh_post'] = self.mesh_post
         self.replacement['script']    = self.script_out.name
 
         script_text = Template(self.script).substitute(self.replacement)
         self.script_out.write(script_text.encode('utf-8'))
-        self.script_out.flush()
+        self.script_out.close()
         return self
 
     def run(self, command):
@@ -36,13 +41,11 @@ class MeshScript:
         check_call(command_run)
 
         # bring the binaries result back as a Trimesh object
-        self.mesh_post.seek(0)
-        mesh_result = load_stl(self.mesh_post)
+        with open(self.mesh_post, mode='rb') as f:
+            mesh_result = load_stl(f)
         return mesh_result
     
     def __exit__(self, *args, **kwargs):
-        # close all the freaking temporary files
-        self.mesh_post.close()
-        self.script_out.close()
-        for f in self.mesh_pre:
-            f.close()
+        # delete all the freaking temporary files
+        pass
+

--- a/trimesh/resources/blender.py.template
+++ b/trimesh/resources/blender.py.template
@@ -19,7 +19,7 @@ if __name__ == "__main__":
   bpy.ops.object.delete(use_global=True)
 
   mesh_pre  = $mesh_pre
-  mesh_post = os.path.abspath('$mesh_post')
+  mesh_post = os.path.abspath(r'$mesh_post')
 
   # When you add objects to blender, other elements are pushed back
   # by going last to first on the filenames we can preserve the index relation


### PR DESCRIPTION
Windows does not allow another process (Blender) to open files that are open.
I rewrote generic.MeshScript.__enter__to close files after creation and store file names that are deleted in __exit__

Also had to put a "r" qualifier in blender.py.template, but now trimesh can perform boolean operations under Windows !