### PR TITLE
Delete modified vertex_list to avoid re-rendering

### DIFF
--- a/trimesh/viewer/widget.py
+++ b/trimesh/viewer/widget.py
@@ -260,6 +260,9 @@ class SceneWidget(glooey.Widget):
             self.mesh_group[node_name] = mesh_group
 
         if self.vertex_list_hash.get(geometry_name) != geometry_hash_new:
+            if geometry_name in self.vertex_list:
+                self.vertex_list[geometry_name].delete()
+
             # convert geometry to constructor args
             args = rendering.convert_to_vertexlist(geometry, group=mesh_group)
             # create the indexed vertex list


### PR DESCRIPTION
This is necessary because always `glooey` tries to render everything that has registered to the batch group before. (In `SceneViewer` it calls `vertex_list[geometry_name].draw()`)