### PR TITLE
Feature/gltf custom vertex attributes

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -244,6 +244,29 @@ class GLTFTest(g.unittest.TestCase):
         # lightly check to see that no references exist
         assert '$ref' not in g.json.dumps(s)
 
+    def test_export_custom_attributes(self):
+        # Write and read custom vertex attributes to gltf
+        sphere = g.trimesh.primitives.Sphere()
+        v_count, _ = sphere.vertices.shape
+
+        sphere.vertex_attributes['_CustomFloat32Scalar'] = g.np.random.rand(v_count, 1).astype(g.np.float32)
+        sphere.vertex_attributes['_CustomUIntScalar'] = g.np.random.random_integers(
+            0, 1000, size=(v_count, 1)
+        ).astype(g.np.uintc)
+        sphere.vertex_attributes['_CustomFloat32Vec3'] = g.np.random.rand(v_count, 3).astype(g.np.float32)
+        sphere.vertex_attributes['_CustomFloat32Mat4'] = g.np.random.rand(v_count, 4, 4).astype(g.np.float32)
+
+        # export as GLB then re-load
+        r = g.trimesh.load(
+            g.trimesh.util.wrap_as_stream(
+                sphere.export(file_type='glb')),
+            file_type='glb')
+
+        for _, val in r.geometry.items():
+            assert set(val.vertex_attributes.keys()) == set(sphere.vertex_attributes.keys())
+            for key in val.vertex_attributes:
+                is_same = g.np.array_equal(val.vertex_attributes[key], sphere.vertex_attributes[key])
+                assert is_same == True
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -250,7 +250,7 @@ class GLTFTest(g.unittest.TestCase):
         v_count, _ = sphere.vertices.shape
 
         sphere.vertex_attributes['_CustomFloat32Scalar'] = g.np.random.rand(v_count, 1).astype(g.np.float32)
-        sphere.vertex_attributes['_CustomUIntScalar'] = g.np.random.random_integers(
+        sphere.vertex_attributes['_CustomUIntScalar'] = g.np.random.randint(
             0, 1000, size=(v_count, 1)
         ).astype(g.np.uintc)
         sphere.vertex_attributes['_CustomFloat32Vec3'] = g.np.random.rand(v_count, 3).astype(g.np.float32)

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -611,6 +611,67 @@ def _append_mesh(mesh,
         # the actual color data
         buffer_items.append(normal_data)
 
+    # for each attribute with a leading underscore, assign them to trimesh vertex_attributes
+    for key in mesh.vertex_attributes:
+        attribute_name = key
+        # Application specific attributes must be prefixed with an underscore
+        if not key.startswith("_"):
+            attribute_name = "_" + key
+        tree["meshes"][-1]["primitives"][0]["attributes"][attribute_name] = len(tree["accessors"])
+        attribute_data = _byte_pad(mesh.vertex_attributes[key].tobytes())
+        accessor = {
+            "bufferView": len(buffer_items),
+            "count": len(mesh.vertex_attributes[key])
+        }
+        accessor.update(_build_accessor(mesh.vertex_attributes[key]))
+        tree["accessors"].append(accessor)
+        buffer_items.append(attribute_data)
+
+def _build_accessor(array):
+    shape = array.shape
+    data_type = "SCALAR"
+    if len(shape) == 2:
+        vec_length = shape[1]
+        if vec_length > 4:
+            raise ValueError("The GLTF spec does not support vectors larger than 4")
+        if vec_length > 1:
+            data_type = "VEC%d" % vec_length
+        else:
+            data_type = "SCALAR"
+
+    if len(shape) == 3:
+        if shape[2] not in [2, 3, 4]:
+            raise ValueError("Matrix types must have 4, 9 or 16 components")
+        data_type = "MAT%d" % shape[2]
+
+    componentType = None
+    if array.dtype == np.byte:
+        componentType = 5120
+    if array.dtype == np.ubyte:
+        componentType = 5121
+    if array.dtype == np.short:
+        componentType = 5122
+    if array.dtype == np.ushort:
+        componentType = 5123
+    if array.dtype == np.uintc:
+        componentType = 5125
+    if array.dtype == np.float32:
+        componentType = 5126
+
+    if componentType is None:
+        raise ValueError("Unsupported componentType %s" % array.dtype)
+
+    accessor =  {
+        "componentType": componentType,
+        "type": data_type,
+        "byteOffset": 0
+    }
+
+    if len(shape) < 3:
+        accessor["max"] = array.max(axis=0).tolist()
+        accessor["min"] = array.min(axis=0).tolist()
+
+    return accessor
 
 def _byte_pad(data, bound=4):
     """
@@ -822,7 +883,6 @@ def _read_buffers(header, buffers, mesh_kwargs, resolver=None):
         # number of items when flattened
         # i.e. a (4, 4) MAT4 has 16
         per_count = np.abs(np.product(per_item))
-
         if 'bufferView' in a:
             # data was stored in a buffer view so get raw bytes
             data = views[a["bufferView"]]
@@ -835,6 +895,7 @@ def _read_buffers(header, buffers, mesh_kwargs, resolver=None):
             # length is the number of bytes per item times total
             length = np.dtype(dtype).itemsize * count * per_count
             # load the bytes data into correct dtype and shape
+
             access[index] = np.frombuffer(
                 data[start:start + length], dtype=dtype).reshape(shape)
         else:
@@ -911,6 +972,15 @@ def _read_buffers(header, buffers, mesh_kwargs, resolver=None):
             # each primitive gets it's own Trimesh object
             if len(m["primitives"]) > 1:
                 name += "_{}".format(j)
+
+            custom_attrs = [attr for attr in p["attributes"] if attr.startswith("_")]
+            if len(custom_attrs):
+                vertex_attributes = {}
+                for attr in custom_attrs:
+                        vertex_attributes[attr] = access[p["attributes"][attr]]
+                kwargs['vertex_attributes'] = vertex_attributes
+
+            kwargs["process"] = False
 
             meshes[name] = kwargs
             mesh_prim[index].append(name)

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -978,7 +978,7 @@ def _read_buffers(header, buffers, mesh_kwargs, resolver=None):
                 vertex_attributes = {}
                 for attr in custom_attrs:
                         vertex_attributes[attr] = access[p["attributes"][attr]]
-                kwargs['vertex_attributes'] = vertex_attributes
+                kwargs["vertex_attributes"] = vertex_attributes
 
             kwargs["process"] = False
 


### PR DESCRIPTION
## Overview
This pull request add the ability to read and write vertex attributes in the glTF file format.

## Test

I've added test coverage for the new feature in `test_gltf.py` 

To run the test:
```bash
$ pytest tests/test_gltf.py
```
Note, I'm seeing a failure in the node name test, but I see this failure on master as well as this feature branch.

>FAILED tests/test_gltf.py::GLTFTest::test_node_name - ValueError: File type: 3dxml not supported

## Relates to
https://github.com/mikedh/trimesh/issues/199
https://github.com/mikedh/trimesh/issues/675

## Reference
https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#meshes