### PR TITLE
Add color argument to trimesh.creation.icosphere for convenience

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -77,6 +77,11 @@ class CreationTest(g.unittest.TestCase):
                 sphere.vertices - sphere.center_mass, axis=1)
             assert g.np.allclose(radii, 1.0)
 
+        # test additional arguments
+        red_sphere = g.trimesh.creation.icosphere(color=(1., 0, 0))
+        expected = g.np.full((len(red_sphere.faces), 4), (255, 0, 0, 255))
+        g.np.testing.assert_allclose(red_sphere.visual.face_colors, expected)
+
     def test_camera_marker(self):
         """
         Create a marker including FOV for a camera object

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -544,7 +544,7 @@ def icosahedron():
     return mesh
 
 
-def icosphere(subdivisions=3, radius=1.0):
+def icosphere(subdivisions=3, radius=1.0, color=None):
     """
     Create an isophere centered at the origin.
 
@@ -556,6 +556,8 @@ def icosphere(subdivisions=3, radius=1.0):
       4 ** subdivisions, so you probably want to keep this under ~5
     radius : float
       Desired radius of sphere
+    color: (3,) float or uint8
+      Desired color of sphere
 
     Returns
     ---------
@@ -574,6 +576,8 @@ def icosphere(subdivisions=3, radius=1.0):
         ico = ico.subdivide()
         refine_spherical()
     ico._validate = True
+    if color is not None:
+        ico.visual.face_colors = color
     return ico
 
 


### PR DESCRIPTION
It seems hard to pass `**kwargs` to `Trimesh()` in `icosphere` like `creation.box`.