### PR TITLE
Add mesh-mesh collision checking

### DIFF
--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -1,0 +1,76 @@
+import generic as g
+
+
+class CollisionTest(g.unittest.TestCase):
+
+    def test_collision(self):
+        # Ensure that FCL is importable
+        try:
+            g.trimesh.collision.CollisionManager()
+        except ValueError:
+            g.log.warning('skipping collision tests, no FCL installed', engine)
+            return
+
+        cube = g.get_mesh('unit_cube.STL')
+
+        tf1 = g.np.eye(4)
+        tf1[:3,3] = g.np.array([5, 0, 0])
+
+        tf2 = g.np.eye(4)
+        tf2[:3,3] = g.np.array([-5, 0, 0])
+
+        # Test one-to-many collision checking
+        m = g.trimesh.collision.CollisionManager()
+        m.add_object('cube0', cube)
+        m.add_object('cube1', cube, tf1)
+
+        ret = m.in_collision_single(cube)
+        self.assertTrue(ret == True)
+
+        ret = m.in_collision_single(cube, tf1)
+        self.assertTrue(ret == True)
+
+        ret = m.in_collision_single(cube, tf2)
+        self.assertTrue(ret == False)
+
+        # Test internal collision checking and object addition/removal/modification
+        ret = m.in_collision_internal()
+        self.assertTrue(ret == False)
+
+        m.add_object('cube2', cube, tf1)
+        ret = m.in_collision_internal()
+        self.assertTrue(ret == True)
+
+        m.set_transform('cube2', tf2)
+        ret = m.in_collision_internal()
+        self.assertTrue(ret == False)
+
+        m.set_transform('cube2', tf1)
+        ret = m.in_collision_internal()
+        self.assertTrue(ret == True)
+
+        m.remove_object('cube2')
+        ret = m.in_collision_internal()
+        self.assertTrue(ret == False)
+
+        # Test manager-to-manager collision checking
+        m = g.trimesh.collision.CollisionManager()
+        m.add_object('cube0', cube)
+        m.add_object('cube1', cube, tf1)
+
+        n = g.trimesh.collision.CollisionManager()
+        n.add_object('cube0', cube, tf2)
+
+        ret = m.in_collision_other(n)
+        self.assertTrue(ret == False)
+
+        n.add_object('cube1', cube, tf1)
+
+        ret = m.in_collision_other(n)
+        self.assertTrue(ret == True)
+
+
+if __name__ == '__main__':
+    g.trimesh.util.attach_to_log()
+    g.unittest.main()
+

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -8,7 +8,7 @@ class CollisionTest(g.unittest.TestCase):
         try:
             g.trimesh.collision.CollisionManager()
         except ValueError:
-            g.log.warning('skipping collision tests, no FCL installed', engine)
+            g.log.warning('skipping collision tests, no FCL installed')
             return
 
         cube = g.get_mesh('unit_cube.STL')

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -26,6 +26,7 @@ from . import geometry
 from . import permutate
 from . import proximity
 from . import triangles
+from . import collision
 from . import comparison
 from . import decomposition
 from . import intersections

--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -1,0 +1,79 @@
+import numpy as np
+
+from .constants import tol, log
+
+_fcl_exists = True
+try:
+    import fcl # pip install python-fcl
+except:
+    log.warning('No FCL -- collision checking will not work')
+    _fcl_exists = False
+
+class CollisionManager(object):
+
+    def __init__(self):
+        if not _fcl_exists:
+            raise ValueError('No FCL Available!')
+        self._objs = {}
+        self._manager = fcl.DynamicAABBTreeCollisionManager()
+        self._manager.setup()
+
+    def add_object(self, name, mesh, transform=None):
+        if transform is None:
+            transform = np.eye(4)
+
+        # Create FCL data
+        b = fcl.BVHModel()
+        b.beginModel(len(mesh.vertices), len(mesh.faces))
+        b.addSubModel(mesh.vertices, mesh.faces)
+        b.endModel()
+        t = fcl.Transform(transform[:3,:3], transform[:3,3])
+        o = fcl.CollisionObject(b, t)
+
+        # Add collision object to set
+        if name in self._objs:
+            self._manager.unregisterObject(self._objs[name])
+        self._objs[name] = o
+        self._manager.registerObject(o)
+        self._manager.update()
+
+    def remove_object(self, name):
+        if name in self._objs:
+            self._manager.unregisterObject(self._objs[name])
+            self._manager.update(self._objs[name])
+            del self._objs[name]
+
+    def set_transform(self, name, transform):
+        if name in self._objs:
+            o = self._objs[name]
+            o.setRotation(transform[:3,:3])
+            o.setTranslation(transform[:3,3])
+            self._manager.update(o)
+
+    def in_collision_single(self, mesh, transform=None):
+        if transform is None:
+            transform = np.eye(4)
+
+        # Create FCL data
+        b = fcl.BVHModel()
+        b.beginModel(len(mesh.vertices), len(mesh.faces))
+        b.addSubModel(mesh.vertices, mesh.faces)
+        b.endModel()
+        t = fcl.Transform(transform[:3,:3], transform[:3,3])
+        o = fcl.CollisionObject(b, t)
+
+        # Collide with manager's objects
+        cdata = fcl.CollisionData()
+        self._manager.collide(o, cdata, fcl.defaultCollisionCallback)
+        return cdata.result.is_collision
+
+    def in_collision_internal(self):
+        cdata = fcl.CollisionData()
+        self._manager.collide(cdata, fcl.defaultCollisionCallback)
+        return cdata.result.is_collision
+
+    def in_collision_other(self, other_manager):
+        cdata = fcl.CollisionData()
+        self._manager.collide(other_manager._manager, cdata, fcl.defaultCollisionCallback)
+        return cdata.result.is_collision
+

