### PR TITLE
Fix for initial camera aspect ration in Three.js view

### DIFF
--- a/trimesh/resources/javascript/load_base64.js
+++ b/trimesh/resources/javascript/load_base64.js
@@ -115,6 +115,7 @@ function init() {
 
       // enable controls
       animate();
+      onWindowResize();
     }
   );
 }


### PR DESCRIPTION
Quick hack to fix the camera aspect ratio problem not being inited correctly which is fixed when resizing the browser window.