### PR TITLE
test_remote uses localhost to fetch remote meshes

### DIFF
--- a/tests/test_loaded.py
+++ b/tests/test_loaded.py
@@ -24,9 +24,10 @@ class LoaderTest(g.unittest.TestCase):
         """
         Try loading a remote mesh using requests
         """
-        # get a unit cube from project's github
-        mesh = g.trimesh.io.load.load_remote(
-            url='https://github.com/mikedh/trimesh/raw/master/models/unit_cube.STL')
+        # get a unit cube from localhost
+        with g.serve_meshes() as address:
+            mesh = g.trimesh.io.load.load_remote(
+                url=address + '/unit_cube.STL')
 
         assert g.np.isclose(mesh.volume, 1.0)
         assert isinstance(mesh, g.trimesh.Trimesh)


### PR DESCRIPTION
This makes sure the test works without Internet access.

In tests, a new serve_meshes() context manager is available,
it can be used to serve contents of the models/ dir over HTTP.

Fixes https://github.com/mikedh/trimesh/issues/247