### PR TITLE
Allow collision checking to return object names

### DIFF
--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -27,19 +27,24 @@ class CollisionTest(g.unittest.TestCase):
         ret = m.in_collision_single(cube)
         self.assertTrue(ret == True)
 
-        ret = m.in_collision_single(cube, tf1)
+        ret, names = m.in_collision_single(cube, tf1, return_names=True)
         self.assertTrue(ret == True)
+        self.assertTrue('cube1' in names)
 
-        ret = m.in_collision_single(cube, tf2)
+        ret, names = m.in_collision_single(cube, tf2, return_names=True)
         self.assertTrue(ret == False)
+        self.assertTrue(len(names) == 0)
 
         # Test internal collision checking and object addition/removal/modification
         ret = m.in_collision_internal()
         self.assertTrue(ret == False)
 
         m.add_object('cube2', cube, tf1)
-        ret = m.in_collision_internal()
+        ret, names = m.in_collision_internal(return_names=True)
         self.assertTrue(ret == True)
+        self.assertTrue(('cube1', 'cube2') in names)
+        self.assertTrue(('cube0', 'cube1') not in names)
+        self.assertTrue(('cube2', 'cube1') not in names)
 
         m.set_transform('cube2', tf2)
         ret = m.in_collision_internal()
@@ -64,10 +69,15 @@ class CollisionTest(g.unittest.TestCase):
         ret = m.in_collision_other(n)
         self.assertTrue(ret == False)
 
-        n.add_object('cube1', cube, tf1)
+        n.add_object('cube3', cube, tf1)
 
         ret = m.in_collision_other(n)
         self.assertTrue(ret == True)
+
+        ret, names = m.in_collision_other(n, return_names=True)
+        self.assertTrue(ret == True)
+        self.assertTrue(('cube1', 'cube3') in names)
+        self.assertTrue(('cube3', 'cube1') not in names)
 
 
 if __name__ == '__main__':

--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -50,7 +50,10 @@ class CollisionManager(object):
         # Add collision object to set
         if name in self._objs:
             self._manager.unregisterObject(self._objs[name])
-        self._objs[name] = o
+        self._objs[name] = {
+            'obj': o,
+            'geom': b
+        }
         self._manager.registerObject(o)
         self._manager.update()
 
@@ -63,8 +66,8 @@ class CollisionManager(object):
         name: str, the identifier for the object
         '''
         if name in self._objs:
-            self._manager.unregisterObject(self._objs[name])
-            self._manager.update(self._objs[name])
+            self._manager.unregisterObject(self._objs[name]['obj'])
+            self._manager.update(self._objs[name]['obj'])
             del self._objs[name]
         else:
             raise ValueError('{} not in collision manager!'.format(name))
@@ -79,25 +82,28 @@ class CollisionManager(object):
         transform: (4,4) float, a new homogenous transform matrix for the object
         '''
         if name in self._objs:
-            o = self._objs[name]
+            o = self._objs[name]['obj']
             o.setRotation(transform[:3, :3])
             o.setTranslation(transform[:3, 3])
             self._manager.update(o)
         else:
             raise ValueError('{} not in collision manager!'.format(name))
 
-    def in_collision_single(self, mesh, transform=None):
+    def in_collision_single(self, mesh, transform=None, return_names=False):
         '''
         Check a single object for collisions against all objects in the manager.
 
         Parameters
         ----------
-        mesh:      Trimesh object, the geometry of the collision object
-        transform: (4,4) float, homogenous transform matrix for the object
+        mesh:          Trimesh object, the geometry of the collision object
+        transform:    (4,4) float,     homogenous transform matrix for the object
+        return_names : bool,           If true, a set is returned containing the names
+                                       of all objects in collision with the provided object
 
         Returns
         -------
         is_collision: bool, True if a collision occurs and False otherwise
+        names: set of str,  The set of names of objects that collided with the provided one
         '''
         if transform is None:
             transform = np.eye(4)
@@ -112,36 +118,104 @@ class CollisionManager(object):
 
         # Collide with manager's objects
         cdata = fcl.CollisionData()
