### PR TITLE
Fix transform (non identity) use in creation.camera_marker

### DIFF
--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -1016,13 +1016,13 @@ def camera_marker(camera,
     z = marker_height
 
     # combine the points into the vertices of an FOV visualization
-    points = transformations.transform_points(
+    points = np.array(
         [(0, 0, 0),
          (-x, -y, z),
          (x, -y, z),
          (x, y, z),
          (-x, y, z)],
-        matrix=camera_transform)
+        dtype=float)
 
     # create line segments for the FOV visualization
     # a segment from the origin to each bound of the FOV
@@ -1036,7 +1036,9 @@ def camera_marker(camera,
                           points[[1, 2,
                                   2, 3,
                                   3, 4,
-                                  4, 1]])).reshape((-1, 2, 3))
+                                  4, 1]]))
+    segments = transformations.transform_points(
+        segments, matrix=camera_transform).reshape((-1, 2, 3))
 
     # add a single Path3D object for all line segments
     meshes.append(load_path(segments))


### PR DESCRIPTION
## Before

![Screencast 2019-04-16 18:45:47](https://user-images.githubusercontent.com/4310419/56232277-4d41a300-6078-11e9-81f4-20c03fdcb596.gif)


## After

![Screencast 2019-04-16 18:45:18](https://user-images.githubusercontent.com/4310419/56232284-516dc080-6078-11e9-96cd-bd5b527d5020.gif)


## Code (includes internal)

```python
import numpy as np
import trimesh


cad_file = '/home/wkentaro/Documents/trimesh/models/fuze.obj'

eyes = uniform_points_on_sphere(5, radius=0.5)
targets = np.full(eyes.shape, (0, 0, 0), dtype=float)
T_world2cam = np.array([
    look_at(eye, target)
    for eye, target in zip(eyes, targets)
])

# -----------------------------------------------------------------------------

scene = trimesh.Scene()

geom = trimesh.load(str(cad_file))
geom.visual = geom.visual.to_color()
scene.add_geometry(geom)

scene.camera.resolution = (640, 480)
scene.camera.fov = (60, 45)

for transform in T_world2cam:
    scene.camera.transform = transform
    geom = trimesh.creation.camera_marker(scene.camera, marker_height=0.1)
    scene.add_geometry(geom)

    geom = trimesh.creation.axis(0.01)
    geom.apply_transform(transform)
    scene.add_geometry(geom)

scene.set_camera()

scene.show()
```