### PR TITLE
Support differing list-lengths in ASCII-PLYs

### DIFF
--- a/models/points_ascii_with_lists.ply
+++ b/models/points_ascii_with_lists.ply
@@ -1,0 +1,18 @@
+ply
+format ascii 1.0
+element vertex 5
+property float x
+property float y
+property float z
+element point_list 2
+property list uchar uint point_indices1
+property list uchar uint point_indices2
+property float some_float
+end_header
+-0.06325 0.0359793 0.0420873 
+-0.06275 0.0360343 0.0425949 
+-0.0645 0.0365101 0.0404362 
+-0.064 0.0366195 0.0414512 
+-0.0635 0.0367289 0.0424662 
+3 10 11 12 2 13 14 1.1
+2 10 11 3 12 13 14 2.2

--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -57,6 +57,27 @@ class PlyTest(g.unittest.TestCase):
         assert m.vertices.shape == (1024, 3)
         assert isinstance(m, g.trimesh.PointCloud)
 
+    def test_list_properties(self):
+        """
+        Test reading point clouds with the following metadata:
+        - lists of differing length
+        - multiple list properties
+        - single-element properties that come after list properties
+        """
+        m = g.get_mesh('points_ascii_with_lists.ply')
+
+        point_list = m.metadata['ply_raw']['point_list']['data']
+        assert g.np.array_equal(
+            point_list['point_indices1'][0], g.np.array([10, 11, 12], dtype=g.np.uint32))
+        assert g.np.array_equal(
+            point_list['point_indices1'][1], g.np.array([10, 11], dtype=g.np.uint32))
+        assert g.np.array_equal(
+            point_list['point_indices2'][0], g.np.array([13, 14], dtype=g.np.uint32))
+        assert g.np.array_equal(
+            point_list['point_indices2'][1], g.np.array([12, 13, 14], dtype=g.np.uint32))
+        assert g.np.array_equal(
+            point_list['some_float'], g.np.array([1.1, 2.2], dtype=g.np.float32))
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()


### PR DESCRIPTION
PLY allows defining list-properties, where every instance of the
property can have a different length. This can for instance be useful
when storing submeshes in the metadata of a PLY-file.

trimesh only supported PLY-files with list-properties, if every
instance of the list had the same length. Properties with lists of
differing lengths let the parser crash at the `vstack`-call in
`ply.ply_ascii`, as arrays of differing size cannot be stacked.

The implementation at hand adds support for lists of differing length.

The drawback of the new implementation is an increased load-time for
elements containing lists. I tried to mitigate this effect by checking
whether an element contains a list and using the old, numpy-based
algorithm to load the data, if none is found.