### PR TITLE
Fix small issues with DAE and GLB mats

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -210,7 +210,7 @@ def _parse_node(node,
 
                 # Get UV coordinates if possible
                 vis = None
-                if colors is None and primitive.material in local_material_map:
+                if primitive.material in local_material_map:
                     material = copy.copy(
                         local_material_map[primitive.material])
                     uv = None

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -783,17 +783,16 @@ def _read_buffers(header, buffers, mesh_kwargs):
             kwargs["vertices"] = access[p["attributes"]["POSITION"]]
 
             # do we have UV coordinates
-            if "TEXCOORD_0" in p["attributes"]:
-                if "material" not in p:
-                    log.warning("texcoord without material!")
-                else:
+            if "material" in p:
+                uv = None
+                if "TEXCOORD_0" in p["attributes"]:
                     # flip UV's top- bottom to move origin to lower-left:
                     # https://github.com/KhronosGroup/glTF/issues/1021
                     uv = access[p["attributes"]["TEXCOORD_0"]].copy()
                     uv[:, 1] = 1.0 - uv[:, 1]
                     # create a texture visual
-                    kwargs["visual"] = visual.texture.TextureVisuals(
-                        uv=uv, material=materials[p["material"]])
+                kwargs["visual"] = visual.texture.TextureVisuals(
+                    uv=uv, material=materials[p["material"]])
 
             # create a unique mesh name per- primitive
             if "name" in m:


### PR DESCRIPTION
Basically, this allows you to actually use DAE and GLB/GLTF materials when (A) vertex colors are present, or (B) when UV coordinates are not present.