-        self._manager.collide(o, cdata, fcl.defaultCollisionCallback)
-        return cdata.result.is_collision
+        if return_names:
+            cdata = fcl.CollisionData(request=fcl.CollisionRequest(num_max_contacts=100000, enable_contact=True))
 
-    def in_collision_internal(self):
+        self._manager.collide(o, cdata, fcl.defaultCollisionCallback)
+
+        result = cdata.result.is_collision
+
+        # If we want to return the objects that were collision, collect them.
+        if return_names:
+            objs_in_collision = set()
+            for contact in cdata.result.contacts:
+                cg = contact.o1
+                if cg == b:
+                    cg = contact.o2
+                name = self._extract_name(cg)
+                objs_in_collision.add(name)
+            return result, objs_in_collision
+        else:
+            return result
+
+    def in_collision_internal(self, return_names=False):
         '''
         Check if any pair of objects in the manager collide with one another.
 
+        Parameters
+        ----------
+        return_names : bool
+            If true, a set is returned containing the names
+            of all pairs of objects in collision.
+
         Returns
         -------
-        is_collision: bool, True if a collision occured between any pair of objects
-                            and False otherwise
+        is_collision: bool,  True if a collision occured between any pair of objects
+                             and False otherwise
+        names: set of 2-tup, The set of pairwise collisions. Each tuple
+                             contains two names in alphabetical order indicating
+                             that the two correspoinding objects are in collision.
         '''
         cdata = fcl.CollisionData()
-        self._manager.collide(cdata, fcl.defaultCollisionCallback)
-        return cdata.result.is_collision
+        if return_names:
+            cdata = fcl.CollisionData(request=fcl.CollisionRequest(num_max_contacts=100000, enable_contact=True))
 
-    def in_collision_other(self, other_manager):
+        self._manager.collide(cdata, fcl.defaultCollisionCallback)
+
+        result = cdata.result.is_collision
+
+        if return_names:
+            objs_in_collision = set()
+            for contact in cdata.result.contacts:
+                name1, name2 = self._extract_name(contact.o1), self._extract_name(contact.o2)
+                names = tuple(sorted((name1, name2)))
+                objs_in_collision.add(names)
+            return result, objs_in_collision
+        else:
+            return result
+
+    def in_collision_other(self, other_manager, return_names=False):
         '''
         Check if any object from this manager collides with any object from another manager.
 
         Parameters
         ----------
         other_manager: CollisionManager, another collision manager object
+        return_names:  bool,             If true, a set is returned containing the names
+                                         of all pairs of objects in collision.
 
         Returns
         -------
-        is_collision: bool, True if a collision occured between any pair of objects
-                            and False otherwise
+        is_collision: bool,  True if a collision occured between any pair of objects
+                             and False otherwise
+        names: set of 2-tup, The set of pairwise collisions. Each tuple
+                             contains two names (first from this manager,
+                             second from the other_manager) indicating
+                             that the two correspoinding objects are in collision.
         '''
         cdata = fcl.CollisionData()
+        if return_names:
+            cdata = fcl.CollisionData(request=fcl.CollisionRequest(num_max_contacts=100000, enable_contact=True))
         self._manager.collide(other_manager._manager,
                               cdata, fcl.defaultCollisionCallback)
-        return cdata.result.is_collision
+        result = cdata.result.is_collision
+
+        if return_names:
+            objs_in_collision = set()
+            for contact in cdata.result.contacts:
+                name1, name2 = self._extract_name(contact.o1), other_manager._extract_name(contact.o2)
+                if name1 is None:
+                    name1, name2 = self._extract_name(contact.o2), other_manager._extract_name(contact.o1)
+                objs_in_collision.add((name1, name2))
+            return result, objs_in_collision
+        else:
+            return result
+
+    def _extract_name(self, geom):
+        """Retrieve the name of an object from the manager by its collision geometry,
+        or return None if not found.
+        """
+        for obj_name in self._objs:
+            if self._objs[obj_name]['geom'] == geom:
+                return obj_name
+        return None


### PR DESCRIPTION
The prior interface to the collision checker only returned boolean
results for collisions. This update allows the checker to also return
the names of objects that were in collision.