### PR TITLE
closest_point() fix for (obtuse) triangles

### DIFF
--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -491,7 +491,6 @@ def closest_point(triangles, points):
     closest: (n,3) float, point on each triangle closest to each point
     """
 
-
     # establish that input triangles and points are sane
     triangles = np.asanyarray(triangles, dtype=np.float64)
     points = np.asanyarray(points, dtype=np.float64)
@@ -499,7 +498,6 @@ def closest_point(triangles, points):
         raise ValueError('triangles shape incorrect')
     if not util.is_shape(points, (len(triangles), 3)):
         raise ValueError('triangles and points must correspond')
-
 
     # convert points to barycentric coordinates
     barycentric = points_to_barycentric(triangles, points)
@@ -529,11 +527,10 @@ def closest_point(triangles, points):
     # 2 negative, 1 positive: closest point is positive vertex
     # 1 negative, 2 positive: closest point is on edge between 2 positive
     # 0 negative, 3 positive: closest point is @ barycentric coord
-    #case_vertex = np.bitwise_and(positive_sum == 1, True ^ case_obtuse)
     case_vertex = positive_sum == 1
     case_edge = positive_sum == 2
     case_barycentric = positive_sum == 3
-    
+
     # closest points to triangle
     closest = np.zeros(points.shape, dtype=np.float64)
 
@@ -560,7 +557,7 @@ def closest_point(triangles, points):
     # our point needs to be on the edge, so the distance along the edge
     # should be clipped to be between 0.0 and 1.0
     edge_distance = np.clip(edge_distance, 0.0, 1.0)
-    
+
     projection = edges[:, 0] + (edge_distance * AB)
     closest[case_edge] = projection
 


### PR DESCRIPTION
Hai again,

I have noticed an issue with the signed_distance() and on_surface() methods and were able to trace it back to an incorrect computation of the closest_point() method of the triangle class.
The selection for case_vertex and case_edge based on the number of positive barycentric coordinates is only correct for certain points but not for all outside of a triangle.
For cases which belong in case_vertex but end up in case_edge, the clipping at the end (to the edge's extend) will fix this and return the correct vertex position.
However, for obtuse triangles there are scenarios that belong in case_edge but end up in case_vertex and will return a wrong point.
I extended the triangle class with a minimally invasive fix on the barycentric-coordinate's 'positive' mask to also handle these cases correctly.
Furthermore, I have added a simple test for one point with ground-truth result and a circle of points with a naive point-to-edge distance comparison to check the results.

The fix feels kind of hacky, but as far as I have checked, it seems to produce correct results now.
Do you think its worth to refactor the method? Let me know, I think I could come up with something.

Cheers,
Dennis

Also - here is a nice wysiwyg-tool which I used to play around with barycentric coordinates and to figure out when and why the current method failed:
https://www.geogebra.org/m/ZuvmPjmy