### PR TITLE
Make color conversion more permissive.

### DIFF
--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -505,11 +505,9 @@ def to_rgba(colors, dtype=np.uint8):
     # integer value for opaque alpha given our datatype
     opaque = np.iinfo(dtype).max
 
-    if (colors.dtype.kind == 'f' and
-            colors.max() < (1.0 + 1e-8)):
+    if (colors.dtype.kind == 'f' and colors.max() < (1.0 + 1e-8)):
         colors = (colors * opaque).astype(dtype)
-    elif (colors.dtype.kind in 'iu' and
-          colors.max() <= opaque):
+    elif (colors.max() <= opaque):
         colors = colors.astype(dtype)
     else:
         raise ValueError('colors non- convertible!')


### PR DESCRIPTION
Extremely small PR here. I've found that sometimes you'll have DAE files that have colors written in the format [255.0 237.0 233.0 255.0], for example (floating point, but really should be int). Making the color converter a bit more permissive makes it possible to cleanly load these types of meshes. I've attached an example here.

[base.dae.zip](https://github.com/mikedh/trimesh/files/2944039/base.dae.zip)

