### PR TITLE
Fixed camera_to_rays implementation, slightly modified interface

### DIFF
--- a/examples/raytrace.py
+++ b/examples/raytrace.py
@@ -33,7 +33,6 @@ if __name__ == '__main__':
     # origin = origins[0]
     origin, vectors = scene.camera.to_rays(scene.camera_transform)
 
-    vectors *= -1  # I'm not sure why this is needed...
     origins = np.tile(np.expand_dims(origin, 0), (len(vectors), 1))
 
     # do the actual ray- mesh queries

--- a/examples/raytrace.py
+++ b/examples/raytrace.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
                              scene.camera.resolution.max())
 
     # convert the camera to rays with one ray per pixel
-    origin, vectors = scene.camera.to_rays(scene.camera_transform)
+    origin, vectors = scene.camera_rays()
 
     # intersects_location requires origins to be the same shape as vectors
     origins = np.tile(np.expand_dims(origin, 0), (len(vectors), 1))

--- a/examples/raytrace.py
+++ b/examples/raytrace.py
@@ -29,7 +29,9 @@ if __name__ == '__main__':
                              scene.camera.resolution.max())
 
     # convert the camera to rays with one ray per pixel
-    origins, vectors, angles = scene.camera.to_rays(scene.camera_transform)
+    origin, vectors = scene.camera.to_rays(scene.camera_transform)
+    origins = np.tile(np.expand_dims(origin, 0), (len(vectors), 1))
+    angles = scene.camera.angles()
 
     # do the actual ray- mesh queries
     points, index_ray, index_tri = mesh.ray.intersects_location(
@@ -37,7 +39,7 @@ if __name__ == '__main__':
 
     # for each hit, find the distance along its vector
     # you could also do this against the single camera Z vector
-    depth = trimesh.util.diagonal_dot(points - origins[0],
+    depth = trimesh.util.diagonal_dot(points - origin,
                                       vectors[index_ray])
 
     # find the angular resolution, in pixels per radian

--- a/examples/raytrace.py
+++ b/examples/raytrace.py
@@ -7,6 +7,8 @@ rays for image reasons.
 
 Install `pyembree` for a speedup (600k+ rays per second)
 """
+from __future__ import division
+
 import PIL.Image
 
 import trimesh
@@ -29,10 +31,9 @@ if __name__ == '__main__':
                              scene.camera.resolution.max())
 
     # convert the camera to rays with one ray per pixel
-    # origins, vectors, angles = scene.camera.to_rays(scene.camera_transform)
-    # origin = origins[0]
     origin, vectors = scene.camera.to_rays(scene.camera_transform)
 
+    # intersects_location requires origins to be the same shape as vectors
     origins = np.tile(np.expand_dims(origin, 0), (len(vectors), 1))
 
     # do the actual ray- mesh queries

--- a/examples/raytrace.py
+++ b/examples/raytrace.py
@@ -29,9 +29,12 @@ if __name__ == '__main__':
                              scene.camera.resolution.max())
 
     # convert the camera to rays with one ray per pixel
+    # origins, vectors, angles = scene.camera.to_rays(scene.camera_transform)
+    # origin = origins[0]
     origin, vectors = scene.camera.to_rays(scene.camera_transform)
+
+    vectors *= -1  # I'm not sure why this is needed...
     origins = np.tile(np.expand_dims(origin, 0), (len(vectors), 1))
-    angles = scene.camera.angles()
 
     # do the actual ray- mesh queries
     points, index_ray, index_tri = mesh.ray.intersects_location(
@@ -45,6 +48,7 @@ if __name__ == '__main__':
     # find the angular resolution, in pixels per radian
     ppr = scene.camera.resolution / np.radians(scene.camera.fov)
     # convert rays to pixel locations
+    angles = scene.camera.angles()
     pixel = (angles * ppr).round().astype(np.int64)
     # make sure we are in the first quadrant
     pixel -= pixel.min(axis=0)

--- a/examples/voxel_silhouette.py
+++ b/examples/voxel_silhouette.py
@@ -1,0 +1,57 @@
+import os
+import trimesh
+import numpy as np
+from PIL import Image
+
+from trimesh.geometry import align_vectors
+from trimesh import util
+from trimesh import transformations
+
+
+resolution = 256
+fov = 60.
+path = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), '..', 'models', 'bunny.ply'))
+
+mesh = trimesh.load(path)
+scene = mesh.scene()
+camera = scene.camera
+
+camera.fov = (fov,) * 2
+camera.resolution = (resolution,) * 2
+origin, rays = camera.to_rays(scene.camera_transform)
+rays = rays.reshape((resolution, resolution, 3))
+offset = mesh.vertices - origin
+
+# dists is vertices projected onto central ray
+dists = np.dot(offset, rays[rays.shape[0] // 2, rays.shape[1] // 2])
+closest = np.min(dists)
+farthest = np.max(dists)
+z = np.linspace(closest, farthest, resolution)
+
+vox = mesh.voxelized(1./resolution, method='binvox')
+
+coords = np.expand_dims(rays, axis=-2) * np.expand_dims(z, axis=-1)
+coords += origin
+frust_vox_dense = vox.is_filled(coords)
+sil = np.any(frust_vox_dense, axis=-1)
+sil = sil.T  # change to image ordering (y, x)
+
+image = np.array(Image.open(trimesh.util.wrap_as_stream(
+    scene.save_image(resolution=None))))
+image = image[..., :3]
+
+
+def vis():
+    # separate function to delay plt import
+    import matplotlib.pyplot as plt
+    _, (ax0, ax1, ax2) = plt.subplots(1, 3)
+    ax0.imshow(image)
+    ax1.imshow(sil)
+    sil_image = image.copy()
+    sil_image[np.logical_not(sil)] = 0
+    ax2.imshow(sil_image)
+    plt.show()
+
+
+vis()

--- a/examples/voxel_silhouette.py
+++ b/examples/voxel_silhouette.py
@@ -21,7 +21,6 @@ camera.fov = (fov,) * 2
 camera.resolution = (resolution,) * 2
 origin, rays = camera.to_rays(scene.camera_transform)
 rays = rays.reshape((resolution, resolution, 3))
-rays = rays[:, -1::-1]  # not sure why this is necessary...
 offset = mesh.vertices - origin
 
 # dists is vertices projected onto central ray

--- a/examples/voxel_silhouette.py
+++ b/examples/voxel_silhouette.py
@@ -19,7 +19,7 @@ camera = scene.camera
 
 camera.fov = (fov,) * 2
 camera.resolution = (resolution,) * 2
-origin, rays = camera.to_rays(scene.camera_transform)
+origin, rays = scene.camera_rays()
 rays = rays.reshape((resolution, resolution, 3))
 offset = mesh.vertices - origin
 

--- a/examples/voxel_silhouette.py
+++ b/examples/voxel_silhouette.py
@@ -3,10 +3,6 @@ import trimesh
 import numpy as np
 from PIL import Image
 
-from trimesh.geometry import align_vectors
-from trimesh import util
-from trimesh import transformations
-
 
 resolution = 256
 fov = 60.
@@ -30,7 +26,7 @@ farthest = np.max(dists)
 z = np.linspace(closest, farthest, resolution)
 print('z range: %f, %f' % (closest, farthest))
 
-vox = mesh.voxelized(1./resolution, method='binvox')
+vox = mesh.voxelized(1. / resolution, method='binvox')
 
 coords = np.expand_dims(rays, axis=-2) * np.expand_dims(z, axis=-1)
 coords += origin

--- a/examples/voxel_silhouette.py
+++ b/examples/voxel_silhouette.py
@@ -21,6 +21,7 @@ camera.fov = (fov,) * 2
 camera.resolution = (resolution,) * 2
 origin, rays = camera.to_rays(scene.camera_transform)
 rays = rays.reshape((resolution, resolution, 3))
+rays = rays[:, -1::-1]  # not sure why this is necessary...
 offset = mesh.vertices - origin
 
 # dists is vertices projected onto central ray
@@ -28,6 +29,7 @@ dists = np.dot(offset, rays[rays.shape[0] // 2, rays.shape[1] // 2])
 closest = np.min(dists)
 farthest = np.max(dists)
 z = np.linspace(closest, farthest, resolution)
+print('z range: %f, %f' % (closest, farthest))
 
 vox = mesh.voxelized(1./resolution, method='binvox')
 

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -222,7 +222,9 @@ class RayMeshIntersector(object):
         index_ray = np.hstack(result_ray_idx)
 
         if return_locations:
-            locations = np.array(result_locations)
+            locations = (
+                np.zeros((0, 3), float) if len(result_locations) == 0
+                else np.array(result_locations))
 
             return index_tri, index_ray, locations
         return index_tri, index_ray

--- a/trimesh/scene/cameras.py
+++ b/trimesh/scene/cameras.py
@@ -256,7 +256,7 @@ class Camera(object):
         angles : (n, 2) float
           Ray spherical coordinate angles in radians.
         """
-        return np.arctan(_ray_pixel_coords(self))
+        return np.arctan(-_ray_pixel_coords(self))
         
 
 
@@ -319,12 +319,7 @@ def look_at(points, fov, rotation=None, distance=None, center=None):
 
 
 def _ray_pixel_coords(camera):
-    # radians of half the field of view
-    half = np.radians(camera.fov / 2.0)
-    # scale it down by two pixels to keep image under resolution
-    # half *= (camera.resolution - 2) / camera.resolution
-
-    bottom_right = np.tan(half)
+    bottom_right = np.tan(np.radians(camera.fov / 2.0))
     # move half a pixel width in
     ## pixel_size = (bottom_right - top_left) / camera.resolution
     # pixel_size = bottom_right*2 / camera.resolution

--- a/trimesh/scene/cameras.py
+++ b/trimesh/scene/cameras.py
@@ -3,9 +3,6 @@ import copy
 import numpy as np
 
 from .. import util
-from .. import transformations
-
-from ..geometry import align_vectors
 
 
 class Camera(object):
@@ -252,7 +249,6 @@ class Camera(object):
         return np.arctan(-ray_pixel_coords(self))
 
 
-
 def look_at(points, fov, rotation=None, distance=None, center=None):
     """
     Generate transform for a camera to keep a list
@@ -381,6 +377,5 @@ def camera_to_rays(camera):
       Ray direction vectors in camera frame with z == -1
     """
     xy = ray_pixel_coords(camera)
-    # vectors = util.unitize(np.column_stack((xy, np.ones_like(xy[:, :1]))))
     vectors = np.column_stack((xy, -np.ones_like(xy[:, :1])))
     return vectors

--- a/trimesh/scene/cameras.py
+++ b/trimesh/scene/cameras.py
@@ -329,7 +329,9 @@ def _ray_pixel_coords(camera):
     top_left = -bottom_right
 
     xy = util.grid_linspace(
-        bounds=[top_left, bottom_right], count=camera.resolution)
+        bounds=[top_left, bottom_right],
+        # bounds=[bottom_right, top_left],
+        count=camera.resolution)
     return xy
 
 
@@ -356,12 +358,7 @@ def camera_to_rays(camera, transform):
     xy = _ray_pixel_coords(camera)
     # vectors = util.unitize(np.column_stack((xy, np.ones_like(xy[:, :1]))))
     vectors = np.column_stack((xy, -np.ones_like(xy[:, :1])))
-
-    # flip the camera transform to change sign of Z
-    transform = np.dot(
-        transform,
-        align_vectors([1, 0, 0], [-1, 0, 0]))
-
+  
     # apply the rotation to the direction vectors
     vectors = transformations.transform_points(
         vectors,

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -485,6 +485,32 @@ class Scene(Geometry):
         """
         return self.graph[self.camera.name][0]
 
+    def camera_rays(self):
+        """
+        Calculate the trimesh.scene.Camera origin and ray direction vectors.
+
+        Will return one ray per pixel, as set in camera.resolution.
+
+        Returns
+        --------------
+        origins: (3,) float
+            Ray origins in space
+        vectors: (n, 3)
+            Ray direction unit vectors in world coordinates
+        """
+        vectors = self.camera.to_rays()
+        transform = self.camera_transform
+
+        # apply the rotation to the direction vectors
+        vectors = transformations.transform_points(
+            vectors,
+            transform,
+            translate=False)
+
+        # camera origin is single point, extract from transform
+        origin = transformations.translation_from_matrix(transform)
+        return origin, vectors
+
     @camera_transform.setter
     def camera_transform(self, camera_transform):
         """


### PR DESCRIPTION
Resolved [this issue](https://github.com/mikedh/trimesh/issues/486). In addition, made the following interface changes to `camera_to_rays` (and `Camera.to_rays`):

* `angles` is no longer an intermediate value, so is not calculated/returned.
* `origin` is no longer tiled to match `vectors`' shape.
* `vectors` in not longer `unitize`d. This means rays point to the image plane rather than lying on a sphere. This makes it easier to make frustums with `z_near` and `z_far` values. They can always be unitized afterwards by the caller.

These interface changes can be accepted/rejected independently - just thought I'd throw them all in the same PR for convenience, but happy to change them back.

~~I've had to introduce a slight [hack](https://github.com/jackd/trimesh/blob/release/major/examples/raytrace.py#L36) to get the raytrace example working. I have no idea why this is necessary... if that makes sense/can be justified by changes elsewhere feel free to fix things up, otherwise I'll look into it when I get a chance.~~

There's a slight hack [here](https://github.com/jackd/trimesh/blob/release/major/examples/voxel_silhouette.py#L24) to make things work. Feels a bit dirty - I'm just reordering the rays so the output silhouette matches the image - but I'm not sure why it's necessary...