### PR TITLE
Fix bug related to specifying the center of circle paths

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -354,14 +354,14 @@ class CreationTests(g.unittest.TestCase):
 
     def test_circle(self):
         from trimesh.path import creation
-        circle = creation.circle(radius=1.0)
+        circle = creation.circle(radius=1.0, center=(1.0, 1.0))
 
         # it's a discrete circle
         assert g.np.isclose(circle.area, g.np.pi, rtol=0.01)
         # should be centered at 0
         assert g.np.allclose(
             circle.polygons_full[0].centroid, [
-                0.0, 0.0], atol=1e-3)
+                1.0, 1.0], atol=1e-3)
 
         assert len(circle.entities) == 1
         assert len(circle.polygons_closed) == 1

--- a/trimesh/path/creation.py
+++ b/trimesh/path/creation.py
@@ -100,7 +100,7 @@ def circle(radius=None, center=None, **kwargs):
     # (3, 2) float, points on arc
     three = arc.to_threepoint(angles=[0, np.pi],
                               center=center,
-                              radius=radius) + center
+                              radius=radius)
 
     result = Path2D(entities=[Arc(points=np.arange(3), closed=True)],
                     vertices=three,


### PR DESCRIPTION
It seems to me the circle center is currently getting added twice.

Let me know if you'd like to keep the original test and just add a separate one (that is almost the same, just with center specified) for the offset circle.