### PR TITLE
Fix bug in intersects_id

### DIFF
--- a/trimesh/ray/ray_triangle.py
+++ b/trimesh/ray/ray_triangle.py
@@ -56,10 +56,10 @@ class RayMeshIntersector:
                                       multiple_hits=multiple_hits,
                                       triangles_normal=self.mesh.face_normals)
         if return_locations:
+            if len(index_tri) == 0:
+                return index_tri, index_ray, locations  
             unique = grouping.unique_rows(np.column_stack((locations,
                                                            index_ray)))[0]
-            if len(unique) == 0:
-                return [], [], []
             return index_tri[unique], index_ray[unique], locations[unique]
         return index_tri, index_ray
 


### PR DESCRIPTION
When returning locations, we must check that the list is non-empty because other grouping.unique_rows throws an error.

Moreover, the user is expecting numpy arrays as a return type instead of python lists, so return these instead of [],[],[].