### PR TITLE
Add delete_geometry and hide/show geometry to SceneViewer

### DIFF
--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -198,6 +198,22 @@ class Scene(Geometry):
                           geometry_flags={'visible': True})
         return node_name
 
+    def delete_geometry(self, name):
+        """
+        Delete a geometry from the scene.
+
+        Parameters
+        --------------
+        name : hashable
+          Name that references geometry
+        """
+        self.graph.transforms.remove_node(name)
+        self.graph._cache.update(
+            {'nodes_geometry': np.array(
+                [n for n, attr in self.graph.transforms.nodes(data=True)
+                 if 'geometry' in attr])})
+        self.geometry.pop(name)
+
     def md5(self):
         """
         MD5 of scene which will change when meshes or

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -241,6 +241,23 @@ class SceneViewer(pyglet.window.Window):
             if tex is not None:
                 self.textures[name] = tex
 
+    def sweap_geometries(self):
+        """
+        Sweap geometries from the viewer.
+
+        """
+        node_names = collections.deque(
+            self.scene.graph.nodes_geometry)
+        deleted_names = []
+        for name in self.vertex_list:
+            if name not in node_names:
+                deleted_names.append(name)
+        for name in deleted_names:
+            self.vertex_list.pop(name, None)
+            self.vertex_list_hash.pop(name, None)
+            self.vertex_list_mode.pop(name, None)
+            self.textures.pop(name, None)
+
     def reset_view(self, flags=None):
         """
         Set view to the default view.

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -123,6 +123,8 @@ class SceneViewer(pyglet.window.Window):
         self.vertex_list_mode = {}
         # store meshes that don't rotate relative to viewer
         self.fixed = fixed
+        # store a hidden (don't not display) node.
+        self._nodes_hidden = set()
         # name : texture
         self.textures = {}
 
@@ -257,6 +259,28 @@ class SceneViewer(pyglet.window.Window):
             self.vertex_list_hash.pop(name, None)
             self.vertex_list_mode.pop(name, None)
             self.textures.pop(name, None)
+
+    def show_geometry(self, node):
+        """
+        Display the geometry contained at a node.
+
+        Parameters
+        -------------
+        node : str
+           Node to display
+        """
+        self._nodes_hidden.discard(node)
+
+    def hide_geometry(self, node):
+        """
+        Don't display the geometry contained at a node.
+
+        Parameters
+        -------------
+        node : str
+           Node to not display
+        """
+        self._nodes_hidden.add(node)
 
     def reset_view(self, flags=None):
         """
@@ -665,6 +689,9 @@ class SceneViewer(pyglet.window.Window):
         while len(node_names) > 0:
             count += 1
             current_node = node_names.popleft()
+
+            if current_node in self._nodes_hidden:
+                continue
 
             # get the transform from world to geometry and mesh name
             transform, geometry_name = self.scene.graph.get(current_node)


### PR DESCRIPTION
Related to #704 

Add a function `delete_geometry` to `SceneViewer`.
By the way, `scene.graph.node_geometry` is the cached property.
What is the best way to update the cached property?
