### PR TITLE
Make lxml import conditional on calling the export_urdf function

### DIFF
--- a/trimesh/io/urdf.py
+++ b/trimesh/io/urdf.py
@@ -2,7 +2,6 @@ import logging
 import os
 import subprocess
 
-import lxml.etree as et
 import numpy as np
 
 from ..decomposition import convex_decomposition
@@ -29,6 +28,8 @@ def export_urdf(mesh,
     ---------
     mesh: The decomposed mesh
     '''
+
+    import lxml.etree as et
 
     # Extract the save directory and the file name
     fullpath = os.path.abspath(directory)


### PR DESCRIPTION
The current master branch of `trimesh` cannot be imported unless `lxml` is present. This PR contains a very small adjustment to the `trimesh.io.urdf` module to make `trimesh` importable without `lxml`.

This example demonstrates the problem:

```
(dev.venv) ws129:trimesh paulmc$ pip freeze
decorator==4.2.1
networkx==2.0
numpy==1.14.0
scipy==1.0.0
(dev.venv) ws129:trimesh paulmc$ python
Python 3.5.3 (v3.5.3:1880cb95a742, Jan 16 2017, 08:49:46)
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import trimesh
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/paulmc/Projects/Public/trimesh/trimesh/__init__.py", line 14, in <module>
    from .base import Trimesh
  File "/Users/paulmc/Projects/Public/trimesh/trimesh/base.py", line 37, in <module>
    from .io.export import export_mesh
  File "/Users/paulmc/Projects/Public/trimesh/trimesh/io/export.py", line 8, in <module>
    from .urdf import export_urdf
  File "/Users/paulmc/Projects/Public/trimesh/trimesh/io/urdf.py", line 5, in <module>
    import lxml.etree as et
ImportError: No module named 'lxml'
>>>
```

I haven't looked too closely at the code, but is there any reason that the built-in `xml.etree` package cannot be used in place of `lxml`? Patching `trimesh/io/urdf.py` (the version from this PR branch) in the following way produces the same output (although xml pretty-printing is lost - this can be done via `xml.dom.minidom` - https://stackoverflow.com/a/1206856):

```diff
--- a/trimesh/io/urdf.py
+++ b/trimesh/io/urdf.py
@@ -29,7 +29,7 @@ def export_urdf(mesh,
     mesh: The decomposed mesh
     '''

-    import lxml.etree as et
+    from xml.etree import ElementTree as et

     # Extract the save directory and the file name
     fullpath = os.path.abspath(directory)
@@ -116,7 +116,7 @@ def export_urdf(mesh,
     # Write URDF file
     tree = et.ElementTree(root)
     urdf_filename = '{}.urdf'.format(name)
-    tree.write(os.path.join(fullpath, urdf_filename), pretty_print=True)
+    tree.write(os.path.join(fullpath, urdf_filename))

     # Write Gazebo config file
     root = et.Element('model')
```

I haven't played with the `trimesh.io.xml_based` module (the only other user of `lxml` as far as I can tell), so don't know if `lxml` could be replaced so easily there.