### PR TITLE
RF: Use __file__ instead of inspect to find resources dir

### DIFF
--- a/trimesh/resources/__init__.py
+++ b/trimesh/resources/__init__.py
@@ -1,11 +1,8 @@
 import os
-import inspect
 
-# find the current absolute path using inspect
-_pwd = os.path.dirname(
-    os.path.abspath(
-        inspect.getfile(
-            inspect.currentframe())))
+
+# find the current absolute path to this directory
+_pwd = os.path.dirname(__file__)
 
 
 def get_resource(name, decode=True):


### PR DESCRIPTION
This PR addresses issue #575 - using `inspect` to identify the location of a python module will return the incorrect path when the code has been "frozen" (bundled into a standalone executable with e.g. [pyinstaller](https://pyinstaller.readthedocs.io/en/stable/)).

This PR proposes that the module-global `__file__` attribute is used instead - this does work in both frozen and conventional (i.e. source) execution environments.

Feel free to ignore if you have good reasons for using `inspect`!