### PR TITLE
Fix caching of TransformForest

### DIFF
--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -38,6 +38,8 @@ class TransformForest(object):
         translation: (3) array
         geometry : Geometry object name
         """
+        self._updated = time.time()
+
         if frame_from is None:
             frame_from = self.base_frame
         matrix = kwargs_to_matrix(**kwargs)
@@ -55,7 +57,6 @@ class TransformForest(object):
                 values={frame_to: kwargs['geometry']})
         if changed:
             self._paths = {}
-        self._updated = time.time()
 
     def md5(self):
         """
@@ -63,7 +64,7 @@ class TransformForest(object):
 
         Currently only hashing update time.
         """
-        result = str(int(self._updated * 1000)) + str(self.base_frame)
+        result = str(int(self._updated * 1e7)) + str(self.base_frame)
         return result
 
     def copy(self):
@@ -305,9 +306,9 @@ class TransformForest(object):
         return self.update(key, matrix=value)
 
     def clear(self):
+        self._updated = time.time()
         self.transforms = EnforcedForest()
         self._paths = {}
-        self._updated = time.time()
 
     def _get_path(self, frame_from, frame_to):
         """


### PR DESCRIPTION
## What is the problem?

Caching in `TransformForest` seems not so robust.

If we have below program and we run it several times, I got below output, which is unexpected.


**program**
```python
#!/usr/bin/env python

import numpy as np
import trimesh


scene = trimesh.Scene()
scene.add_geometry(trimesh.creation.axis(0.01))

scene.set_camera()
print('transform (old):\n', scene.camera.transform)
scene.camera.transform = np.eye(4)
print('transform (new):\n', scene.camera.transform)

scene.show()
```

**output**
```
% python spam.py
transform (old):
 [[1.         0.         0.         0.04514312]
 [0.         1.         0.         0.04509278]
 [0.         0.         1.         0.23255776]
 [0.         0.         0.         1.        ]]
transform (new):
 [[1. 0. 0. 0.]
 [0. 1. 0. 0.]
 [0. 0. 1. 0.]
 [0. 0. 0. 1.]]

% python spam.py
transform (old):
 [[1.         0.         0.         0.04514312]
 [0.         1.         0.         0.04509278]
 [0.         0.         1.         0.23255776]
 [0.         0.         0.         1.        ]]
transform (new):
 [[1.         0.         0.         0.04514312]
 [0.         1.         0.         0.04509278]
 [0.         0.         1.         0.23255776]
 [0.         0.         0.         1.        ]]

% python spam.py
transform (old):
 [[1.         0.         0.         0.04514312]
 [0.         1.         0.         0.04509278]
 [0.         0.         1.         0.23255776]
 [0.         0.         0.         1.        ]]
transform (new):
 [[1. 0. 0. 0.]
 [0. 1. 0. 0.]
 [0. 0. 1. 0.]
 [0. 0. 0. 1.]]

% python spam.py
transform (old):
 [[1.         0.         0.         0.04514312]
 [0.         1.         0.         0.04509278]
 [0.         0.         1.         0.23255776]
 [0.         0.         0.         1.        ]]
transform (new):
 [[1.         0.         0.         0.04514312]
 [0.         1.         0.         0.04509278]
 [0.         0.         1.         0.23255776]
 [0.         0.         0.         1.        ]]
```

The `transform (new)` must be always identity matrix (I expect) but it's not.
This problem is caused by the caching strategy in `trimesh.scene.transforms.TransformForest`, and this PR fixes it.
