### PR TITLE
Support OFF headers not separated by whitespace.

### DIFF
--- a/trimesh/exchange/off.py
+++ b/trimesh/exchange/off.py
@@ -1,3 +1,4 @@
+import re
 import numpy as np
 
 from .. import util
@@ -22,8 +23,7 @@ def load_off(file_obj, **kwargs):
     # will magically survive weird encoding sometimes
     text = util.decode_text(text).lstrip()
     # split the first key
-    header, raw = text.split(None, 1)
-
+    _, header, raw = re.split('(COFF|OFF)', text, 1)
     if header.upper() not in ['OFF', 'COFF']:
         raise NameError(
             'Not an OFF file! Header was: `{}`'.format(header))


### PR DESCRIPTION
I've encountered some OFF files that don't have any separator after the header. 

For example, the [ModelNet](https://modelnet.cs.princeton.edu/) models looks like this:
```
OFF28048 35408 0
-7.236239 -13.051139 -4.200710
-7.826739 -13.051139 -10.06685
-7.236239 -13.051139 -10.06685
-7.826739 -13.051139 -4.200710
...
```

This fixes this by splitting by the header instead of whitespace.