### PR TITLE
Fixed a bug with multiplane slicing on models that rest entirely on the negative half-space.

### DIFF
--- a/trimesh/intersections.py
+++ b/trimesh/intersections.py
@@ -12,6 +12,7 @@ from . import util
 from . import geometry
 from . import grouping
 from . import transformations
+from . import points
 
 
 def mesh_plane(mesh,
@@ -221,7 +222,11 @@ def mesh_multiplane(mesh,
     plane_normal = util.unitize(plane_normal)
     plane_origin = np.asanyarray(plane_origin,
                                  dtype=np.float64)
-    heights = np.asanyarray(heights, dtype=np.float64)
+
+    # Move points by the lowest offset.
+    signed_offset = points.point_plane_distance([0, 0, 0],
+                                                plane_normal, plane_origin)
+    heights = np.asanyarray(heights + signed_offset, dtype=np.float64)
 
     # dot product of every vertex with plane
     vertex_dots = np.dot(plane_normal,


### PR DESCRIPTION
The following call would previously produce only empty sections on the attached object:

mesh = trimesh.load('cube_negative_z.obj')
z_extents = mesh.bounds[:,2]
z_levels  = np.arange(*z_extents, step=1)
sections = mesh.section_multiplane(plane_origin=mesh.bounds[0], plane_normal=[0,0,1], heights=z_levels)

[cube_negative_z.zip](https://github.com/mikedh/trimesh/files/2214635/cube_negative_z.zip)
