### PR TITLE
Fix missing arg in call to unique_bincount

### DIFF
--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1905,6 +1905,7 @@ class Trimesh(Geometry):
         """
         # use unique_bincount over np.unique for a 20x speedup
         unique, inverse = util.unique_bincount(self.faces.reshape(-1),
+                                               minlength=len(self.vertices),
                                                return_inverse=True)
         self.faces = inverse.reshape((-1, 3))
         self.vertices = self.vertices[unique]


### PR DESCRIPTION
Missing kwarg `mincount` to `unique_bincount` was causing an error on master when removing unreferenced vertices.