### PR TITLE
Fix indices_to_points to make it consistent to VoxelMesh.as_boxes

### DIFF
--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -101,6 +101,33 @@ class VoxelTest(g.unittest.TestCase):
                                                 radius=2,
                                                 fill=True)
 
+    def test_points_to_from_indices(self):
+        points = [[0.05, 0.55, 0.35]]
+        origin = [0, 0, 0]
+        pitch = 0.1
+        indices = [[1, 6, 4]]
+
+        # points -> indices
+        indices2 = g.trimesh.voxel.points_to_indices(
+            points=points, origin=origin, pitch=pitch
+        )
+        g.np.testing.assert_allclose(indices, indices2, atol=0, rtol=0)
+
+        # indices -> points
+        points2 = g.trimesh.voxel.indices_to_points(
+            indices=indices, origin=origin, pitch=pitch
+        )
+        g.np.testing.assert_allclose(points, points2)
+
+        # indices -> points -> indices (this must be consistent)
+        points2 = g.trimesh.voxel.indices_to_points(
+            indices=indices, origin=origin, pitch=pitch
+        )
+        indices2 = g.trimesh.voxel.points_to_indices(
+            points=points2, origin=origin, pitch=pitch
+        )
+        g.np.testing.assert_allclose(indices, indices2, atol=0, rtol=0)
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/voxel.py
+++ b/trimesh/voxel.py
@@ -273,7 +273,7 @@ class VoxelMesh(Voxel):
         else:
             filled = self.sparse_surface
         # center points of voxels
-        centers = indices_to_points(filled, pitch, self.origin)
+        centers = indices_to_points(indices=filled, pitch=self.pitch, origin=self.origin)
         mesh = multibox(centers=centers, pitch=self.pitch)
         return mesh
 

--- a/trimesh/voxel.py
+++ b/trimesh/voxel.py
@@ -109,11 +109,10 @@ class Voxel(object):
         ---------
         index: (3,) int tuple, index in self.matrix
         """
-        point = np.asanyarray(point)
-        if point.shape != (3,):
-            raise ValueError('to_index requires a single point')
-        index = np.round((point - self.origin) / self.pitch + 0.5).astype(int)
-        index = tuple(index)
+        indices = points_to_indices(points=[point],
+                                    pitch=self.pitch,
+                                    origin=self.origin)
+        index = tuple(indices[0])
         return index
 
     def is_filled(self, point):
@@ -273,7 +272,9 @@ class VoxelMesh(Voxel):
         else:
             filled = self.sparse_surface
         # center points of voxels
-        centers = indices_to_points(indices=filled, pitch=self.pitch, origin=self.origin)
+        centers = indices_to_points(indices=filled,
+                                    pitch=self.pitch,
+                                    origin=self.origin)
         mesh = multibox(centers=centers, pitch=self.pitch)
         return mesh
 
@@ -559,6 +560,34 @@ def fill_voxelization(occupied):
     return filled
 
 
+def points_to_indices(points, pitch, origin):
+    """
+    Convert center points of an (n,m,p) matrix into its indices.
+
+    Parameters
+    ----------
+    points: (q, 3) float, center points of voxel matrix (n,m,p)
+    pitch: float, what pitch was the voxel matrix computed with
+    origin: (3,) float, what is the origin of the voxel matrix
+
+    Returns
+    ----------
+    indices: (q, 3) int, list of indices
+    """
+    points = np.asanyarray(points, dtype=np.float64)
+    origin = np.asanyarray(origin, dtype=np.float64)
+    pitch = float(pitch)
+
+    if points.shape != (points.shape[0], 3):
+        raise ValueError('shape of points must be (q, 3)')
+
+    if origin.shape != (3,):
+        raise ValueError('shape of origin must be (3,)')
+
+    indices = np.round((points - origin) / pitch + 0.5).astype(int)
+    return indices
+
+
 def indices_to_points(indices, pitch, origin):
     """
     Convert indices of an (n,m,p) matrix into a set of voxel center points.
@@ -571,14 +600,17 @@ def indices_to_points(indices, pitch, origin):
 
     Returns
     ----------
-    points: (q, 3) list of points
+    points: (q, 3) float, list of points
     """
     indices = np.asanyarray(indices, dtype=np.float64)
     origin = np.asanyarray(origin, dtype=np.float64)
     pitch = float(pitch)
 
+    if indices.shape != (indices.shape[0], 3):
+        raise ValueError('shape of indices must be (q, 3)')
+
     if origin.shape != (3,):
-        raise ValueError('origin incorrect shape!')
+        raise ValueError('shape of origin must be (3,)')
 
     points = (indices - 0.5) * pitch + origin
     return points

--- a/trimesh/voxel.py
+++ b/trimesh/voxel.py
@@ -573,6 +573,13 @@ def indices_to_points(indices, pitch, origin):
     ----------
     points: (q, 3) list of points
     """
+    indices = np.asanyarray(indices, dtype=np.float64)
+    origin = np.asanyarray(origin, dtype=np.float64)
+    pitch = float(pitch)
+
+    if origin.shape != (3,):
+        raise ValueError('origin incorrect shape!')
+
     points = (indices - 0.5) * pitch + origin
     return points
 

--- a/trimesh/voxel.py
+++ b/trimesh/voxel.py
@@ -592,7 +592,7 @@ def matrix_to_points(matrix, pitch, origin):
     points: (q, 3) list of points
     """
     indices = np.column_stack(np.nonzero(matrix))
-    points = indices_to_points(indices, pitch, origin)
+    points = indices_to_points(indices=indices, pitch=pitch, origin=origin)
     return points
 
 


### PR DESCRIPTION
I'm not so sure, but usually voxel point coordinate should be calculated as:

  (index - 0.5) * pitch + origin = index * pitch + origin - pitch / 2.0

In VoxelMesh.as_boxes this formulation is used, but the matrix_to_points function does not.