### PR TITLE
 Add ply export support for 1) generating ascii ply 2) including vertex normals

### DIFF
--- a/trimesh/io/ply.py
+++ b/trimesh/io/ply.py
@@ -58,21 +58,34 @@ def load_ply(file_obj, *args, **kwargs):
     return kwargs
 
 
-def export_ply(mesh):
+def export_ply(mesh, **kwargs):
     '''
     Export a mesh in the PLY format.
 
     Parameters
     ----------
     mesh : Trimesh object
+    encoding : ['ascii'|'binary_little_endian']
+    vertex_normal : include vertex normals
 
     Returns
     ----------
     export : bytes of result
     '''
+
+    encoding = 'binary_little_endian'
+    if kwargs.has_key('encoding'):
+        encoding = kwargs['encoding']
+
+    use_vertex_normal = False
+    if kwargs.has_key('vertex_normal'):
+        use_vertex_normal = kwargs['vertex_normal']
+
     dtype_face = [('count', '<u1'),
                   ('index', '<i4', (3))]
     dtype_vertex = [('vertex', '<f4', (3))]
+
+    dtype_vertex_normal = [('vertex_normal', '<f4', (3))]
 
     dtype_color = ('rgba', '<u1', (4))
 
@@ -81,36 +94,62 @@ def export_ply(mesh):
     header = templates['intro']
     header += templates['vertex']
 
+    if use_vertex_normal == True:
+        header += templates['vertex_normal']
+        dtype_vertex += dtype_vertex_normal
+    
     if mesh.visual.kind == 'vertex':
-        dtype_vertex.append(dtype_color)
-        vertex = np.zeros(len(mesh.vertices),
-                          dtype=dtype_vertex)
-        vertex['rgba'] = mesh.visual.vertex_colors
         header += templates['color']
-    else:
-        vertex = np.zeros(len(mesh.vertices),
-                          dtype=dtype_vertex)
+        dtype_vertex.append(dtype_color)
+
+    vertex = np.zeros(len(mesh.vertices),
+                      dtype=dtype_vertex)
+
     vertex['vertex'] = mesh.vertices
+
+    if use_vertex_normal == True:
+        vertex['vertex_normal'] = mesh.vertex_normals
+    if mesh.visual.kind == 'vertex':
+        vertex['rgba'] = mesh.visual.vertex_colors
 
     header += templates['face']
     if mesh.visual.kind == 'face':
         header += templates['color']
         dtype_face.append(dtype_color)
-        faces = np.zeros(len(mesh.faces), dtype=dtype_face)
-        faces['rgba'] = mesh.visual.face_colors
-    else:
-        faces = np.zeros(len(mesh.faces), dtype=dtype_face)
+
+    faces = np.zeros(len(mesh.faces), dtype=dtype_face)
+
     faces['count'] = 3
     faces['index'] = mesh.faces
+    if mesh.visual.kind == 'face':
+        faces['rgba'] = mesh.visual.face_colors
 
     header += templates['outro']
 
-    counts = {'vertex_count': len(mesh.vertices),
-              'face_count': len(mesh.faces)}
+    header_params = {'vertex_count': len(mesh.vertices),
+                     'face_count': len(mesh.faces),
+                     'encoding' : encoding}
 
-    export = Template(header).substitute(counts).encode('utf-8')
-    export += vertex.tostring()
-    export += faces.tostring()
+    export = Template(header).substitute(header_params).encode('utf-8')
+
+    def ndtoascii(d):
+        fields = []
+        for e in d:
+            if type(e) is np.ndarray:
+                fields += e.tolist()
+            else:
+                fields.append(e)
+        fields = map(str, fields)
+        return ' '.join(fields) + '\n'
+
+    if encoding == 'binary_little_endian':
+        export += vertex.tostring()
+        export += faces.tostring()
+    else:
+        for v in vertex:
+            export += ndtoascii(v)
+        for f in faces:
+            export += ndtoascii(f)
     return export
 
 

--- a/trimesh/io/ply.py
+++ b/trimesh/io/ply.py
@@ -58,7 +58,7 @@ def load_ply(file_obj, *args, **kwargs):
     return kwargs
 
 
-def export_ply(mesh, **kwargs):
+def export_ply(mesh, encoding='binary_little_endian', vertex_normal=False):
     '''
     Export a mesh in the PLY format.
 
@@ -73,14 +73,6 @@ def export_ply(mesh, **kwargs):
     export : bytes of result
     '''
 
-    encoding = 'binary_little_endian'
-    if kwargs.has_key('encoding'):
-        encoding = kwargs['encoding']
-
-    use_vertex_normal = False
-    if kwargs.has_key('vertex_normal'):
-        use_vertex_normal = kwargs['vertex_normal']
-
     dtype_face = [('count', '<u1'),
                   ('index', '<i4', (3))]
     dtype_vertex = [('vertex', '<f4', (3))]
@@ -94,7 +86,7 @@ def export_ply(mesh, **kwargs):
     header = templates['intro']
     header += templates['vertex']
 
-    if use_vertex_normal == True:
+    if vertex_normal == True:
         header += templates['vertex_normal']
         dtype_vertex += dtype_vertex_normal
     
@@ -107,7 +99,7 @@ def export_ply(mesh, **kwargs):
 
     vertex['vertex'] = mesh.vertices
 
-    if use_vertex_normal == True:
+    if vertex_normal == True:
         vertex['vertex_normal'] = mesh.vertex_normals
     if mesh.visual.kind == 'vertex':
         vertex['rgba'] = mesh.visual.vertex_colors

--- a/trimesh/resources/ply.template
+++ b/trimesh/resources/ply.template
@@ -1,7 +1,8 @@
 {
     "face": "element face $face_count\nproperty list uchar int vertex_indices\n",
     "vertex": "element vertex $vertex_count\nproperty float x\nproperty float y\nproperty float z\n",
+    "vertex_normal": "property float nx\nproperty float ny\nproperty float nz\n",
     "color": "property uchar red\nproperty uchar green\nproperty uchar blue\nproperty uchar alpha\n",
-    "intro": "ply\nformat binary_little_endian 1.0\ncomment github.com/mikedh/trimesh\n",
+    "intro": "ply\nformat $encoding 1.0\ncomment github.com/mikedh/trimesh\n",
     "outro": "end_header\n"
 }


### PR DESCRIPTION
Hi,

This is a minor change to allow the generation of ascii ply files + the inclusion of vertex normals. There must be a better way to implement ndtoascii. Happy to learn (I'm not strong on numpy).

Hope the change is of value. Tested a combination of ply formats (vertex/face colours, ascii/binary, w/wo normals and all opened successfully in meshlab.

Thanks,
Stu