### PR TITLE
Add support for importing and exporting xyz pointclouds

### DIFF
--- a/trimesh/exchange/export.py
+++ b/trimesh/exchange/export.py
@@ -11,6 +11,7 @@ from .off import _off_exporters
 from .stl import export_stl, export_stl_ascii
 from .ply import _ply_exporters
 from .dae import _collada_exporters
+from .xyz import _xyz_exporters
 
 
 def export_mesh(mesh, file_obj, file_type=None, **kwargs):
@@ -64,6 +65,51 @@ def export_mesh(mesh, file_obj, file_type=None, **kwargs):
         file_obj.close()
 
     return result
+
+
+def export_pointcloud(cloud, file_obj, file_type=None, **kwargs):
+    """
+    Export a Pointcloud object to a file- like object, or to a filename
+
+    Parameters
+    -----------
+    file_obj : str, file-like
+      Where should pointcloud be exported to
+    file_type : str or None
+      Represents file type (eg: 'xyz')
+
+    Returns
+    ----------
+    exported : bytes or str
+      Result of exporter
+    """
+    # if we opened a file object in this function
+    # we will want to close it when we're done
+    was_opened = False
+
+    if util.is_string(file_obj):
+        if file_type is None:
+            file_type = (str(file_obj).split('.')[-1]).lower()
+        if file_type in _pointcloud_exporters:
+            was_opened = True
+            file_obj = open(file_obj, 'wb')
+    file_type = str(file_type).lower()
+
+    if not (file_type in _pointcloud_exporters):
+        raise ValueError('%s exporter not available!', file_type)
+
+    export = _pointcloud_exporters[file_type](cloud, **kwargs)
+
+    if hasattr(file_obj, 'write'):
+        result = util.write_encoded(file_obj, export)
+    else:
+        result = export
+
+    if was_opened:
+        file_obj.close()
+
+    return result
+
 
 
 def export_dict64(mesh):
@@ -191,3 +237,6 @@ _mesh_exporters.update(_ply_exporters)
 _mesh_exporters.update(_obj_exporters)
 _mesh_exporters.update(_off_exporters)
 _mesh_exporters.update(_collada_exporters)
+
+_pointcloud_exporters = {}
+_pointcloud_exporters.update(_xyz_exporters)

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -21,6 +21,7 @@ from .threemf import _three_loaders
 from .openctm import _ctm_loaders
 from .xml_based import _xml_loaders
 from .binvox import _binvox_loaders
+from .xyz import _xyz_loaders
 
 
 try:
@@ -72,6 +73,7 @@ def available_formats():
     loaders = mesh_formats()
     loaders.extend(path_formats())
     loaders.extend(compressed_loaders.keys())
+    loaders.extend(pointcloud_loaders.keys())
 
     return loaders
 
@@ -147,6 +149,12 @@ def load(file_obj,
                 file_type=file_type,
                 resolver=resolver,
                 **kwargs)
+        elif file_type in pointcloud_loaders:
+            loaded = load_pointcloud(
+                file_obj,
+                file_type=file_type,
+                resolver=resolver,
+                **kwargs)
         else:
             if file_type in ['svg', 'dxf']:
                 # call the dummy function to raise the import error
