### PR TITLE
writeable/consistency changes

### DIFF
--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -44,6 +44,42 @@ class CameraTests(g.unittest.TestCase):
             fov=None)
         assert np.allclose(camera.fov, fov)
 
+    def test_focal_updates_on_resolution_change(self):
+        """Test changing resolution with set fov updates focal."""
+        base_res = (320, 240)
+        updated_res = (640, 480)
+        fov = (60, 40)
+        base_cam = g.trimesh.scene.Camera(
+            resolution=base_res,
+            fov=fov)
+        base_focal = base_cam.focal
+        base_cam.resolution = updated_res
+        assert base_cam.focal is not base_focal
+        new_cam = g.trimesh.scene.Camera(
+            resolution=updated_res,
+            fov=fov,
+        )
+        np.testing.assert_allclose(base_cam.focal, new_cam.focal)
+
+    def test_fov_updates_on_resolution_change(self):
+        """Test changing resolution with set focal updates fov."""
+        base_res = (320, 240)
+        updated_res = (640, 480)
+        focal = (100, 100)
+        base_cam = g.trimesh.scene.Camera(
+            resolution=base_res,
+            focal=focal)
+        base_fov = base_cam.fov
+        base_cam.resolution = updated_res
+        assert base_cam.fov is not base_fov
+        new_cam = g.trimesh.scene.Camera(
+            resolution=updated_res,
+            focal=focal,
+        )
+        np.testing.assert_allclose(base_cam.fov, new_cam.fov)
+
+
+
     def test_lookat(self):
         """
         Test the "look at points" function

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -78,8 +78,6 @@ class CameraTests(g.unittest.TestCase):
         )
         np.testing.assert_allclose(base_cam.fov, new_cam.fov)
 
-
-
     def test_lookat(self):
         """
         Test the "look at points" function

--- a/trimesh/scene/cameras.py
+++ b/trimesh/scene/cameras.py
@@ -196,7 +196,7 @@ class Camera(object):
         if self._focal is None:
             # calculate focal length from FOV
             focal = (
-              self._resolution / (2.0 * np.tan(np.radians(self._fov / 2.0))))
+                self._resolution / (2.0 * np.tan(np.radians(self._fov / 2.0))))
             focal.flags.writeable = False
             self._focal = focal
 

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -455,11 +455,14 @@ class Scene(Geometry):
             self.camera.fov = fov
             self.camera._scene = self
             self.camera.transform = transform
+            if resolution is not None:
+                self.camera.resolution = resolution
         else:
             # create a new camera object
             self.camera = cameras.Camera(fov=fov,
                                          scene=self,
-                                         transform=transform)
+                                         transform=transform,
+                                         resolution=resolution)
         return self.camera
 
     @property


### PR DESCRIPTION
Fixed a bug where implicitly calculated fov/focal camera values could become out of sync following an update to resolution. The implementation is a bit clunky, but at least I'm fairly confident it works.

Other smaller stuff:
* Fixed ignored `resolution` argument in `Scene.set_camera`
* Added `flags.writeable = False` to various camera properties. I'm assuming the performance penalty on this isn't too dear?
*  numpy-ized some small stuff (I'm guessing that's faster than non-numpy? Quite possibly not now that I think about it... happy to roll back)