### PR TITLE
Fix a handful of invalid log messages

### DIFF
--- a/trimesh/interfaces/blender.py
+++ b/trimesh/interfaces/blender.py
@@ -16,14 +16,14 @@ if platform.system() == 'Windows':
     _search_path.append('C:\Program Files\Blender Foundation\Blender')
     _search_path.append('C:\Program Files (x86)\Blender Foundation\Blender')
     _search_path = ';'.join(_search_path)
-    log.debug('searching for blender in: ', _search_path)
+    log.debug('searching for blender in: %s', _search_path)
 
 if platform.system() == 'Darwin':
     _search_path = [i for i in _search_path.split(':') if len(i) > 0]
     _search_path.append('/Applications/blender.app/Contents/MacOS')
     _search_path = ':'.join(_search_path)
-    log.debug('searching for blender in: ', _search_path)
-    log.warning('searching for blender in: ', _search_path)
+    log.debug('searching for blender in: %s', _search_path)
+    log.warning('searching for blender in: %s', _search_path)
 
 
 _blender_executable = find_executable('blender', path=_search_path)

--- a/trimesh/interfaces/scad.py
+++ b/trimesh/interfaces/scad.py
@@ -13,14 +13,14 @@ if platform.system() == 'Windows':
     _search_path.append(os.path.normpath('C:\Program Files\OpenSCAD'))
     _search_path.append(os.path.normpath('C:\Program Files (x86)\OpenSCAD'))
     _search_path = ';'.join(_search_path)
-    log.debug('searching for scad in: ', _search_path)
+    log.debug('searching for scad in: %s', _search_path)
 
 if platform.system() == 'Darwin':
     _search_path = [i for i in _search_path.split(':') if len(i) > 0]
     _search_path.append('/Applications/OpenSCAD.app/Contents/MacOS')
     _search_path = ':'.join(_search_path)
-    log.debug('searching for scad in: ', _search_path)
-    log.warning('searching for scad in: ', _search_path)
+    log.debug('searching for scad in: %s', _search_path)
+    log.warning('searching for scad in: %s', _search_path)
 
 _scad_executable = find_executable('openscad', path=_search_path)
 if not _scad_executable:

--- a/trimesh/interfaces/vhacd.py
+++ b/trimesh/interfaces/vhacd.py
@@ -13,7 +13,7 @@ if platform.system() == 'Windows':
     _search_path.append('C:\Program Files')
     _search_path.append('C:\Program Files (x86)')
     _search_path = ';'.join(_search_path)
-    log.debug('searching for vhacd in: ', _search_path)
+    log.debug('searching for vhacd in: %s', _search_path)
 
 
 _vhacd_executable = None


### PR DESCRIPTION
This PR fixes a few log calls that have incorrect string formatting. Without these fixes, running this simple test case under Python 3.5.3:

```python
import logging
logging.basicConfig()
import trimesh
```

causes an extremely verbose stack trace to be produced, the important part of which is:

```
--- Logging error ---
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/logging/__init__.py", line 981, in emit
    msg = self.format(record)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/logging/__init__.py", line 831, in format
    return fmt.format(record)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/logging/__init__.py", line 568, in format
    record.message = record.getMessage()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/logging/__init__.py", line 331, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting

...

  File "/Users/paulmc/Projects/Public/trimesh/trimesh/interfaces/__init__.py", line 2, in <module>
    from . import blender
  File "<frozen importlib._bootstrap>", line 1016, in _handle_fromlist
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/Users/paulmc/Projects/Public/trimesh/trimesh/interfaces/blender.py", line 26, in <module>
    log.warning('searching for blender in: ', _search_path)
```