### PR TITLE
[dae] Fix unicode for Python 2

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -219,7 +219,7 @@ def _parse_node(node,
                     vis = visual.texture.TextureVisuals(
                         uv=uv, material=material)
 
-                primid = '{}.{}'.format(geometry.id, i)
+                primid = '{}.{}'.format(geometry.id.encode('utf-8'), i)
                 meshes[primid] = {
                     'vertices': vertices,
                     'faces': faces,


### PR DESCRIPTION
The current dae loader failed to load some `collada` file which contains `utf-8` geometry tag on Python2.
Example `collada` file is following.
https://drive.google.com/open?id=1BBFboFA-WSKoVlf1JihBZ85tFEQmU6IO