### PR TITLE
followup on closest_point()

### DIFF
--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -522,6 +522,7 @@ def closest_point(triangles, points):
     # by the right-hand rule: edge-vectors (index finger) x normal (middle finger)
     # compute the r-vectors (thumb) pointing away from the triangle
     rVecsABC = simpleCross(eVecsABC.reshape(-1,3), np.repeat(normalsABC, 3, axis=0))
+    rVecsABC /= np.sqrt(np.sum(rVecsABC**2, axis=1)).reshape(-1,1)
     distsToEdgeLines = inner1d(rVecsABC, inPlaneVecs.reshape(-1,3)).reshape(-1,3)
 
     # separate points on the inside/outside of the triange with the dot-product signs

--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -480,7 +480,7 @@ def closest_point(triangles, points):
     """
     Return the closest point on the surface of each triangle for a
     list of corresponding points.
-    
+
     Parameters
     ----------
     triangles: (n,3,3) float, triangles in space


### PR DESCRIPTION
This method was developed for my specific use-case to compute distances from many points to one triangle. So I just extended some dimensions here and there to generalize it for a list of triangles.
It has less case distinctions and in my tests was a bit faster than the RTCD method - so I thought, you might want to check it out. =)

Here is a sketch that illustrates how the edge-selection works: https://ggbm.at/qfxsevaq

I often use stripped-down versions of NumPy operations for arrays of known size which often perform a lot faster due to less overhead ... like the simpleCross(), normalization with sqrt(dot()), or inner1d() which I think is equivalent to your util.diagonal_dot().

Cheers,
Dennis