### PR TITLE
Lazily import shapely during testing

### DIFF
--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -2,12 +2,12 @@ try:
     from . import generic as g
 except BaseException:
     import generic as g
-from shapely.geometry import Polygon
 
 
 class PackingTest(g.unittest.TestCase):
 
     def setUp(self):
+        from shapely.geometry import Polygon
         self.nestable = [Polygon(i) for i in g.data['nestable']]
 
     def test_obb(self):


### PR DESCRIPTION
This allows running a subset of the tests (e.g. `python3 -m pytest -k test_repair`) without having shapely installed.