### PR TITLE
Fix bug in assimp loaders

### DIFF
--- a/trimesh/exchange/assimp.py
+++ b/trimesh/exchange/assimp.py
@@ -2,7 +2,7 @@ import tempfile
 import numpy as np
 
 
-def load_pyassimp(file_obj, file_type=None, resolver=None):
+def load_pyassimp(file_obj, file_type=None, resolver=None, **kwargs):
     """
     Use the pyassimp library to load a mesh, from a file object and type,
     or filename (if file_obj is a string)
@@ -38,7 +38,7 @@ def load_pyassimp(file_obj, file_type=None, resolver=None):
     return meshes
 
 
-def load_cyassimp(file_obj, file_type=None, resolver=None):
+def load_cyassimp(file_obj, file_type=None, resolver=None, **kwargs):
     """
     Load a file using the cyassimp bindings.
 


### PR DESCRIPTION
The issue is that all other `load()` functions take in mesh kwargs (even if they don't use them). The assimp functions did not admit kwargs, and therefore failed when `trimesh.load_mesh()` was called with kwargs like `process=False` or something similar.