### PR TITLE
Update wavefront.py

### DIFF
--- a/trimesh/exchange/wavefront.py
+++ b/trimesh/exchange/wavefront.py
@@ -3,7 +3,7 @@ import collections
 import numpy as np
 
 try:
-    import PIL
+    import PIL.Image
 except ImportError:
     pass
 


### PR DESCRIPTION
fix "PIL has no attribute Image"

PIL itself does not have anything, need explicit import.