### PR TITLE
Enhance arguments to PointCloud.__init__()

### DIFF
--- a/tests/generic.py
+++ b/tests/generic.py
@@ -17,6 +17,7 @@ import itertools
 import subprocess
 import contextlib
 import threading
+import warnings
 
 try:
     # Python 3

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -66,6 +66,28 @@ class PointsTest(g.unittest.TestCase):
         assert g.np.allclose(cloud.vertices,
                              cloud.copy().vertices)
 
+    def test_init_arguments(self):
+        # unsupported arguments
+        vertices = [[0, 0, 0], [1, 1, 1]]
+        colors = [[0, 0, 1.0], [1.0, 0, 0]]
+        # in args
+        self.assertRaises(
+            TypeError, lambda: g.trimesh.PointCloud(vertices, colors, 1))
+        # in kwargs
+        self.assertRaises(
+            TypeError, lambda: g.trimesh.PointCloud(unsupported=1))
+
+        # deprecated color -> colors
+        with g.warnings.catch_warnings(record=True) as w:
+            g.warnings.simplefilter('always')
+            p = g.trimesh.PointCloud(vertices=vertices, color=colors)
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, DeprecationWarning)
+        g.np.testing.assert_allclose(p.colors, colors)
+        # introduced colors
+        p = g.trimesh.PointCloud(vertices=vertices, colors=colors)
+        g.np.testing.assert_allclose(p.colors, colors)
+
     def test_empty(self):
         p = g.trimesh.PointCloud(None)
         assert p.is_empty

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -67,16 +67,8 @@ class PointsTest(g.unittest.TestCase):
                              cloud.copy().vertices)
 
     def test_init_arguments(self):
-        # unsupported arguments
         vertices = [[0, 0, 0], [1, 1, 1]]
         colors = [[0, 0, 1.0], [1.0, 0, 0]]
-        # in args
-        self.assertRaises(
-            TypeError, lambda: g.trimesh.PointCloud(vertices, colors, 1))
-        # in kwargs
-        self.assertRaises(
-            TypeError, lambda: g.trimesh.PointCloud(unsupported=1))
-
         # deprecated color -> colors
         with g.warnings.catch_warnings(record=True) as w:
             g.warnings.simplefilter('always')

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -349,7 +349,7 @@ class PointCloud(Geometry):
     in a scene.
     """
 
-    def __init__(self, vertices, colors=None, *args, **kwargs):
+    def __init__(self, vertices, colors=None, color=None):
         self._data = caching.DataStore()
         self._cache = caching.Cache(self._data.md5)
         self.metadata = {}
@@ -359,19 +359,11 @@ class PointCloud(Geometry):
 
         if colors is not None:
             self.colors = colors
-        if colors is None and 'color' in kwargs:
+        elif color is not None:
             warnings.warn(
                 "argument 'color' is deprecated, use 'colors' instead",
                 DeprecationWarning)
-            self.colors = kwargs.pop('color')
-
-        if args:
-            raise TypeError(
-                '__init__() got unexpected arguments: {}'.format(args))
-        if kwargs:
-            raise TypeError(
-                '__init__() got unexpected keyword arguments: {}'
-                .format(kwargs))
+            self.colors = color
 
     def __setitem__(self, *args, **kwargs):
         return self.vertices.__setitem__(*args, **kwargs)

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -5,6 +5,7 @@ points.py
 Functions dealing with (n, d) points.
 """
 import copy
+import warnings
 
 import numpy as np
 
@@ -359,7 +360,9 @@ class PointCloud(Geometry):
         if colors is not None:
             self.colors = colors
         if colors is None and 'color' in kwargs:
-            log.warning("argument 'color' is deprecated, use 'colors' instead")
+            warnings.warn(
+                "argument 'color' is deprecated, use 'colors' instead",
+                DeprecationWarning)
             self.colors = kwargs.pop('color')
 
         if args:

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -8,6 +8,7 @@ import copy
 
 import numpy as np
 
+from .constants import log
 from .constants import tol
 from .geometry import plane_transform
 from .parent import Geometry
@@ -347,7 +348,7 @@ class PointCloud(Geometry):
     in a scene.
     """
 
-    def __init__(self, vertices, *args, **kwargs):
+    def __init__(self, vertices, colors=None, *args, **kwargs):
         self._data = caching.DataStore()
         self._cache = caching.Cache(self._data.md5)
         self.metadata = {}
@@ -355,8 +356,19 @@ class PointCloud(Geometry):
         # load vertices
         self.vertices = vertices
 
-        if 'color' in kwargs:
-            self.colors = kwargs['color']
+        if colors is not None:
+            self.colors = colors
+        if colors is None and 'color' in kwargs:
+            log.warning("argument 'color' is deprecated, use 'colors' instead")
+            self.colors = kwargs.pop('color')
+
+        if args:
+            raise TypeError(
+                '__init__() got unexpected arguments: {}'.format(args))
+        if kwargs:
+            raise TypeError(
+                '__init__() got unexpected keyword arguments: {}'
+                .format(kwargs))
 
     def __setitem__(self, *args, **kwargs):
         return self.vertices.__setitem__(*args, **kwargs)


### PR DESCRIPTION
- color is renamed to colors
- checks invalid (unused) args and kwargs

For me, `colors` looks better. What do you think? @mikedh 