### PR TITLE
Fix bug in the ray tracer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,108 @@
-*.py[cod]
+# Temporary files
 *~
 *.swp
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/trimesh/intersections.py
+++ b/trimesh/intersections.py
@@ -243,3 +243,44 @@ def planes_lines(plane_origins,
     on_plane += line_origins[valid]
 
     return on_plane, valid
+
+def planes_rays(plane_origins,
+                plane_normals,
+                ray_origins,
+                ray_directions):
+    '''
+    Given one ray per plane, find the intersection points
+
+    Parameters
+    -----------
+    plane_origins:  (n,3) float, plane origins
+    plane_normals:  (n,3) float, plane normals
+    ray_origins:    (n,3) float, ray origins
+    ray_directions: (n,3) float, ray directions
+
+    Returns
+    ----------
+    on_plane: (n,3) float, points on specified planes
+    valid:    (n,) bool, did plane intersect line or not
+    '''
+
+    plane_origins  = np.asanyarray(plane_origins, dtype=np.float64)
+    plane_normals  = np.asanyarray(plane_normals, dtype=np.float64)
+    ray_origins    = np.asanyarray(ray_origins, dtype=np.float64)
+    ray_directions = np.asanyarray(ray_directions, dtype=np.float64)
+
+    origin_vectors = plane_origins - ray_origins
+
+    projection_ori = util.diagonal_dot(origin_vectors, plane_normals)
+    projection_dir = util.diagonal_dot(ray_directions, plane_normals)
+
+    valid = np.logical_and(np.abs(projection_dir) > tol.merge,
+                           projection_ori * projection_dir > 0)
+
+    distance = np.divide(projection_ori[valid],
+                         projection_dir[valid])
+
+    on_plane = ray_directions[valid] * distance.reshape((-1, 1))
+    on_plane += ray_origins[valid]
+
+    return on_plane, valid

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -141,11 +141,11 @@ class RayMeshIntersector:
                 break
 
             # find the location of where the ray hit the triangle plane
-            new_origins, valid = intersections.planes_lines(
+            new_origins, valid = intersections.planes_rays(
                 plane_origins=plane_origins[hit_triangle],
                 plane_normals=plane_normals[hit_triangle],
-                line_origins=ray_origins[current],
-                line_directions=ray_directions[current])
+                ray_origins=ray_origins[current],
+                ray_directions=ray_directions[current])
 
             if not valid.all():
                 # since a plane intersection was invalid we have to go back and

--- a/trimesh/ray/ray_triangle.py
+++ b/trimesh/ray/ray_triangle.py
@@ -177,9 +177,6 @@ def ray_triangle_id(triangles,
     # get subsets which are corresponding rays and triangles
     # (c,3,3) triangle candidates
     triangle_candidates = triangles[ray_candidates]
-    # (c,3) origins and vectors for the rays
-    line_origins = ray_origins[ray_id]
-    line_directions = ray_directions[ray_id]
 
     # get the plane origins and normals from the triangle candidates
     plane_origins = triangle_candidates[:, 0, :]
@@ -191,10 +188,10 @@ def ray_triangle_id(triangles,
         plane_normals = triangles_normal[ray_candidates]
 
     # find the intersection location of the rays with the planes
-    location, valid = intersections.planes_lines(plane_origins=plane_origins,
-                                                 plane_normals=plane_normals,
-                                                 line_origins=line_origins,
-                                                 line_directions=line_directions)
+    location, valid = intersections.planes_rays(plane_origins=plane_origins,
+                                                plane_normals=plane_normals,
+                                                ray_origins=ray_origins[ray_id],
+                                                ray_directions=ray_directions[ray_id])
 
     if (len(triangle_candidates) == 0 or
             not valid.any()):


### PR DESCRIPTION
Basically, the ray tracer assumed that the planes given to the function
planes_lines() all intersected the ray in the positive direction.
This assumption was made because planes intersecting the ray in the
negative direction should have been pruned via the rtree. However, if
the ray's origin is too close to any triangle, the triangle won't be
pruned even if intersects the ray in the negative direction.

In order to fix this, this commit adds a new function, planes_rays(),
that performs the check explicitly. The ray tracers now call this
function instead of planes_lines() by default.