### PR TITLE
Fixed a bug with multiplane slicing.

### DIFF
--- a/trimesh/intersections.py
+++ b/trimesh/intersections.py
@@ -221,15 +221,15 @@ def mesh_multiplane(mesh,
     plane_normal = util.unitize(plane_normal)
     plane_origin = np.asanyarray(plane_origin,
                                  dtype=np.float64)
-    heights = np.asanyarray(heights, dtype=np.float64)
+    heights = np.asanyarray(heights - heights[0], dtype=np.float64)
 
     # dot product of every vertex with plane
     vertex_dots = np.dot(plane_normal,
                          (mesh.vertices - plane_origin).T)
 
-    # reconstruct transforms for each 2D section
-    base_transform = geometry.plane_transform(origin=plane_origin,
-                                              normal=plane_normal)
+    # transforms to 3D for each 2D section.
+    base_transform = np.linalg.inv(geometry.plane_transform(origin=plane_origin,
+                                                            normal=plane_normal))
     # alter translation Z inside loop
     translation = np.eye(4)
 


### PR DESCRIPTION
Fixed a bug with multiplane slicing that caused the wrong transformations and offset.

1) The original base_transform was a transformation from the original bounds to the z = 0 plane ("3D -> 2D"). It is now its reverse, projecting a 2D slice on the z = 0 plane to the original bounds ("2D -> 3D"). This is required to produce the correct to_3D and to_2D matrices.

2) Moreover, the stored heights should be stored with respect to the first height value (since the inverse of the new base transform already moves that distance to the origin).

The bug is unnoticeable if the model begins at z = 0, the plane_normal equals [0,0,1], and the heights vector begins in 0.