### PR TITLE
Support loading ShapeNet models: support Kd in mtl and some fixes in 'vt' and 'f'

### DIFF
--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -215,7 +215,7 @@ class VisualTest(g.unittest.TestCase):
         uv = g.np.array([[0.25, 0.2], [0.4, 0.5]], dtype=float)
         texture = g.np.arange(96, dtype=g.np.uint8).reshape(8, 4, 3)
         colors = g.trimesh.visual.uv_to_color(uv, PIL.Image.fromarray(texture))
-        colors_expected = [[75, 76, 77, 255], [54, 55, 56, 255]]
+        colors_expected = [[75, 76, 77, 255], [51, 52, 53, 255]]
 
         g.np.testing.assert_allclose(colors, colors_expected, rtol=0, atol=0)
 

--- a/trimesh/io/wavefront.py
+++ b/trimesh/io/wavefront.py
@@ -215,7 +215,7 @@ def load_wavefront(file_obj, resolver=None, **kwargs):
                         vertex_colors_i = None
                     if vertex_colors_i is None:
                         vertex_colors_i = np.full(
-                            (len(uv), 4), (102, 102, 102, 255), dtype=np.uint8)
+                            (len(uv), 4), visual.DEFAULT_COLOR, dtype=np.uint8)
                     vertex_colors = np.r_[vertex_colors, vertex_colors_i]
                 loaded['vertex_colors'] = vertex_colors[vert_order]
 

--- a/trimesh/io/wavefront.py
+++ b/trimesh/io/wavefront.py
@@ -204,7 +204,8 @@ def load_wavefront(file_obj, resolver=None, **kwargs):
             if len(current['usemtl']) > 0:
                 texture = np.array(current['vt'], dtype=np.float64)
                 vertex_colors = np.zeros((0, 4), dtype=np.uint8)
-                for usemtl, findices in usemtl_to_findices.items():
+                for usemtl in current['usemtl']:
+                    findices = usemtl_to_findices[usemtl]
                     uv = texture[findices]
                     try:
                         vertex_colors_i = _get_vertex_colors(
@@ -281,6 +282,7 @@ def load_wavefront(file_obj, resolver=None, **kwargs):
             append_mesh()
             # reset current to empty lists
             current = {k: [] for k in current.keys()}
+            usemtl_to_findices = collections.defaultdict(list)
             remap = {}
             next_idx = 0
             group_idx = 0

--- a/trimesh/io/wavefront.py
+++ b/trimesh/io/wavefront.py
@@ -206,8 +206,13 @@ def load_wavefront(file_obj, resolver=None, **kwargs):
                 vertex_colors = np.zeros((0, 4), dtype=np.uint8)
                 for usemtl, findices in usemtl_to_findices.items():
                     uv = texture[findices]
-                    vertex_colors_i = _get_vertex_colors(
-                        uv=uv, mtllib=mtllibs[usemtl], resolver=resolver)
+                    try:
+                        vertex_colors_i = _get_vertex_colors(
+                            uv=uv, mtllib=mtllibs[usemtl], resolver=resolver)
+                    except BaseException:
+                        log.error('failed to load texture: {}'.format(usemtl),
+                                  exc_info=True)
+                        vertex_colors_i = None
                     if vertex_colors_i is None:
                         vertex_colors_i = np.full(
                             (len(uv), 4), (102, 102, 102, 255), dtype=np.uint8)

--- a/trimesh/visual/texture.py
+++ b/trimesh/visual/texture.py
@@ -19,10 +19,18 @@ def uv_to_color(uv, image):
     colors : (n, 4) float
       RGBA color at each of the UV coordinates
     """
-    x = (uv[:, 0] * image.width).round().astype(int)
-    y = ((1 - uv[:, 1]) * image.height).round().astype(int)
+    # https://shapenet.org/qaforum/index.php?qa=15&qa_1=why-is-the-texture-coordinate-in-the-obj-file-not-in-the-range  # NOQA
+    if not (uv.min() >= 0 and uv.max() <= 1):
+        uv = uv - np.floor(uv)
+
+    x = (uv[:, 0] * (image.width - 1)).round().astype(int)
+    y = ((1 - uv[:, 1]) * (image.height - 1)).round().astype(int)
 
     image = np.asarray(image)
     colors = image[y, x]
-    colors = to_rgba(colors)
+    if colors.ndim == 1:  # gray scale
+        colors = np.repeat(colors[:, None], 3, axis=1)
+    # now ndim == 2
+    if colors.shape[1] == 3:
+        colors = to_rgba(colors)  # rgb -> rgba
     return colors


### PR DESCRIPTION
With this change, trimesh now supports loading textures and colors for models in ShapeNetSem.v0.
(This information was the key for uv_to_color with uv out of range from [0, 1]: https://shapenet.org/qaforum/index.php?qa=15&qa_1=why-is-the-texture-coordinate-in-the-obj-file-not-in-the-range)

<img src='https://drive.google.com/uc?id=1ANxzreOjd-q3m82KkYczaSyfiinNuKNf' width='50%' />

```python
import pathlib
import numpy as np
import trimesh

# trimesh.util.attach_to_log()

scene = trimesh.Scene()

models_dir = pathlib.Path('ShapeNetSemModels')
for cad_file in models_dir.glob('*.obj'):
    print(cad_file)

    cad = trimesh.load(str(cad_file))

    # centerize
    xyz_min = np.min(cad.vertices, axis=0)
    xyz_max = np.max(cad.vertices, axis=0)
    xyz_center = (xyz_max + xyz_min) / 2.
    cad.vertices -= xyz_center

    max_size = (xyz_max - xyz_min).max()
    cad.vertices /= max_size  # normalize

    print(cad.bounding_box.primitive.extents)

    # shift for visualization
    x = len(scene.geometry) % 4
    y = len(scene.geometry) // 4
    transform = trimesh.transformations.translation_matrix(
        [1.5 * x, 1.5 * y, 0]
    )
    scene.add_geometry(cad, transform=transform)

    if len(scene.geometry) == 16:
        break
scene.show()
```

Of course, it works with YCB object models:

<img src="https://drive.google.com/uc?id=1AQ73VP2MPfJBKihN7gY9CrTm8W0rLm7f" width="50%" />

```python
import pathlib
import numpy as np
import trimesh

# trimesh.util.attach_to_log()

scene = trimesh.Scene()

models_dir = pathlib.Path('YCB_Video_Models')
for obj_dir in sorted(models_dir.iterdir()):
    cad_file = obj_dir / 'textured.obj'
    print(cad_file)

    cad = trimesh.load(str(cad_file))

    # centerize
    xyz_min = np.min(cad.vertices, axis=0)
    xyz_max = np.max(cad.vertices, axis=0)
    xyz_center = (xyz_max + xyz_min) / 2.
    cad.vertices -= xyz_center

    max_size = (xyz_max - xyz_min).max()
    cad.vertices /= max_size  # normalize

    print(cad.bounding_box.primitive.extents)

    # shift for visualization
    x = len(scene.geometry) % 4
    y = len(scene.geometry) // 4
    transform = trimesh.transformations.translation_matrix(
        [1.5 * x, 1.5 * y, 0]
    )
    scene.add_geometry(cad, transform=transform)

    if len(scene.geometry) == 16:
        break
scene.show()
```