### PR TITLE
added support for materials with names with spaces

### DIFF
--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -429,7 +429,7 @@ def parse_mtl(mtl, resolver=None):
                 materials[material.pop('newmtl')] = material
 
             # start a fresh new material
-            material = {'newmtl': ' '.joint(split[1:])}
+            material = {'newmtl': ' '.join(split[1:])}
 
         elif key == 'map_Kd':
             # represents the file name of the texture image

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -429,7 +429,7 @@ def parse_mtl(mtl, resolver=None):
                 materials[material.pop('newmtl')] = material
 
             # start a fresh new material
-            material = {'newmtl': split[1]}
+            material = {'newmtl': ' '.joint(split[1:])}
 
         elif key == 'map_Kd':
             # represents the file name of the texture image


### PR DESCRIPTION
Partially resolves [this issue](https://github.com/mikedh/trimesh/issues/475). Not sure if spaces in newmtl names are officially part of the spec, but it is supported by meshlab and it doesn't add much.