### PR TITLE
Small BRLE tweaks and VoxelGrid updates for breaking changes

### DIFF
--- a/examples/voxel.py
+++ b/examples/voxel.py
@@ -27,15 +27,15 @@ def show(chair_mesh, chair_voxels, colors=(1, 1, 1, 0.3)):
 
 base_name = 'chair_model'
 chair_mesh = trimesh.load(os.path.join(dir_models, '%s.obj' % base_name))
-if isinstance(chair_mesh, (list, tuple)):
+if isinstance(chair_mesh, trimesh.scene.Scene):
     chair_mesh = trimesh.util.concatenate([
-        trimesh.Trimesh(mesh.vertices, mesh.faces) for mesh in chair_mesh])
+        trimesh.Trimesh(mesh.vertices, mesh.faces)
+        for mesh in chair_mesh.geometry.values()])
 
 binvox_path = os.path.join(dir_models, '%s.binvox' % base_name)
 chair_voxels = trimesh.load(binvox_path)
 
-chair_voxels = v.VoxelGrid(
-    chair_voxels.encoding.dense, chair_voxels.transform_matrix)
+chair_voxels = v.VoxelGrid(chair_voxels.encoding.dense, chair_voxels.transform)
 
 print('white: voxelized chair (binvox, exact)')
 show(
@@ -57,7 +57,7 @@ show(chair_mesh, revox, colors=(0, 1, 1, 0.3))
 
 values = chair_voxels.encoding.dense.copy()
 values[:values.shape[0] // 2] = 0
-stripped = v.VoxelGrid(values, chair_voxels.transform_matrix.copy()).strip()
+stripped = v.VoxelGrid(values, chair_voxels.transform.copy()).strip()
 print('yellow: stripped halved voxel grid. Transform is updated appropriately')
 show(chair_mesh, stripped, colors=(1, 1, 0, 0.3))
 

--- a/tests/test_binvox.py
+++ b/tests/test_binvox.py
@@ -22,7 +22,7 @@ class BinvoxTest(g.unittest.TestCase):
         base = binvox.voxel_from_binvox(
             rl_data, shape, translate, scale, axis_order='xzy')
         s = scale / (n - 1)
-        np.testing.assert_equal(base.transform_matrix, np.array([
+        np.testing.assert_equal(base.transform, np.array([
             [s, 0, 0, 2],
             [0, s, 0, 5],
             [0, 0, s, 10],
@@ -43,8 +43,7 @@ class BinvoxTest(g.unittest.TestCase):
         np.testing.assert_equal(loaded.encoding.dense, base.encoding.dense)
         self.assertTrue(isinstance(base, v.VoxelGrid))
         self.assertTrue(isinstance(loaded, v.VoxelGrid))
-        np.testing.assert_equal(
-            base.transform_matrix, loaded.transform_matrix)
+        np.testing.assert_equal(base.transform, loaded.transform)
         np.testing.assert_equal(base.shape, loaded.shape)
 
 

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -147,6 +147,15 @@ class TrackedArray(np.ndarray):
             obj._modified_c = True
             obj._modified_m = True
             obj._modified_x = True
+    
+    @property
+    def mutable(self):
+        return self.flags['WRITEABLE']
+
+    @mutable.setter
+    def mutable(self, value):
+        # self.flags['WRITEABLE'] = value
+        self.flags.writeable = value
 
     def md5(self):
         """
@@ -525,8 +534,9 @@ class DataStore(collections.Mapping):
         is_mutable = bool(value)
         # apply the flag to any data stored
         for n, i in self.data.items():
-            i.flags['WRITEABLE'] = is_mutable
-            print(n, i.flags['WRITEABLE'])
+            i.mutable = value
+            # i.flags['WRITEABLE'] = is_mutable
+            # print(n, i.flags['WRITEABLE'])
         # save the mutable setting
         self._mutable = is_mutable
 
@@ -573,7 +583,7 @@ class DataStore(collections.Mapping):
             # otherwise wrap data
             tracked = tracked_array(data)
         # apply our mutability setting
-        tracked.flags['WRITEABLE'] = self.mutable
+        tracked.mutable = self.mutable
         self.data[key] = tracked
 
     def __contains__(self, key):

--- a/trimesh/exchange/binvox.py
+++ b/trimesh/exchange/binvox.py
@@ -12,6 +12,7 @@ import collections
 from distutils.spawn import find_executable
 
 from .. import util
+from ..base import Trimesh
 
 # find the executable
 binvox_encoder = find_executable('binvox')
@@ -499,6 +500,8 @@ def voxelize_mesh(mesh, binvoxer=None, export_type='off', **binvoxer_kwargs):
     ------------
     `VoxelGrid` object resulting.
     """
+    if not isinstance(mesh, Trimesh):
+        raise ValueError('mesh must be Trimesh instace, got %s' % str(mesh))
     if binvoxer is None:
         binvoxer = Binvoxer(**binvoxer_kwargs)
     elif len(binvoxer_kwargs) > 0:

--- a/trimesh/exchange/binvox.py
+++ b/trimesh/exchange/binvox.py
@@ -54,7 +54,7 @@ def parse_binvox_header(fp):
     return shape, translate, scale
 
 
-def parse_binvox(fp):
+def parse_binvox(fp, writeable=False):
     """Read a binvox file.
 
     Spec at https://www.patrickmin.com/binvox/binvox.html
@@ -73,7 +73,10 @@ def parse_binvox(fp):
     data = fp.read()
     if hasattr(data, 'encode'):
         data = data.encode()
-    rle_data = np.frombuffer(data, dtype=np.uint8)
+    if writeable:
+        rle_data = np.fromstring(data, dtype=np.uint8)
+    else:
+        rle_data = np.frombuffer(data, dtype=np.uint8)
     return Binvox(rle_data, shape, translate, scale)
 
 
@@ -181,7 +184,7 @@ def voxel_from_binvox(
 
 
 def load_binvox(
-        file_obj, resolver=None, axis_order='xzy', file_type=None, **kwargs):
+        file_obj, resolver=None, axis_order='xzy', file_type=None):
     """Load trimesh `VoxelGrid` instance from file.
 
     Parameters
@@ -190,7 +193,6 @@ def load_binvox(
     resolve: unused
     axis_order: order of axes in encoded data. binvox default is
         'xzy', but 'xyz' may be faster results where this is not relevant.
-    **kwargs: unused
 
     Returns
     ---------
@@ -199,7 +201,7 @@ def load_binvox(
     if file_type is not None and file_type != 'binvox':
         raise ValueError(
             'file_type must be None or binvox, got %s' % file_type)
-    data = parse_binvox(file_obj)
+    data = parse_binvox(file_obj, writeable=True)
     return voxel_from_binvox(
         rle_data=data.rle_data,
         shape=data.shape,

--- a/trimesh/exchange/binvox.py
+++ b/trimesh/exchange/binvox.py
@@ -73,10 +73,9 @@ def parse_binvox(fp, writeable=False):
     data = fp.read()
     if hasattr(data, 'encode'):
         data = data.encode()
+    rle_data = np.frombuffer(data, dtype=np.uint8)
     if writeable:
-        rle_data = np.fromstring(data, dtype=np.uint8)
-    else:
-        rle_data = np.frombuffer(data, dtype=np.uint8)
+        rle_data = rle_data.copy()
     return Binvox(rle_data, shape, translate, scale)
 
 

--- a/trimesh/voxel/encoding.py
+++ b/trimesh/voxel/encoding.py
@@ -325,11 +325,11 @@ class SparseEncoding(Encoding):
         return np.column_stack(np.unravel_index(flat_indices, self.shape))
 
     def gather_nd(self, indices):
-        indices = self._flat_indices(indices)
-        out = np.empty(shape=(indices.shape[0], 1), dtype=self.dtype)
-        self._csc[indices].todense(out=out)
-        return out.squeeze(axis=-1)
-
+        mat = self._csc[self._flat_indices(indices)].todense()
+        # mat is a np matrix, which stays rank 2 after squeeze
+        # np.asarray changes this to a standard rank 2 array.
+        return np.asarray(mat).squeeze(axis=-1)
+        
     def mask(self, mask):
         i, _ = np.where(self._csc[mask.reshape((-1,))])
         return self._shaped_indices(i)
@@ -571,7 +571,7 @@ class BinaryRunLengthEncoding(RunLengthEncoding):
         return rl.brle_to_dense(self._data)
 
     def gather(self, indices):
-        return rl.brle_gather_1d(self._data, indices, dtype=bool)
+        return rl.brle_gather_1d(self._data, indices)
 
     def gather_nd(self, indices):
         indices = np.squeeze(indices)

--- a/trimesh/voxel/encoding.py
+++ b/trimesh/voxel/encoding.py
@@ -145,7 +145,14 @@ class Encoding(ABC):
 
     def _transpose(self, perm):
         return TransposedEncoding(self, perm)
-
+    
+    @property
+    def mutable(self):
+        return self._data.mutable
+    
+    @mutable.setter
+    def mutable(self, value):
+        self._data.mutable = value
 
 class DenseEncoding(Encoding):
     """Simple `Encoding` implementation based on a numpy ndarray."""


### PR DESCRIPTION
* Initial BRLE required even number of values. This constraint was removed, but functions still did unnecessary padding. I've removed this padding.
* A small bug fix with BRLE gathering
* Fixed runlength documentation
* changed mutability setter to set `mutable` property of values, rather than set `flags['WRITABLE']` and added `mutable` setter to `TrackedArray`. Could alternatively add `flags` implementation to `encodings` - just thought the former was simpler. Happy to be convinced.
* fixed writeability issues with loading from binvox. This involves a change from `np.frombuffer` to `np.fromstring` in which may be __slightly__ slower. I don't think it will be massive, but we could tweak mutable setter to make a data copy only when set to True.
* fixed VoxelGrid tests/examples (`transform_matrix` -> `transform`)

Didn't realize you were working on caching stuff just now - hope my changes aren't getting in the way. 