### PR TITLE
Do not merge vertices with different normals

### DIFF
--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -56,6 +56,7 @@ def merge_vertices(mesh,
         # converted to integers at requested precision
         stacked = np.column_stack((
             mesh.vertices * (10 ** digits),
+            mesh.vertex_normals * (10 ** digits),
             mesh.visual.uv * (10 ** uv_digits))).round().astype(np.int64)
         # Merge vertices with identical positions and UVs
         # we don't merge vertices just based on position
@@ -74,9 +75,11 @@ def merge_vertices(mesh,
             # this is used for PointCloud objects
             referenced = np.ones(len(mesh.vertices), dtype=np.bool)
 
-        # check unique rows of referenced vertices
-        u, i = unique_rows(mesh.vertices[referenced],
-                           digits=digits)
+        # only remove duplicates if vertex position and normal are close
+        stacked = np.column_stack((
+            mesh.vertices[referenced] * (10 ** digits),
+            mesh.vertex_normals[referenced] * (10 ** digits))).round().astype(np.int64)
+        u, i = unique_rows(stacked)
 
         # construct an inverse using the subset
         inverse = np.zeros(len(mesh.vertices), dtype=np.int64)


### PR DESCRIPTION
I've been having issues with vertex normals not loaded correctly. I traced the issue to the automatic vertex merger, which does not seem to take vertex normals into account.

Here is an example before this fix:

![Screen Shot 2019-12-24 at 12 13 33 PM](https://user-images.githubusercontent.com/902935/71424658-8939f880-2648-11ea-8cd4-44600f42a4ac.png)

Here is an example after this fix (or with merging commented out):

![Screen Shot 2019-12-24 at 12 13 59 PM](https://user-images.githubusercontent.com/902935/71424661-9525ba80-2648-11ea-8c39-3d882c276d43.png)
