### PR TITLE
Prevent exception in "trimesh.repair.broken_faces" definition when using custom colour and no broken faces exist.

### DIFF
--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -184,7 +184,7 @@ def broken_faces(mesh, color=None):
     broken = [k for k, v in dict(adjacency.degree()).items()
               if v != 3]
     broken = np.array(broken)
-    if color is not None:
+    if color is not None and broken.size != 0:
         # if someone passed a broken color
         color = np.array(color)
         if not (color.shape == (4,) or color.shape == (3,)):


### PR DESCRIPTION
Using `trimesh.repair.broken_faces` on a mesh without broken faces but while using a custom colour raise an exception because later indexing is performed with an empty `ndarray`:

```python
mesh = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]],
                           faces=[[0, 1, 2]])
trimesh.repair.broken_faces(mesh, color=(255, 0, 0, 255))
```

```
Traceback (most recent call last):
  File "/Users/kelsolaar/Documents/Development/colour-science/colour/colour/gamut/boundary/common.py", line 225, in <module>
    trimesh.repair.broken_faces(mesh, color=(255, 255, 0, 255))
  File "/Users/kelsolaar/Documents/Development/colour-science/trimesh/trimesh/repair.py", line 193, in broken_faces
    mesh.visual.face_colors[broken] = color
  File "/Users/kelsolaar/Documents/Development/colour-science/trimesh/trimesh/caching.py", line 353, in __setitem__
    **kwargs)
IndexError: arrays used as indices must be of integer (or boolean) type
```