### PR TITLE
Fix matrix_to_marching_cubes offset

### DIFF
--- a/trimesh/voxel.py
+++ b/trimesh/voxel.py
@@ -338,7 +338,7 @@ def matrix_to_marching_cubes(matrix, pitch, origin):
         vertices, faces, normals, vals = meshed
 
     # Return to the origin, add in the pad_width
-    vertices = np.subtract(np.add(vertices, origin), pad_width)
+    vertices = np.subtract(np.add(vertices, origin), pad_width*pitch)
     mesh = Trimesh(vertices=vertices, faces=faces)
     return mesh
 


### PR DESCRIPTION
The previous code produces an incorrect offset for the mesh produced by marching cubes, as illustrated by the below code.

import numpy as np
from trimesh.voxel import matrix_to_marching_cubes

voxels = np.ones((3,3,3), dtype=np.bool)
mesh = matrix_to_marching_cubes(voxels, 1.0, np.zeros(3))
print(mesh.bounds)
mesh = matrix_to_marching_cubes(voxels, 3.0, np.zeros(3))
print(mesh.bounds)