### PR TITLE
add return_counts to unique_bincount, vertex face lookup

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -284,16 +284,22 @@ class UniqueTests(unittest.TestCase):
                 minlength = 10
 
             # try our unique bincount function
-            unique, inverse = g.trimesh.grouping.unique_bincount(
+            unique, inverse, counts = g.trimesh.grouping.unique_bincount(
                 values,
                 minlength=minlength,
-                return_inverse=True)
+                return_inverse=True,
+                return_counts=True)
             # make sure inverse is correct
             assert (unique[inverse] == values).all()
 
+            # make sure that the number of counts matches
+            # the number of unique values
+            assert (len(unique) == len(counts))
+
             # get the truth
-            truth_unique, truth_inverse = np.unique(values,
-                                                    return_inverse=True)
+            truth_unique, truth_inverse, truth_counts = np.unique(values,
+                                                                  return_inverse=True,
+                                                                  return_counts=True)
             # make sure truth is doing what we think
             assert (truth_unique[truth_inverse] == values).all()
 
@@ -302,6 +308,9 @@ class UniqueTests(unittest.TestCase):
 
             # make sure all values are identical
             assert set(truth_unique) == set(unique)
+
+            # make sure that the truth counts are identical to our counts
+            assert np.all(truth_counts == counts)
 
 
 if __name__ == '__main__':

--- a/tests/test_vertices.py
+++ b/tests/test_vertices.py
@@ -1,0 +1,42 @@
+try:
+    from . import generic as g
+except BaseException:
+    import generic as g
+
+
+class VerticesTest(g.unittest.TestCase):
+
+    def test_vertex_faces(self):
+
+        # One watertight, one not; also various sizes
+        meshes = [g.get_mesh('featuretype.STL'),
+                  g.get_mesh('cycloidal.ply')]
+
+        for m in meshes:
+            # Choose random face indices and make sure that their vertices
+            # contain those face indices
+            rand_faces = g.np.random.randint(low=0, high=len(m.faces), size=100)
+            for f in rand_faces:
+                v_inds = m.faces[f]
+                assert (f in m.vertex_faces[v_inds[0]])
+                assert (f in m.vertex_faces[v_inds[1]])
+                assert (f in m.vertex_faces[v_inds[2]])
+
+            # Choose some random vertices and make sure their face indices
+            # are correct
+            rand_vertices = g.np.random.randint(low=0, high=len(m.vertices), size=100)
+            for v in rand_vertices:
+                v_faces = g.np.flip(g.np.where(m.faces == v)[0], axis=0)
+                assert (g.np.all(v_faces == m.vertex_faces[v][m.vertex_faces[v] >= 0]))
+
+            # Intentionally cause fallback to looping over vertices and make sure we
+            # get the same result
+            loop_vertex_faces = g.trimesh.geometry.vertex_face_indices(len(m.vertices), 
+                                                                       m.faces, 
+                                                                       sparse=None)
+            assert (g.np.all(loop_vertex_faces == m.vertex_faces))
+
+
+if __name__ == '__main__':
+    g.trimesh.util.attach_to_log()
+    g.unittest.main()

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -458,6 +458,27 @@ class Trimesh(Geometry):
             sparse=self.faces_sparse)
         return vertex_normals
 
+    @caching.cache_decorator
+    def vertex_faces(self):
+        """
+        A representation of the face indices that correspond to each vertex.
+
+        Returns
+        ----------
+        vertex_faces : (n,m) int
+          Each row contains the face indices that correspond to the given vertex,
+          padded with -1 up to the max number of faces corresponding to any one vertex
+          Where n == len(self.vertices), m == max number of faces for a single vertex
+        """
+        # make sure we have faces_sparse
+        assert hasattr(self.faces_sparse, 'dot')
+        vertex_faces = geometry.vertex_face_indices(
+            vertex_count=len(self.vertices),
+            faces=self.faces,
+            sparse=self.faces_sparse
+        )
+        return vertex_faces
+
     @vertex_normals.setter
     def vertex_normals(self, values):
         """

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -265,8 +265,9 @@ def unique_ordered(data):
 
 
 def unique_bincount(values,
-                    minlength,
-                    return_inverse=True):
+                    minlength=0,
+                    return_inverse=False,
+                    return_counts=False):
     """
     For arrays of integers find unique values using bin counting.
     Roughly 10x faster for correct input than np.unique
@@ -279,14 +280,19 @@ def unique_bincount(values,
       Maximum value that will occur in values (values.max())
     return_inverse : bool
       If True, return an inverse such that unique[inverse] == values
+    return_counts : bool
+      If True, also return the number of times each unique item appears in values
 
     Returns
     ------------
     unique : (m,) int
       Unique values in original array
-    inverse : (n,) int
+    inverse : (n,) int, optional
       An array such that unique[inverse] == values
       Only returned if return_inverse is True
+    counts : (m,) int, optional
+      An array holding the counts of each unique item in values
+      Only returned if return_counts is True
     """
     values = np.asanyarray(values)
     if len(values.shape) != 1 or values.dtype.kind != 'i':
@@ -299,7 +305,9 @@ def unique_bincount(values,
         # casting failed on 32 bit windows
         log.error('casting failed!', exc_info=True)
         # fall back to numpy unique
-        return np.unique(values, return_inverse=return_inverse)
+        return np.unique(values,
+                         return_inverse=return_inverse,
+                         return_counts=return_counts)
 
     # which bins are occupied at all
     # counts are integers so this works
@@ -308,13 +316,20 @@ def unique_bincount(values,
     # which values are unique
     # indexes correspond to original values
     unique = np.where(unique_bin)[0]
+    ret = (unique,)
 
     if return_inverse:
         # find the inverse to reconstruct original
         inverse = (np.cumsum(unique_bin) - 1)[values]
-        return unique, inverse
+        ret += (inverse,)
 
-    return unique
+    if return_counts:
+        unique_counts = counts[unique]
+        ret += (unique_counts,)
+
+    if len(ret) == 1:
+        return ret[0]
+    return ret
 
 
 def merge_runs(data, digits=None):


### PR DESCRIPTION
Makes this function more like np.unique. Plus the counts are already calculated as part of bincount.
Vertex face lookup addresses #232 using the faces_sparse array. Also falls back to a loop if sparse matrix is not available.