### PR TITLE
Add support for vt and vn to OBJ

### DIFF
--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -47,6 +47,7 @@ class Trimesh(object):
                  faces=None,
                  face_normals=None,
                  vertex_normals=None,
+                 vertex_texture=None,
                  face_colors=None,
                  vertex_colors=None,
                  metadata=None,
@@ -66,6 +67,7 @@ class Trimesh(object):
                         serves as a speedup as otherwise they will be computed with
                         crossproducts
         vertex_normals: (n,3) float set of normal vectors for vertices
+        vertex_texture: (n,2) float set of vectors for vertices texture
         metadata:       dict, any metadata about the mesh
         process:        bool, if True basic mesh cleanup will be done on instantiation
         validate_faces: bool, if True, faces will not be returned until face normals
@@ -118,6 +120,10 @@ class Trimesh(object):
         # (n, 3) float of vertex normals, can be created from face normals
         if vertex_normals is not None:
             self.vertex_normals = vertex_normals
+
+        # (n, 2) float of vertex texture
+        if vertex_texture is not None:
+            self.vertex_texture = vertex_texture
 
         # create a ray-mesh query object for the current mesh
         # initializing is very inexpensive and object is convenient to have.

--- a/trimesh/io/export.py
+++ b/trimesh/io/export.py
@@ -82,10 +82,21 @@ def export_obj(mesh):
     -----------
     export: str, string of OBJ format output
     '''
+
     export = 'v '
     export += util.array_to_string(mesh.vertices,
                                    col_delim=' ',
                                    row_delim='\nv ',
+                                   digits=8) + '\n'
+    export += 'vn '
+    export += util.array_to_string(mesh.vertex_normals,
+                                   col_delim=' ',
+                                   row_delim='\nvn ',
+                                   digits=8) + '\n'
+    export += 'vt '
+    export += util.array_to_string(mesh.vertex_texture,
+                                   col_delim=' ',
+                                   row_delim='\nvt ',
                                    digits=8) + '\n'
     export += 'f '
     export += util.array_to_string(mesh.faces + 1,

--- a/trimesh/io/misc.py
+++ b/trimesh/io/misc.py
@@ -49,8 +49,6 @@ def load_wavefront(file_obj, file_type=None):
     Loads an ascii Wavefront OBJ file_obj into kwargs
     for the Trimesh constructor.
 
-    Discards texture normals and vertex color information.
-
 
     Parameters
     ----------
@@ -152,11 +150,14 @@ def load_wavefront(file_obj, file_type=None):
         vid = np.nonzero(data == 'v')[0].reshape((-1, 1)) + np.arange(3) + 1
         # indexes which contain vertex normal information
         nid = np.nonzero(data == 'vn')[0].reshape((-1, 1)) + np.arange(3) + 1
+        # indexes which contain vertex texture information
+        tid = np.nonzero(data == 'vt')[0].reshape((-1, 1)) + np.arange(2) + 1
         # some varients of the format have face groups
         gid = np.nonzero(data == 'g')[0].reshape((-1, 1)) + 1
 
         loaded = {'vertices': data[vid].astype(float),
                   'vertex_normals': data[nid].astype(float),
+                  'vertex_texture': data[tid].astype(float),
                   'faces': faces}
 
         # if face groups have been defined add them to metadata


### PR DESCRIPTION
Include lines starting with vn and vt in the exported
mesh for Wavefront OBJ.

vt lines are just passed through the exported mesh
without any operations applied to them.

Applying a transformation changed vn lines as well.