### PR TITLE
Make visualization faster with updating the scene

### DIFF
--- a/trimesh/viewer/widget.py
+++ b/trimesh/viewer/widget.py
@@ -78,7 +78,7 @@ class SceneGroup(pyglet.graphics.Group):
         self._set_view()
 
         SceneViewer._gl_set_background(self._background)
-        SceneViewer._gl_enable_depth(self.scene)
+        SceneViewer._gl_enable_depth()
         SceneViewer._gl_enable_color_material()
         SceneViewer._gl_enable_blending()
         SceneViewer._gl_enable_smooth_lines()

--- a/trimesh/viewer/widget.py
+++ b/trimesh/viewer/widget.py
@@ -57,7 +57,7 @@ class SceneGroup(pyglet.graphics.Group):
         gl.glPushMatrix()
         gl.glLoadIdentity()
         near = 0.01
-        far = self.scene.scale * 5.0
+        far = 1000.
         gl.gluPerspective(self.scene.camera.fov[1], width / height, near, far)
         gl.glMatrixMode(gl.GL_MODELVIEW)
 

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -448,7 +448,7 @@ class SceneViewer(pyglet.window.Window):
         gl.gluPerspective(fovY,
                           width / float(height),
                           .01,
-                          self.scene.scale * 5.0)
+                          1000.)
         gl.glMatrixMode(gl.GL_MODELVIEW)
 
         return width, height

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -252,7 +252,7 @@ class SceneViewer(pyglet.window.Window):
                           exc_info=True)
 
         self._gl_set_background(background)
-        self._gl_enable_depth(self.scene)
+        self._gl_enable_depth()
         self._gl_enable_color_material()
         self._gl_enable_blending()
         self._gl_enable_smooth_lines()
@@ -267,12 +267,8 @@ class SceneViewer(pyglet.window.Window):
         gl.glClearColor(*[0, 0, 0, 0])
 
     @staticmethod
-    def _gl_enable_depth(scene):
-        # find the maximum depth based on
-        # maximum length of scene AABB
-        max_depth = (np.abs(scene.bounds).max(axis=1) ** 2).sum() ** .5
-        max_depth = np.clip(max_depth, 500.00, np.inf)
-        gl.glDepthRange(0.0, max_depth)
+    def _gl_enable_depth():
+        gl.glDepthRange(0.0, 1000.0)
 
         gl.glClearDepth(1.0)
         gl.glEnable(gl.GL_DEPTH_TEST)


### PR DESCRIPTION
If I update change scene frequently, `scene.centroid` computes bounding box of the scene every time, which makes the visualization very slow.
I suppose in most case setting fixed `far` is fine. If we need to simulate a depth camera, which has minimum and maximum range, we can add `far` as an argument to `__init__()`. However, currently this is not necessary since rendering depth is not supported in `SceneViewer` and `SceneWidget` with OpenGL.