--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -10,8 +10,14 @@ except:
     _fcl_exists = False
 
 class CollisionManager(object):
+    '''
+    A mesh-mesh collision manager.
+    '''
 
     def __init__(self):
+        '''
+        Initialize a mesh-mesh collision manager.
+        '''
         if not _fcl_exists:
             raise ValueError('No FCL Available!')
         self._objs = {}
@@ -19,6 +25,16 @@ class CollisionManager(object):
         self._manager.setup()
 
     def add_object(self, name, mesh, transform=None):
+        '''
+        Add an object to the collision manager.
+        If an object with the given name is already in the manager, replace it.
+
+        Parameters
+        ----------
+        name:      str, an identifier for the object
+        mesh:      Trimesh object, the geometry of the collision object
+        transform: (4,4) float, homogenous transform matrix for the object
+        '''
         if transform is None:
             transform = np.eye(4)
 
@@ -38,19 +54,50 @@ class CollisionManager(object):
         self._manager.update()
 
     def remove_object(self, name):
+        '''
+        Delete an object from the collision manager.
+
+        Parameters
+        ----------
+        name: str, the identifier for the object
+        '''
         if name in self._objs:
             self._manager.unregisterObject(self._objs[name])
             self._manager.update(self._objs[name])
             del self._objs[name]
+        else:
+            raise ValueError('{} not in collision manager!'.format(name))
 
     def set_transform(self, name, transform):
+        '''
+        Set the transform for one of the manager's objects. This replaces the prior transform.
+
+        Parameters
+        ----------
+        name:      str, an identifier for the object already in the manager
+        transform: (4,4) float, a new homogenous transform matrix for the object
+        '''
         if name in self._objs:
             o = self._objs[name]
             o.setRotation(transform[:3,:3])
             o.setTranslation(transform[:3,3])
             self._manager.update(o)
+        else:
+            raise ValueError('{} not in collision manager!'.format(name))
 
     def in_collision_single(self, mesh, transform=None):
+        '''
+        Check a single object for collisions against all objects in the manager.
+
+        Parameters
+        ----------
+        mesh:      Trimesh object, the geometry of the collision object
+        transform: (4,4) float, homogenous transform matrix for the object
+
+        Returns
+        -------
+        is_collision: bool, True if a collision occurs and False otherwise
+        '''
         if transform is None:
             transform = np.eye(4)
 
@@ -68,12 +115,31 @@ class CollisionManager(object):
         return cdata.result.is_collision
 
     def in_collision_internal(self):
+        '''
+        Check if any pair of objects in the manager collide with one another.
+
+        Returns
+        -------
+        is_collision: bool, True if a collision occured between any pair of objects
+                            and False otherwise
+        '''
         cdata = fcl.CollisionData()
         self._manager.collide(cdata, fcl.defaultCollisionCallback)
         return cdata.result.is_collision
 
     def in_collision_other(self, other_manager):
+        '''
+        Check if any object from this manager collides with any object from another manager.
+
+        Parameters
+        ----------
+        other_manager: CollisionManager, another collision manager object
+
+        Returns
+        -------
+        is_collision: bool, True if a collision occured between any pair of objects
+                            and False otherwise
+        '''
         cdata = fcl.CollisionData()
         self._manager.collide(other_manager._manager, cdata, fcl.defaultCollisionCallback)
         return cdata.result.is_collision
-


### PR DESCRIPTION
This collision checking depends on python-fcl, a python wrapper
for FCL 0.5.0. Not having python-fcl will not break things.
python-fcl is pip installable and supports Linux at the moment,
although I'll add support for OS X and Windows soon.