### PR TITLE
Fix camera resolution check in viewer.py

### DIFF
--- a/trimesh/scene/viewer.py
+++ b/trimesh/scene/viewer.py
@@ -46,7 +46,8 @@ class SceneViewer(pyglet.window.Window):
 
         if scene.camera is not None:
             if resolution is not None:
-                if not all(resolution == scene.camera.resolution):
+                if not np.allclose(resolution, scene.camera.resolution,
+                                   rtol=0, atol=0):
                     log.warning(
                         'resolution is overwritten by Camera: '
                         '{} -> {}'.format(resolution,

--- a/trimesh/scene/viewer.py
+++ b/trimesh/scene/viewer.py
@@ -46,7 +46,7 @@ class SceneViewer(pyglet.window.Window):
 
         if scene.camera is not None:
             if resolution is not None:
-                if resolution != scene.camera.resolution:
+                if not all(resolution == scene.camera.resolution):
                     log.warning(
                         'resolution is overwritten by Camera: '
                         '{} -> {}'.format(resolution,


### PR DESCRIPTION
To fix below:

```
Traceback (most recent call last):
  File "check_look_at.py", line 107, in <module>
    scene_camera.show(start_loop=False)
  File "/home/wkentaro/SceneNetRGBD/scenenetrgb-d/python/src/trimesh/trimesh/scene/scene.py", line 820, in show
    return SceneViewer(self, **kwargs)
  File "/home/wkentaro/SceneNetRGBD/scenenetrgb-d/python/src/trimesh/trimesh/scene/viewer.py", line 49, in __init__
    if resolution != scene.camera.resolution:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```