### PR TITLE
Fix undefined variable name in ContactData

### DIFF
--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -31,7 +31,7 @@ class ContactData(object):
             names[0]: contact.b1,
             names[1]: contact.b2
         }
-        self._point = result.pos
+        self._point = contact.pos
 
     @property
     def point(self):


### PR DESCRIPTION
In the current code, requesting contact information for collisions raises an error as `result` is not defined in the initialiser.