### PR TITLE
`collections.abc` compatibility for Python 3.8+

### DIFF
--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -15,6 +15,11 @@ import hashlib
 
 from functools import wraps
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 from .constants import log
 from .util import is_sequence
 
@@ -491,7 +496,7 @@ class Cache(object):
         self.id_current = self._id_function()
 
 
-class DataStore(collections.Mapping):
+class DataStore(Mapping):
     """
     A class to store multiple numpy arrays and track them all
     for changes.

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -45,6 +45,11 @@ else:
     StringIO.__exit__ = lambda a, b, c, d: a.close()
     BytesIO = StringIO
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 # create a default logger
 log = logging.getLogger('trimesh')
 
@@ -2058,7 +2063,7 @@ def allclose(a, b, atol):
     return np.all(np.abs(a - b).max() < atol)
 
 
-class FunctionRegistry(collections.Mapping):
+class FunctionRegistry(Mapping):
     """
     Non-overwritable mapping of string keys to functions.
 


### PR DESCRIPTION
Suppresses warnings like these:

```
trimesh/util.py:2061
  /Users/pnm/code/trimesh/trimesh/util.py:2061: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    class FunctionRegistry(collections.Mapping):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```