### PR TITLE
Fix bug in mesh loader

### DIFF
--- a/trimesh/io/load.py
+++ b/trimesh/io/load.py
@@ -446,7 +446,7 @@ def parse_file_args(file_obj,
             opened = True
         else:
             if file_type is not None:
-                return file_obj, file_type, metadata
+                return file_obj, file_type, metadata, opened
             elif '{' in file_obj:
                 # if a dict bracket is in the string, its probably a straight
                 # JSON


### PR DESCRIPTION
There was a bug in the existing mesh loading code that was triggered whenever I used a string instead of a file as the source for a mesh loader. This PR fixes it. Basically, just an inconsistent number of return arguments in `parse_file_args()`.