### PR TITLE
windows compatible script_text

### DIFF
--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -38,6 +38,7 @@ class MeshScript:
         self.replacement['script'] = self.script_out.name
 
         script_text = Template(self.script).substitute(self.replacement)
+        script_text = script_text.replace("\\", "\\\\")
         self.script_out.write(script_text.encode('utf-8'))
 
         # close all temporary files


### PR DESCRIPTION
Dear Michael, :)

when I apply boolean operations (python 2.7.10, scad engine, win10, 64bit), execution fails with message:
> WARNING: Can't open import file '"c:usersschaeferappdatalocal\temp\tmprzu3wa.STL"'.

I figured out, that it is due to the temporary generated scad-script containing single backslashes. This commit fixes the issue by replacing the single backslashes with escaped backslashes in the scad-script .

Successfully tested with scad- and blender-engine on Windows.
Not tested for Linux version, but should also work.

Implementing the fix via "self.replacement['\\'] = '\\\\'" would be cleaner, but unfortunately does not seem to work.

Best regards
David