### PR TITLE
Include member summary tables in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,10 @@ def abspath(rel):
     return os.path.abspath(os.path.join(cwd, rel))
 
 
-extensions = ['sphinxcontrib.napoleon']
+extensions = [
+    'sphinx.ext.napoleon',
+    'autodocsumm',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -82,3 +85,9 @@ html_theme = 'sphinx_rtd_theme'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'trimeshdoc'
+
+# -- Extensions configuration ----------------------------------------
+
+autodoc_default_options = {
+    'autosummary': True,
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ sphinx
 jupyter
 sphinx_rtd_theme
 pyopenssl
+autodocsumm


### PR DESCRIPTION
Use `autodocsumm` to generate member summary tables, which include member name and docstring summary, grouped by member type.

This helps with quickly seeing the functionality without having to scroll through large amounts of type documentation.