### PR TITLE
Handle PBR materials appropriately

### DIFF
--- a/trimesh/visual/texture.py
+++ b/trimesh/visual/texture.py
@@ -204,17 +204,27 @@ class PBRMaterial(Material):
                  baseColorFactor=None,
                  metallicFactor=None,
                  roughnessFactor=None,
-                 metallicRoughnessTexture=None):
+                 metallicRoughnessTexture=None,
+                 doubleSided=False,
+                 alphaMode='OPAQUE',
+                 alphaCutoff=0.5):
+
+        # To to-float conversions
+        if baseColorFactor is not None:
+            baseColorFactor = np.array(baseColorFactor, dtype=np.float)
+        if emissiveFactor is not None:
+            emissiveFactor = np.array(emissiveFactor, dtype=np.float)
 
         # (4,) float
-        self.baseColorFactor = baseColorFactor
+        self.baseColorFactor = color.to_rgba(baseColorFactor)
 
         # (3,) float
-        self.emissiveFactor = emissiveFactor
+        self.emissiveFactor = color.to_rgba(emissiveFactor)
 
         # float
         self.metallicFactor = metallicFactor
         self.roughnessFactor = roughnessFactor
+        self.alphaCutoff = alphaCutoff
 
         # PIL image
         self.normalTexture = normalTexture
@@ -222,6 +232,12 @@ class PBRMaterial(Material):
         self.occlusionTexture = occlusionTexture
         self.baseColorTexture = baseColorTexture
         self.metallicRoughnessTexture = metallicRoughnessTexture
+
+        # bool
+        self.doubleSided = doubleSided
+
+        # str
+        alphaMode = alphaMode
 
     def to_color(self, uv):
         color = uv_to_color(uv=uv, image=self.baseColorTexture)


### PR DESCRIPTION
Just added the last few PBR things you might get from a .glb file and cleans up the way we convert colors from glTF's floats to trimesh's uint8's. Example mesh is attached (nike_shoe).

Also, as an FYI, we don't yet cleanly handle .obj files with multiple materials per mesh. See attached example (dish). We could probably handle this by splitting meshes based on their face grouping, although it's a bit weird.

Best,
Matt

[nike_shoe.glb.zip](https://github.com/mikedh/trimesh/files/2903051/nike_shoe.glb.zip)

[Dish with Sailing-ship Design.zip](https://github.com/mikedh/trimesh/files/2903050/Dish.with.Sailing-ship.Design.zip)
