### PR TITLE
Enable material transparency in collada importer

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -313,6 +313,11 @@ def _parse_material(effect, resolver):
             log.warning('unable to load bumpmap',
                         exc_info=True)
 
+    # Compute opacity
+    if (effect.transparent is not None
+            and not isinstance(effect.transparent, collada.material.Map)):
+        baseColorFactor = tuple([*baseColorFactor[:3], effect.transparent[3]])
+
     return visual.material.PBRMaterial(
         emissiveFactor=emissiveFactor,
         emissiveTexture=emissiveTexture,


### PR DESCRIPTION
Hi Mike! Hope you've been doing well. This is just a quick, minor update that reads the "transparent" DAE attribute and uses it to set the base color's alpha channel if one is present. I tested this on meshes exported from Blender and it worked well. Let me know if you have any questions.

Best,
Matt