### PR TITLE
[WIP] Toggle axis in SceneViewer

### DIFF
--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -53,6 +53,8 @@ def extrude_polygon(polygon,
       2D geometry to extrude
     height : float
       Distance to extrude polygon along Z
+    **kwargs:
+        passed to Trimesh
 
     Returns
     ----------
@@ -193,6 +195,8 @@ def extrude_triangulation(vertices,
       Triangle indexes of vertices
     height : float
       Distance to extrude triangulation
+    **kwargs:
+        passed to Trimesh
 
     Returns
     ---------
@@ -258,7 +262,8 @@ def extrude_triangulation(vertices,
 
     mesh = Trimesh(*util.append_faces(vertices_seq,
                                       faces_seq),
-                   process=True)
+                   process=True,
+                   **kwargs)
 
     assert mesh.volume > 0.0
 
@@ -433,7 +438,7 @@ def _polygon_to_kwargs(polygon):
     return result
 
 
-def box(extents=None, transform=None):
+def box(extents=None, transform=None, **kwargs):
     """
     Return a cuboid.
 
@@ -443,6 +448,8 @@ def box(extents=None, transform=None):
       Edge lengths
     transform: (4, 4) float
       Transformation matrix
+    **kwargs:
+        passed to Trimesh to create box
 
     Returns
     ------------
@@ -476,7 +483,8 @@ def box(extents=None, transform=None):
     box = Trimesh(vertices=vertices,
                   faces=faces,
                   face_normals=face_normals,
-                  process=False)
+                  process=False,
+                  **kwargs)
     if transform is not None:
         box.apply_transform(transform)
 
@@ -667,7 +675,8 @@ def capsule(height=1.0,
 def cylinder(radius=1.0,
              height=1.0,
              sections=32,
-             transform=None):
+             transform=None,
+             **kwargs):
     """
     Create a mesh of a cylinder along Z centered at the origin.
 
@@ -679,6 +688,8 @@ def cylinder(radius=1.0,
       The height of the cylinder
     sections : int
       How many pie wedges should the cylinder have
+    **kwargs:
+        passed to Trimesh to create cylinder
 
     Returns
     ----------
@@ -703,7 +714,8 @@ def cylinder(radius=1.0,
     # extrude the 2D triangulation into a Trimesh object
     cylinder = extrude_triangulation(vertices=vertices,
                                      faces=faces,
-                                     height=height)
+                                     height=height,
+                                     **kwargs)
     # the extrusion was along +Z, so move the cylinder
     # center of mass back to the origin
     cylinder.vertices[:, 2] -= height * .5
@@ -719,7 +731,8 @@ def annulus(r_min=1.0,
             r_max=2.0,
             height=1.0,
             sections=32,
-            transform=None):
+            transform=None,
+            **kwargs):
     """
     Create a mesh of an annular cylinder along Z,
     centered at the origin.
@@ -734,6 +747,8 @@ def annulus(r_min=1.0,
       The height of the annular cylinder
     sections : int
       How many pie wedges should the annular cylinder have
+    **kwargs:
+        passed to Trimesh to create annulus
 
     Returns
     ----------
@@ -775,7 +790,8 @@ def annulus(r_min=1.0,
     # extrude the 2D profile into a mesh
     annulus = extrude_triangulation(vertices=vertices,
                                     faces=faces,
-                                    height=height)
+                                    height=height,
+                                    **kwargs)
 
     # move the annulus so the centroid is at the origin
     annulus.vertices[:, 2] -= height * .5

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -63,7 +63,9 @@ class Scene(Geometry):
     def add_geometry(self,
                      geometry,
                      node_name=None,
-                     geom_name=None):
+                     geom_name=None,
+                     parent_node_name=None,
+                     transform=None):
         """
         Add a geometry to the scene.
 
@@ -75,6 +77,8 @@ class Scene(Geometry):
         ----------
         geometry: Trimesh, Path3D, or list of same
         node_name: name in the scene graph
+        parent_node_name: name of parent node in the scene graph
+        transform: (4, 4) float, transformation matrix
 
         Returns
         ----------
@@ -123,9 +127,12 @@ class Scene(Geometry):
             # geometry name + UUID
             node_name = name + '_' + unique.upper()
 
-        # create an identity transform from world
-        transform = np.eye(4)
+        if transform is None:
+            # create an identity transform from parent_node
+            transform = np.eye(4)
+
         self.graph.update(frame_to=node_name,
+                          frame_from=parent_node_name,
                           matrix=transform,
                           geometry=name,
                           geometry_flags={'visible': True})


### PR DESCRIPTION
Toggle axis in the scene with `A`.

![kapture 2018-11-22 at 2 04 23](https://user-images.githubusercontent.com/4310419/48877499-6ca30f80-edfb-11e8-8652-301fd7510ac6.gif)

@mikedh I have just tried it out. Do you have some idea how to store the previous state of `scene`, `vertex_list_XXX` in SceneViewer? Or should I add some functionalities like `delete_geometry`?


## Example used above

```python
#!/usr/bin/env python

import numpy as np
import trimesh
import trimesh.transformations as tf


scene = trimesh.Scene()

# plane
plane = trimesh.creation.box(
    extents=[1, 1, 0.01], face_colors=[0.5, 0.5, 0.5, 0.5]
)
node_name = scene.add_geometry(plane)

# object-1 (box)
box = trimesh.creation.box(extents=[0.3, 0.3, 0.3], face_colors=[0, 1, 0, 0.5])
translation = tf.translation_matrix([-0.2, 0, 0.15 + 0.01])
rotation = tf.rotation_matrix(np.deg2rad(30), [0, 0, 1], point=box.centroid)
transform = rotation @ translation
node_name = scene.add_geometry(box, transform=transform)

# object-2 (cylinder)
cylinder = trimesh.creation.cylinder(
    radius=0.1, height=0.3, face_colors=[0, 0, 1., 0.5]
)
translation = tf.translation_matrix([0.1, -0.2, 0.15 + 0.01])
node_name = scene.add_geometry(cylinder, transform=translation)

scene.show()
```