### PR TITLE
Fix bug when updating vertices with a mask

### DIFF
--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -835,12 +835,12 @@ class Trimesh(object):
             self.faces = inverse[self.faces.reshape(-1)].reshape((-1, 3))
         self.visual.update_vertices(mask)
         cached_normals = self._cache.get('vertex_normals')
+        self.vertices = self.vertices[mask]
         if util.is_shape(cached_normals, (-1, 3)):
             try:
                 self.vertex_normals = cached_normals[mask]
             except BaseException:
                 pass
-        self.vertices = self.vertices[mask]
 
     def update_faces(self, mask):
         '''


### PR DESCRIPTION
Basically, the given code in update_vertices() is designed to update the
vertex list by filtering it out with a mask. In addition, it attempts
to filter the vertex normals by the same mask. However, the given
code will never accomplish this -- the newly-masked vertex normals
won't be the same shape as the old vertex list, so setting
vertex_normals will result in a no-op, leaving the vertex normals
unchanged. Assigning to the vertices first, then to the vertex normals
fixes this bug.