### PR TITLE
Remove index shift by +-0.5 in voxel.py

### DIFF
--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -102,30 +102,38 @@ class VoxelTest(g.unittest.TestCase):
                                                 fill=True)
 
     def test_points_to_from_indices(self):
-        points = [[0.05, 0.55, 0.35]]
+        # indices = (points - origin) / pitch
+        points = [[0, 0, 0], [0.04, 0.55, 0.39]]
         origin = [0, 0, 0]
         pitch = 0.1
-        indices = [[1, 6, 4]]
+        indices = [[0, 0, 0], [0, 6, 4]]
 
         # points -> indices
-        indices2 = g.trimesh.voxel.points_to_indices(
-            points=points, origin=origin, pitch=pitch
-        )
+        indices2 = g.trimesh.voxel.points_to_indices(points=points,
+                                                     origin=origin,
+                                                     pitch=pitch)
         g.np.testing.assert_allclose(indices, indices2, atol=0, rtol=0)
 
         # indices -> points
-        points2 = g.trimesh.voxel.indices_to_points(
-            indices=indices, origin=origin, pitch=pitch
-        )
-        g.np.testing.assert_allclose(points, points2)
+        points2 = g.trimesh.voxel.indices_to_points(indices=indices,
+                                                    origin=origin,
+                                                    pitch=pitch)
+        g.np.testing.assert_allclose(g.np.array(indices) * pitch + origin,
+                                     points2,
+                                     atol=0,
+                                     rtol=0)
+        g.np.testing.assert_allclose(points,
+                                     points2,
+                                     atol=pitch / 2 * 1.01,
+                                     rtol=0)
 
         # indices -> points -> indices (this must be consistent)
-        points2 = g.trimesh.voxel.indices_to_points(
-            indices=indices, origin=origin, pitch=pitch
-        )
-        indices2 = g.trimesh.voxel.points_to_indices(
-            points=points2, origin=origin, pitch=pitch
-        )
+        points2 = g.trimesh.voxel.indices_to_points(indices=indices,
+                                                    origin=origin,
+                                                    pitch=pitch)
+        indices2 = g.trimesh.voxel.points_to_indices(points=points2,
+                                                     origin=origin,
+                                                     pitch=pitch)
         g.np.testing.assert_allclose(indices, indices2, atol=0, rtol=0)
 
     def test_as_boxes(self):

--- a/trimesh/voxel.py
+++ b/trimesh/voxel.py
@@ -138,6 +138,22 @@ class VoxelBase(object):
 
 class Voxel(VoxelBase):
 
+    """
+    Voxel representation with matrix, pitch and origin.
+
+    All voxels are referenced by the center of their cell box, for example,
+    the ``origin`` exactly matches the center of the first voxel.
+
+    Parameters
+    ----------
+    matrix: (X, Y, Z)
+        Matrix that is interpreted as boolean to represent filled voxels.
+    pitch: float
+        Scale of each voxel.
+    origin: (3,) float
+        The center of the first voxel.
+    """
+
     def __init__(self, matrix, pitch, origin):
         super(Voxel, self).__init__()
 

--- a/trimesh/voxel.py
+++ b/trimesh/voxel.py
@@ -646,7 +646,7 @@ def points_to_indices(points, pitch, origin):
     if origin.shape != (3,):
         raise ValueError('shape of origin must be (3,)')
 
-    indices = np.round((points - origin) / pitch + 0.5).astype(int)
+    indices = np.round((points - origin) / pitch).astype(int)
     return indices
 
 
@@ -676,7 +676,7 @@ def indices_to_points(indices, pitch, origin):
     if origin.shape != (3,):
         raise ValueError('shape of origin must be (3,)')
 
-    points = (indices - 0.5) * pitch + origin
+    points = indices * pitch + origin
     return points
 
 


### PR DESCRIPTION
Close https://github.com/mikedh/trimesh/issues/370

**NOTE**: This is not backward compatible.