### PR TITLE
Adjust trimesh.intersections.mesh_plane so that it returns vertex distances

### DIFF
--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1062,7 +1062,7 @@ class Trimesh(object):
         from .io.load import load_path
         lines = intersections.mesh_plane(mesh=self,
                                          plane_normal=plane_normal,
-                                         plane_origin=plane_origin)
+                                         plane_origin=plane_origin)[0]
         if len(lines) == 0:
             raise ValueError('Specified plane doesn\'t intersect mesh!')
         path = load_path(lines)


### PR DESCRIPTION
Howdy, 

I have made some adjustments/additions to the `mesh_plane` function so that, in addition to returning the intersection line vertices, it also returns:

 - The faces of all intersected triangles
 - The distances from the intersection line vertices to the intersected triangle vertices (normalised and inverted).

I did this in order to be able to linearly interpolate vertex data values from the triangle vertices to the intersection line vertices. 

For example, the following figure shows an intersected triangle, and the intersection line. Each intersection line vertex is labelled with the "contribution" (just the distance between the triangle and line vertices, normalised and inverted) of each triangle vertex:

![example](https://cloud.githubusercontent.com/assets/236128/23103123/a6c1029a-f6ad-11e6-9019-aeacc7a3ff0a.png)

These distance values can be used to apply data values to the intersection line vertices, interpolated from the data values associated with the triangle vertices.

If you are interested in incorporating this, I am happy to add some test cases.

Cheers,

Paul