### PR TITLE
Added doubleSided attribute to gltf export

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1150,6 +1150,10 @@ def _append_material(mat, tree, buffer_items, mat_hashes):
     # if alphaMode is defined, export
     if isinstance(as_pbr.alphaMode, str):
         result['alphaMode'] = as_pbr.alphaMode
+    
+    # if doubleSided is defined, export
+    if isinstance(as_pbr.doubleSided, bool):
+        result['doubleSided'] = as_pbr.doubleSided
 
     # if scalars are defined correctly export
     if isinstance(as_pbr.metallicFactor, float):

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1147,6 +1147,10 @@ def _append_material(mat, tree, buffer_items, mat_hashes):
     except BaseException:
         pass
 
+    # if name is defined, export
+    if isinstance(as_pbr.name, str):
+        result['name'] = as_pbr.name
+
     # if alphaMode is defined, export
     if isinstance(as_pbr.alphaMode, str):
         result['alphaMode'] = as_pbr.alphaMode

--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -221,6 +221,7 @@ class PBRMaterial(Material):
         self.doubleSided = doubleSided
 
         # str
+        self.name = name
         self.alphaMode = alphaMode
 
     def to_color(self, uv):


### PR DESCRIPTION
Found that the gltf material export did not include the `doubleSided` attribute mentioned in the [specification](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#double-sided). Added it where it seemed to be appropriate.