### PR TITLE
Preserves the alphaMode when reading and writing gltf

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1122,6 +1122,10 @@ def _append_material(mat, tree, buffer_items):
     except BaseException:
         pass
 
+    # if alphaMode is defined, export
+    if isinstance(mat.alphaMode, str):
+        pbr['alphaMode'] = mat.alphaMode
+
     # if scalars are defined correctly export
     if isinstance(mat.metallicFactor, float):
         pbr['metallicFactor'] = mat.metallicFactor

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1162,6 +1162,7 @@ def _append_material(mat, tree, buffer_items):
     pbr_subset = ['baseColorTexture',
                   'baseColorFactor',
                   'roughnessFactor',
+                  'metallicFactor'
                   'metallicRoughnessTexture']
     # move keys down a level
     for key in pbr_subset:

--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -135,7 +135,7 @@ class PBRMaterial(Material):
         self.doubleSided = doubleSided
 
         # str
-        alphaMode = alphaMode
+        self.alphaMode = alphaMode
 
     def to_color(self, uv):
         """


### PR DESCRIPTION
I found that in the course of reading and writing gltf files, transparent objects became opaque. This was caused by the alphaMode being unassigned in the PBRMaterial and not included in the gltf export.

I've also added a missing `matallicFactor` property.
