### PR TITLE
Don't use the pyglet shadow window

### DIFF
--- a/trimesh/rendering.py
+++ b/trimesh/rendering.py
@@ -9,6 +9,7 @@ import numpy as np
 
 try:
     import pyglet
+    pyglet.options['shadow_window'] = False
     from pyglet import gl
     # bring in mode enum
     GL_LINES, GL_POINTS, GL_TRIANGLES = (

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -9,6 +9,7 @@ Works on all major platforms: Windows, Linux, and OSX.
 """
 
 import pyglet
+pyglet.options['shadow_window'] = False
 import pyglet.gl as gl
 
 import numpy as np


### PR DESCRIPTION
This is a bit of an interesting one. Basically, Pyglet automagically pops a shadow window when you import `pyglet.gl`, which allows you to do shared context stuff and lets you load objects into OpenGL before you make your "real" window. However, your viewer doesn't use this feature, and using it breaks the ability to get OpenGL 3+ contexts on MacOS.

The way to fix this is to disable the shadow window -- right after you import pyglet, just do

```python
pyglet.options['shadow_window'] = False
```

The reason I wanted to try to make this change in trimesh is because it needs to be done the first time pyglet is imported _anywhere_ in your code. On OSX, if you import trimesh before pyrender, you simply won't be able to use pyrender's viewer since pyglet will have already created the shadow window.

I'll investigate further into why exactly pyglet's windowing system is broken, but this would be a (hopefully zero-cost) stopgap fix. Open to discussions on it.