### PR TITLE
Support subdividing attributes.

### DIFF
--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -57,7 +57,7 @@ def load_obj(file_obj,
     # Load Materials
     materials = {}
     mtl_position = text.find('mtllib')
-    if mtl_position >= 0:
+    if mtl_position >= 0 and not kwargs.get('ignore_mtl', False):
         # take the line of the material file after `mtllib`
         # which should be the file location of the .mtl file
         mtl_path = text[mtl_position + 6:text.find('\n', mtl_position)].strip()

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -217,9 +217,10 @@ def load_obj(file_obj,
             visual = TextureVisuals(
                 uv=uv, material=materials[material])
         elif material is not None:
-            # material will be None by default
-            log.warning('specified material ({})  not loaded!'.format(
-                material))
+            if not kwargs.get('ignore_mtl', False):
+                # material will be None by default
+                log.warning('specified material ({})  not loaded!'.format(
+                    material))
             if kwargs.get('default_material', None) is not None:
                 visual = TextureVisuals(uv=uv, material=kwargs.get('default_material'))
         mesh['visual'] = visual

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -220,6 +220,8 @@ def load_obj(file_obj,
             # material will be None by default
             log.warning('specified material ({})  not loaded!'.format(
                 material))
+            if kwargs.get('default_material', None) is not None:
+                visual = TextureVisuals(uv=uv, material=kwargs.get('default_material'))
         mesh['visual'] = visual
 
         # store geometry by name

--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -13,7 +13,8 @@ from . import grouping
 
 def subdivide(vertices,
               faces,
-              face_index=None):
+              face_index=None,
+              attributes=None):
     """
     Subdivide a mesh into smaller triangles.
 
@@ -81,7 +82,20 @@ def subdivide(vertices,
 
     new_vertices = np.vstack((vertices, mid))
 
-    return new_vertices, new_faces
+    if attributes is not None:
+        new_attributes = {}
+        for name, attribute in attributes.items():
+            attr_tris = attribute[faces]
+            attr_mid = np.vstack([attr_tris[:, g, :].mean(axis=1)
+                                  for g in [[0, 1],
+                                            [1, 2],
+                                            [2, 0]]])
+            attr_mid = attr_mid[unique]
+            new_attributes[name] = np.vstack((attribute, attr_mid))
+
+        return new_vertices, new_faces, new_attributes
+    else:
+        return new_vertices, new_faces
 
 
 def subdivide_to_size(vertices,


### PR DESCRIPTION
Adds support for subdividing other attributes such as uvs.

e.g.,

```python
def subdivide_mesh(mesh):
    attributes = {}
    if hasattr(mesh.visual, 'uv'):
        attributes = {'uv': mesh.visual.uv}
    vertices, faces, attributes = trimesh.remesh.subdivide(
        mesh.vertices, mesh.faces, attributes=attributes)
    mesh.vertices = vertices
    mesh.faces = faces
    if 'uv' in attributes:
        mesh.visual.uv = attributes['uv']

    return mesh
```