### PR TITLE
Estimate memory usage before actually computing the radius using cdist

### DIFF
--- a/trimesh/nsphere.py
+++ b/trimesh/nsphere.py
@@ -74,6 +74,10 @@ def minimum_nsphere(obj):
     try:
         # cdist is massivly faster than looping or tiling methods
         # although it does create a very large intermediate array
+
+        memory_estimate = len(voronoi.vertices) * len(points) * 8 # bytes
+        if memory_estimate > 2e6:
+            raise MemoryError
         radii_2 = spatial.distance.cdist(
             voronoi.vertices, points,
             metric='sqeuclidean').max(axis=1)

--- a/trimesh/nsphere.py
+++ b/trimesh/nsphere.py
@@ -83,7 +83,7 @@ def minimum_nsphere(obj):
             metric='sqeuclidean').max(axis=1)
     except MemoryError:
         # log the MemoryError
-        log.warning('MemoryError (%s): falling back to slower check!' % memory_estimate)
+        log.warning('MemoryError: falling back to slower check!')
         # fall back to a potentially very slow list comprehension
         radii_2 = np.array([((points - v) ** 2).sum(axis=1).max()
                             for v in voronoi.vertices])

--- a/trimesh/nsphere.py
+++ b/trimesh/nsphere.py
@@ -76,14 +76,14 @@ def minimum_nsphere(obj):
         # although it does create a very large intermediate array
 
         memory_estimate = len(voronoi.vertices) * len(points) * 8 # bytes
-        if memory_estimate > 1e6:
+        if memory_estimate > 1e9:
             raise MemoryError
         radii_2 = spatial.distance.cdist(
             voronoi.vertices, points,
             metric='sqeuclidean').max(axis=1)
     except MemoryError:
         # log the MemoryError
-        log.warning('MemoryError: falling back to slower check!')
+        log.warning('MemoryError (%s): falling back to slower check!' % memory_estimate)
         # fall back to a potentially very slow list comprehension
         radii_2 = np.array([((points - v) ** 2).sum(axis=1).max()
                             for v in voronoi.vertices])

--- a/trimesh/nsphere.py
+++ b/trimesh/nsphere.py
@@ -76,7 +76,7 @@ def minimum_nsphere(obj):
         # although it does create a very large intermediate array
 
         memory_estimate = len(voronoi.vertices) * len(points) * 8 # bytes
-        if memory_estimate > 2e6:
+        if memory_estimate > 1e6:
             raise MemoryError
         radii_2 = spatial.distance.cdist(
             voronoi.vertices, points,


### PR DESCRIPTION
Hi Mike!

I came across a file that consumed 23 GB (94698 voronoi vertices and 31361 points), while computing the radius of the bounding sphere, no `MemoryError` was thrown but my machine became unusable and it took quite a while because it was using swap, so I thought that a memory estimate might by a good solution here?

Not sure if 1 GB is an appropriate limit though ...