### PR TITLE
Fix the logic of boundary crossing

### DIFF
--- a/trimesh/viewer/widget.py
+++ b/trimesh/viewer/widget.py
@@ -227,8 +227,8 @@ class SceneWidget(glooey.Widget):
         y_prev = y - dy
         left, bottom = self.rect.left, self.rect.bottom
         width, height = self.rect.width, self.rect.height
-        if not (left <= x_prev <= left + width) or \
-                not (bottom <= y_prev <= bottom + height):
+        if not (left < x_prev <= left + width) or \
+                not (bottom < y_prev <= bottom + height):
             self.view['ball'].down(np.array([x, y]))
 
         SceneViewer.on_mouse_drag(self, x, y, dx, dy, buttons, modifiers)


### PR DESCRIPTION
To fix below:

```
Traceback (most recent call last):
  File "./insertPointCloud.py", line 125, in <module>
    main()
  File "./insertPointCloud.py", line 121, in main
    pyglet.app.run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/__init__.py", line 138, in run
    event_loop.run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/base.py", line 142, in run
    self._run()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/base.py", line 155, in _run
    platform_event_loop.step(timeout)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/app/xlib.py", line 125, in step
    device.select()
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/canvas/xlib.py", line 168, in select
    dispatch(e)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/window/xlib/__init__.py", line 922, in dispatch_platform_event_view
    event_handler(e)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/window/xlib/__init__.py", line 1155, in _event_motionnotify_view
    x, y, dx, dy, buttons, modifiers)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/window/__init__.py", line 1232, in dispatch_event
    if EventDispatcher.dispatch_event(self, *args) != False:
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/event.py", line 357, in dispatch_event
    if handler(*args):
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/glooey/widget.py", line 693, in on_mouse_drag
    child.dispatch_event('on_mouse_drag', x, y, dx, dy, buttons, modifiers)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/event.py", line 367, in dispatch_event
    if getattr(self, event_type)(*args):
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/glooey/widget.py", line 693, in on_mouse_drag
    child.dispatch_event('on_mouse_drag', x, y, dx, dy, buttons, modifiers)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/event.py", line 367, in dispatch_event
    if getattr(self, event_type)(*args):
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/glooey/widget.py", line 693, in on_mouse_drag
    child.dispatch_event('on_mouse_drag', x, y, dx, dy, buttons, modifiers)
  File "/home/wkentaro/Documents/octomap-python/.anaconda3/lib/python3.6/site-packages/pyglet/event.py", line 367, in dispatch_event
    if getattr(self, event_type)(*args):
  File "/home/wkentaro/Documents/octomap-python/src/trimesh/trimesh/viewer/widget.py", line 234, in on_mouse_drag
    SceneViewer.on_mouse_drag(self, x, y, dx, dy, buttons, modifiers)
  File "/home/wkentaro/Documents/octomap-python/src/trimesh/trimesh/viewer/windowed.py", line 486, in on_mouse_drag
    self.view['ball'].drag(np.array([x, y]))
  File "/home/wkentaro/Documents/octomap-python/src/trimesh/trimesh/viewer/trackball.py", line 124, in drag
    dx, dy = point - self._pdown
AttributeError: 'Trackball' object has no attribute '_pdown'
```