### PR TITLE
Fix collada I/O bugs

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -85,7 +85,7 @@ def export_collada(mesh, **kwargs):
     export: str, string of COLLADA format output
     """
     meshes = mesh
-    if not isinstance(mesh, list) and not isinstance(mesh, tuple):
+    if not isinstance(mesh, (list, tuple, set, np.ndarray)):
         meshes = [mesh]
 
     c = collada.Collada()
@@ -176,7 +176,7 @@ def _parse_node(node,
                 local_material_map[symbol] = _parse_material(m, resolver)
 
         # Iterate over primitives of geometry
-        for primitive in geometry.primitives:
+        for i, primitive in enumerate(geometry.primitives):
             if isinstance(primitive, collada.polylist.Polylist):
                 primitive = primitive.triangleset()
             if isinstance(primitive, collada.triangleset.TriangleSet):
@@ -221,16 +221,17 @@ def _parse_node(node,
                     vis = visual.texture.TextureVisuals(
                         uv=uv, material=material)
 
-                meshes[geometry.id] = {
+                primid = '{}.{}'.format(geometry.id, i)
+                meshes[primid] = {
                     'vertices': vertices,
                     'faces': faces,
                     'vertex_normals': normals,
                     'vertex_colors': colors,
                     'visual': vis}
 
-                graph.append({'frame_to': id(node),
+                graph.append({'frame_to': primid,
                               'matrix': parent_matrix,
-                              'geometry': geometry.id})
+                              'geometry': primid})
 
     # recurse down tree for nodes with children
     elif isinstance(node, collada.scene.Node):

--- a/trimesh/exchange/export.py
+++ b/trimesh/exchange/export.py
@@ -41,7 +41,7 @@ def export_mesh(mesh, file_obj, file_type=None, **kwargs):
     if not (file_type in _mesh_exporters):
         raise ValueError('%s exporter not available!', file_type)
 
-    if isinstance(mesh, list) or isinstance(mesh, tuple):
+    if isinstance(mesh, (list, tuple, set, np.ndarray)):
         faces = 0
         for m in mesh:
             faces += len(m.faces)


### PR DESCRIPTION
Hey man, sorry I got this to you late! There was a bug in your revision of the COLLADA exporter that crops up for geometry nodes with more than one primitive. Basically, each node could have several meshes assigned to it as primitives, and using the geometry's ID as a dict key was preventing these meshes from being added.

Also, added more types to the "list" check to make it easier to export many meshes into one DAE.