### PR TITLE
add centroid property to Path3D class

### DIFF
--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -1017,6 +1017,19 @@ class Path3D(Path):
         if show:
             plt.show()
 
+    @caching.cache_decorator
+    def centroid(self):
+        """
+        Return the centroid of the path object.
+
+        Returns
+        -----------
+        centroid : (d,) float
+          Approximate centroid of the path
+        """
+        centroid = self.vertices.mean(axis=0)
+        return centroid
+
 
 class Path2D(Path):
 


### PR DESCRIPTION
Copied the centroid cached method from Path2D to Path3D because why not?