### PR TITLE
Vox tweak

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -2,8 +2,8 @@ try:
     from . import generic as g
 except BaseException:
     import generic as g
-from trimesh.voxel import encoding as enc
-from trimesh.voxel import runlength as rl
+enc = g.trimesh.voxel.encoding
+rl = g.trimesh.voxel.runlength
 np = g.np
 
 shape = (10, 10, 10)
@@ -173,6 +173,29 @@ class EncodingTest(g.unittest.TestCase):
             stripped.sparse_indices, expected_sparse_indices)
         np.testing.assert_equal(
             calculated_padding, 2 * np.ones((3, 2), dtype=int))
+
+    def test_empty_stripped(self):
+        res = 10
+        encoding = enc.DenseEncoding(np.zeros((res,) * 3, dtype=bool))
+        stripped, calculated_padding = encoding.stripped
+        self.assertEqual(stripped.size, 0)
+        np.testing.assert_equal(
+            calculated_padding, [[0, res], [0, res], [0, res]])
+
+    def test_is_empty(self):
+        res = 10
+        empty = np.zeros((res,), dtype=bool)
+        not_empty = np.zeros((res,), dtype=bool)
+        not_empty[[1, 2, 5, 6, 7]] = True
+        self.assertTrue(enc.DenseEncoding(empty).is_empty)
+        self.assertFalse(enc.DenseEncoding(not_empty).is_empty)
+
+        for cls in (
+                enc.SparseEncoding,
+                enc.RunLengthEncoding,
+                enc.BinaryRunLengthEncoding):
+            self.assertTrue(cls.from_dense(empty).is_empty)
+            self.assertFalse(cls.from_dense(not_empty).is_empty)
 
 
 if __name__ == '__main__':

--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -353,6 +353,18 @@ class VoxelGridTest(g.unittest.TestCase):
         np.testing.assert_allclose(octant.points, stripped.points)
         self.assertGreater(octant.encoding.size, stripped.encoding.size)
 
+    def test_binvox_with_dimension(self):
+        if not g.has_binvox:
+            g.log.warning('no binvox to test!')
+            return
+
+        dim = 10
+        octant = Sphere().voxelized(pitch=None,
+                                    dimension=dim,
+                                    method='binvox',
+                                    exact=True)
+        self.assertEqual(octant.shape, (dim,)*3)
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -363,7 +363,7 @@ class VoxelGridTest(g.unittest.TestCase):
                                     dimension=dim,
                                     method='binvox',
                                     exact=True)
-        self.assertEqual(octant.shape, (dim,)*3)
+        self.assertEqual(octant.shape, (dim,) * 3)
 
 
 if __name__ == '__main__':

--- a/trimesh/voxel/runlength.py
+++ b/trimesh/voxel/runlength.py
@@ -415,7 +415,7 @@ def rle_mask(rle_data, mask):
             count = next(data_iter)
         except StopIteration:
             break
-        for c in range(count):
+        for _ in range(count):
             m = next(mask_iter)
             if m:
                 yield value


### PR DESCRIPTION
Stripping empty encodings was causing issues, and `Encoding.is_empty` implementations - though unused - were incorrect (though not used elsewhere). Sorry these made it this far.

voxelize_binvox change is less important, but it's a more direct way of doing things if you know the output size rather than the pitch.