### PR TITLE
Slice with multiple planes and performance tweaks

### DIFF
--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -176,6 +176,32 @@ class SliceTest(g.unittest.TestCase):
         # should be lots of stuff at the plane and nothing behind
         assert g.np.isclose(dot.min(), 0.0)
 
+        # Cut part of top off of box with multiple planes at once
+        # and make sure bounds and number of faces is correct
+        plane_origins = [mesh.bounds[1] - 0.05, mesh.bounds[1] - 0.05]
+        plane_normals = [g.np.array([0, 0, 1]), g.np.array([0, 1, 0])]
+
+        sliced = mesh.slice_planes(plane_origins=plane_origins,
+                                   plane_normals=plane_normals)
+
+        assert g.np.isclose(
+            sliced.bounds[0], mesh.bounds[0] + g.np.array([0, 0.95, 0.95])).all()
+        assert g.np.isclose(sliced.bounds[1], mesh.bounds[1]).all()
+        assert len(sliced.faces) == 11
+
+        # Try with more complicated mesh and make sure we get correct projections and some faces
+        origins = [bunny.bounds.mean(axis=0), bunny.bounds.mean(axis=0)+0.01*g.trimesh.unitize([1, 1, 2])]
+        normals = [g.trimesh.unitize([1, 1, 2]), -g.trimesh.unitize([1, 1, 2])]
+
+        sliced = bunny.slice_planes(plane_origins=origins,
+                                    plane_normals=normals)
+        assert len(sliced.faces) > 0
+
+        for o,n in zip(origins,normals):
+            # check the projections manually
+            dot = g.np.dot(n, (sliced.vertices - o).T)
+            # should be lots of stuff at the plane and nothing behind
+            assert g.np.isclose(dot.min(), 0.0)
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1858,6 +1858,39 @@ class Trimesh(Geometry):
             **kwargs)
 
         return new_mesh
+    
+    def slice_planes(self,
+                     plane_origins,
+                     plane_normals,
+                     **kwargs):
+        """
+        Returns another mesh that is the current mesh
+        sliced by the planes defined by origins and normals.
+        Saves some computation over calling the slice_mesh_plane
+        method multiple times by not creating a new object and 
+        just carrying the faces and vertices arrays.
+
+        Parameters
+        ---------
+        plane_normals: (n,3) float
+          Normal vectors of slicing planes
+        plane_origins : (n,3) float
+          Points on the slicing planes
+
+        Returns
+        ---------
+        new_mesh: trimesh.Trimesh or None
+          Subset of current mesh sliced by planes
+        """
+
+        # return a new mesh
+        new_mesh = intersections.slice_mesh_planes(
+            mesh=self,
+            plane_normals=plane_normals,
+            plane_origins=plane_origins,
+            **kwargs)
+
+        return new_mesh
 
     @caching.cache_decorator
     def convex_hull(self):


### PR DESCRIPTION
Two main things:
1) I found that slicing with multiple planes (not necessarily parallel) gets a speed up when not creating a new Trimesh object every time, so I've expanded the slice_plane method to slice_planes, where you can instead pass an array of origins/normals. I left the old method for compatibility sake, but feel free to do what you want with it (e.g., the new method subsumes the old, so eventually might want to just switch over to the new one)!
2) Some minor performance tweaks. The biggest one was replacing np.unique with np.bincount. Since the faces arrays are all integer-valued, it seems like np.bincount/cumsum perform a lot better than np.unique (e.g., 2-3x faster for small meshes, 10x faster for large meshes). Here are some examples for a smaller mesh (10s of faces) and a larger mesh (~40,000) faces (using kernprof):
![headings](https://user-images.githubusercontent.com/7028710/49317488-8999ab80-f4a9-11e8-9521-4393c7b938fa.png)
![np_unique](https://user-images.githubusercontent.com/7028710/49317492-8d2d3280-f4a9-11e8-839e-2ac8b2943026.png)
![np_unique_big](https://user-images.githubusercontent.com/7028710/49317496-8ef6f600-f4a9-11e8-9368-0a15c807ac64.png)
![unique_replacement](https://user-images.githubusercontent.com/7028710/49317499-90c0b980-f4a9-11e8-8e71-e348dd9f625b.png)
![unique_replacement_big](https://user-images.githubusercontent.com/7028710/49317507-9d451200-f4a9-11e8-9954-2a67e61ebce9.png)

Happy to answer questions and I hope it helps!
