### PR TITLE
Protection

### DIFF
--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -110,6 +110,8 @@ def angles(triangles):
     # run the cosine and an einsum that definitely does something
     a = np.arccos(np.clip(np.einsum('ij, ij->i', u, v), -1, 1))
     b = np.arccos(np.clip(np.einsum('ij, ij->i', -u, w), -1, 1))
+    a=np.nan_to_num(a)
+    b=np.nan_to_num(b)
     c = np.pi - a - b
 
     return np.column_stack([a, b, c])


### PR DESCRIPTION
During smoothing if an element flips it raises an error and the angle becomes NAN 
Quite annoying and messes all operations with angles... but it would be important to raise an warning?