### PR TITLE
1 dimensional rgb for PointCloud colors

### DIFF
--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -537,7 +537,7 @@ class PointCloud(Geometry):
     @colors.setter
     def colors(self, data):
         data = np.asanyarray(data)
-        if data.shape == (4,):
+        if data.shape in [(3,), (4,)]:
             data = np.tile(data, (len(self.vertices), 1))
         self._data['colors'] = data
 


### PR DESCRIPTION
In addition to the 1 dimensional rgba like
```python
pcd = PointCloud(vertices=points_xyz)
pcd.colors = [1.0, 0, 0, 1.0]
pcd.colors = [1.0, 0, 0]  # this doesn't work without this PR
```