@@ -218,6 +226,71 @@ def load_mesh(file_obj,
 
         log.debug('loaded mesh using %s',
                   mesh_loaders[file_type].__name__)
+
+        if not isinstance(results, list):
+            results = [results]
+
+        loaded = []
+        for result in results:
+            kwargs.update(result)
+            loaded.append(load_kwargs(kwargs))
+            loaded[-1].metadata.update(metadata)
+        if len(loaded) == 1:
+            loaded = loaded[0]
+    finally:
+        # if we failed to load close file
+        if opened:
+            file_obj.close()
+
+    return loaded
+
+
+@log_time
+def load_pointcloud(file_obj,
+              file_type=None,
+              resolver=None,
+              **kwargs):
+    """
+    Load a pointcloud file into a Pointcloud object
+
+    Parameters
+    -----------
+    file_obj : str or file object
+      File name or file with pointcloud data
+    file_type : str or None
+      Which file type, e.g. 'xyz'
+    kwargs : dict
+      Passed to Pointcloud constructor
+
+    Returns
+    ----------
+    mesh : trimesh.Pointcloud
+      Loaded geometry data
+    """
+
+    # parse the file arguments into clean loadable form
+    (file_obj,  # file- like object
+     file_type,  # str, what kind of file
+     metadata,  # dict, any metadata from file name
+     opened,    # bool, did we open the file ourselves
+     resolver   # object to load referenced resources
+     ) = parse_file_args(file_obj=file_obj,
+                         file_type=file_type,
+                         resolver=resolver)
+
+    try:
+        # make sure we keep passed kwargs to loader
+        # but also make sure loader keys override passed keys
+        results = pointcloud_loaders[file_type](file_obj,
+                                          file_type=file_type,
+                                          resolver=resolver,
+                                          **kwargs)
+
+        if util.is_file(file_obj):
+            file_obj.close()
+
+        log.debug('loaded pointcloud using %s',
+                  pointcloud_loaders[file_type].__name__)
 
         if not isinstance(results, list):
             results = [results]
@@ -598,3 +671,6 @@ mesh_loaders.update(_three_loaders)
 
 voxel_loaders = {}
 voxel_loaders.update(_binvox_loaders)
+
+pointcloud_loaders = {}
+pointcloud_loaders.update(_xyz_loaders)

--- a/trimesh/exchange/xyz.py
+++ b/trimesh/exchange/xyz.py
@@ -1,0 +1,62 @@
+import numpy as np
+
+
+def load_xyz(file_obj,
+             delimiter=' ',
+             *args,
+             **kwargs):
+    """
+    Load a XYZ file from an open file object.
+    
+    Parameters
+    ----------
+    file_obj : an open file-like object 
+      Source data, ASCII XYZ
+    separator : string
+      Symol(s) used to separate the columns of the file
+
+    Returns
+    -------
+
+    pointcloud_kwargs : dict
+      Data which can be passed to 
+      Pointcloud constructor, eg: c = Pointcloud(**pointcloud_kwargs)
+    """
+    data = np.loadtxt(file_obj, ndmin=2, delimiter=delimiter)
+    num_cols = len(data[0])
+    vertices = data[:, :3]
+    if num_cols == 3:
+        # only positions
+        colors = None
+    elif num_cols == 4:
+        # color given by scalar value, map to color?
+        colors = None
+    elif num_cols == 6:
+        colors = np.array(data[:, 3:], dtype=np.uint8)
+        colors = np.concatenate((colors,
+                                 np.ones((len(data), 1), dtype=np.uint8)*255),
+                                axis=1)
+    elif num_cols == 7:
+        colors = np.array(data[:, 3:], dtype=np.uint8)
+    else:
+        raise ValueError("Unknown data type in xyz file")
+    result = {'vertices': vertices,
+              'colors': colors,
+              'metadata': {}}
+    return result
+
+def export_xyz(cloud, write_colors=True, delimiter=' '):
+    data = cloud.vertices
+    num_cols = 3
+    
+    if write_colors and cloud.colors is not None:
+        data = np.concatenate((data, cloud.colors), axis=1)
+        num_cols += 4
+
+    fmt = (('{}' + delimiter)*num_cols)[:-1]
+    export = ((fmt+'\n')*len(data))[:-1].format(*data.flatten())
+    return export
+               
+
+_xyz_loaders = {'xyz': load_xyz}
+_xyz_exporters = {'xyz': export_xyz}

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -12,6 +12,8 @@ from .constants import tol
 from .geometry import plane_transform
 from .parent import Geometry
 
+from .exchange.export import export_pointcloud
+
 from . import util
 from . import caching
 from . import grouping
@@ -581,3 +583,22 @@ class PointCloud(Geometry):
         Open a viewer window displaying the current PointCloud
         """
         self.scene().show(**kwargs)
+
+    def export(self, file_obj=None, file_type=None, **kwargs):
+        """
+        Export the current pointcloud to a file object.
+        If file_obj is a filename, file will be written there.
+        Supported formats are xyz
+        Parameters
+        ------------
+        file_obj: open writeable file object
+          str, file name where to save the pointcloud
+          None, if you would like this function to return the export blob
+        file_type: str
+          Which file type to export as.
+          If file name is passed this is not required
+        """
+        return export_pointcloud(cloud=self,
+                                 file_obj=file_obj,
+                                 file_type=file_type,
+                                 **kwargs)


### PR DESCRIPTION
Hello, 

I was working with trimesh, while I realized, that it already supports pointclouds from `ply` files, but not for example `xyz` files, which I was using. Even though loading them with numpy is very easy, I implemented pointcloud import and export, with the idea, that more formats might follow, if desired. I took a lot of "inspiration" from the import and export functionality for meshes, to make it a little easier.

As there is no official standard for the xyz format, the implementation is highly based on my specific data and needs.

I would like to discuss these changes, if they are wanted, complete, in the shape and form required and so on. I would like to also offer to take care of further changes to this code.

Thanks for the awesome software and kind regards

Paul