### PR TITLE
Add ignore_mtl and default_material flags for OBJ.

### DIFF
--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -61,7 +61,7 @@ def load_obj(file_obj,
     # Load Materials
     materials = {}
     mtl_position = text.find('mtllib')
-    if mtl_position >= 0:
+    if mtl_position >= 0 and not kwargs.get('ignore_mtl', False)::
         # take the line of the material file after `mtllib`
         # which should be the file location of the .mtl file
         mtl_path = text[mtl_position + 6:text.find('\n', mtl_position)].strip()
@@ -221,9 +221,14 @@ def load_obj(file_obj,
             visual = TextureVisuals(
                 uv=uv, material=materials[material])
         elif material is not None:
-            # material will be None by default
-            log.warning('specified material ({})  not loaded!'.format(
-                material))
+            # It's okay that the MTL file does not exist if ignore_mtl is set.
+            if not kwargs.get('ignore_mtl', False):
+                # material will be None by default
+                log.warning('specified material ({})  not loaded!'.format(
+                    material))
+            # Override material with the specified one if set.
+            if kwargs.get('default_material', None) is not None:
+                visual = TextureVisuals(uv=uv, material=kwargs.get('default_material'))
         mesh['visual'] = visual
 
         # store geometry by name

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -61,7 +61,7 @@ def load_obj(file_obj,
     # Load Materials
     materials = {}
     mtl_position = text.find('mtllib')
-    if mtl_position >= 0 and not kwargs.get('ignore_mtl', False)::
+    if mtl_position >= 0 and not kwargs.get('ignore_mtl', False):
         # take the line of the material file after `mtllib`
         # which should be the file location of the .mtl file
         mtl_path = text[mtl_position + 6:text.find('\n', mtl_position)].strip()


### PR DESCRIPTION
These flags were added in https://github.com/mikedh/trimesh/pull/538 but were removed in https://github.com/mikedh/trimesh/commit/b45b74dc3aaecd8833c789e41d77650b2ddbe0be#diff-24e7992eca78afee5fd5565cf0bf76e9

It was my mistake for not splitting the PR. This PR re-introduces these flags

 - `ignore_mtl`: ignore the existence of MTL files and do not throw an error if it doesn't exist
 - `default_material`: overrides the materials to one set in the `kwargs`. This is particularly useful if you don't want to load the materials but still need the UV mappings.
