### PR TITLE
[SEE #419] Set camera.scene = self in Scene.__init__()

### DIFF
--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -68,7 +68,10 @@ class Scene(Geometry):
             # if we've been passed a graph override the default
             self.graph = graph
 
-        self.camera = camera
+        if camera is not None:
+            self.camera = camera
+            self.camera.scene = self
+
         self.lights = lights
 
     def apply_transform(self, transform):


### PR DESCRIPTION
To avoid below error.
```
camera_SV5LGN world
Traceback (most recent call last):
  File "example.py", line 66, in <module>
    scene.show()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/scene.py", line 882, in show
    return SceneViewer(self, **kwargs)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/viewer/windowed.py", line 149, in __init__
    pyglet.app.run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/__init__.py", line 138, in run
    event_loop.run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/base.py", line 142, in run
    self._run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/base.py", line 154, in _run
    timeout = self.idle()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/base.py", line 281, in idle
    window.dispatch_event('on_draw')
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/window/__init__.py", line 1232, in dispatch_event
    if EventDispatcher.dispatch_event(self, *args) != False:
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/event.py", line 367, in dispatch_event
    if getattr(self, event_type)(*args):
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/viewer/windowed.py", line 546, in on_draw
    frame_from=self.scene.camera.name)[0]
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/transforms.py", line 281, in get
    path = self._get_path(frame_from, frame_to)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/transforms.py", line 364, in _get_path
    frame_from, frame_to)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/transforms.py", line 443, in shortest_path_undirected
    raise E
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/transforms.py", line 440, in shortest_path_undirected
    path = nx.shortest_path(self._undirected, u, v)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/networkx/algorithms/shortest_paths/generic.py", line 170, in shortest_path
    paths = nx.bidirectional_shortest_path(G, source, target)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/networkx/algorithms/shortest_paths/unweighted.py", line 223, in bidirectional_shortest_path
    raise nx.NodeNotFound(msg.format(source, target))
networkx.exception.NodeNotFound: Either source camera_SV5LGN or target world is not in G
```