### PR TITLE
Use transform from scene.camera

### DIFF
--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -541,9 +541,7 @@ class SceneViewer(pyglet.window.Window):
         gl.glLoadIdentity()
 
         # pull the new camera transform from the scene
-        transform_camera = self.scene.graph.get(
-            frame_to='world',
-            frame_from=self.scene.camera.name)[0]
+        transform_camera = np.linalg.inv(self.scene.camera.transform)
 
         # apply the camera transform to the matrix stack
         gl.glMultMatrixf(rendering.matrix_to_gl(transform_camera))


### PR DESCRIPTION
Another way to solve problem in #418 

I prefer this since different scenes can share same camera model.

```
camera_SV5LGN world
Traceback (most recent call last):
  File "example.py", line 66, in <module>
    scene.show()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/scene.py", line 882, in show
    return SceneViewer(self, **kwargs)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/viewer/windowed.py", line 149, in __init__
    pyglet.app.run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/__init__.py", line 138, in run
    event_loop.run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/base.py", line 142, in run
    self._run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/base.py", line 154, in _run
    timeout = self.idle()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/base.py", line 281, in idle
    window.dispatch_event('on_draw')
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/window/__init__.py", line 1232, in dispatch_event
    if EventDispatcher.dispatch_event(self, *args) != False:
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/event.py", line 367, in dispatch_event
    if getattr(self, event_type)(*args):
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/viewer/windowed.py", line 546, in on_draw
    frame_from=self.scene.camera.name)[0]
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/transforms.py", line 281, in get
    path = self._get_path(frame_from, frame_to)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/transforms.py", line 364, in _get_path
    frame_from, frame_to)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/transforms.py", line 443, in shortest_path_undirected
    raise E
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/trimesh/scene/transforms.py", line 440, in shortest_path_undirected
    path = nx.shortest_path(self._undirected, u, v)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/networkx/algorithms/shortest_paths/generic.py", line 170, in shortest_path
    paths = nx.bidirectional_shortest_path(G, source, target)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/networkx/algorithms/shortest_paths/unweighted.py", line 223, in bidirectional_shortest_path
    raise nx.NodeNotFound(msg.format(source, target))
networkx.exception.NodeNotFound: Either source camera_SV5LGN or target world is not in G
```