### PR TITLE
Remove NullHandler from logger since it filters messages

### DIFF
--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -8,7 +8,6 @@ _fcl_exists = True
 try:
     import fcl  # pip install python-fcl
 except BaseException:
-    log.warning('No FCL -- collision checking will not work')
     _fcl_exists = False
 
 

--- a/trimesh/constants.py
+++ b/trimesh/constants.py
@@ -1,8 +1,8 @@
 from time import time as time_function
-from logging import getLogger as _getLogger
-from logging import NullHandler as _NullHandler
 
 import numpy as np
+
+from .util import log
 
 
 class ToleranceMesh(object):
@@ -123,10 +123,6 @@ tol = ToleranceMesh()
 # instantiate path tolerances with defaults
 tol_path = TolerancePath()
 res_path = ResolutionPath()
-
-# logging
-log = _getLogger('trimesh')
-log.addHandler(_NullHandler())
 
 
 def log_time(method):

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -36,7 +36,6 @@ else:
 
 # create a default logger
 log = logging.getLogger('trimesh')
-log.addHandler(logging.NullHandler())
 
 # include constants here so we don't have to import
 # a floating point threshold for 0.0


### PR DESCRIPTION
Close https://github.com/mikedh/trimesh/issues/396

It filters every warnings and errors.

I'm not sure if how you decided adding NullHandler and if it is right answer removing it.