### PR TITLE
Add a noninteractive flag in the apt script.

### DIFF
--- a/docker/builds/apt.bash
+++ b/docker/builds/apt.bash
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -xe
+DEBIAN_FRONTEND=noninteractive
 
 # Install binary dependencies directly from APT.
 apt-get update -qq


### PR DESCRIPTION
APT doesn't like running interactively in docker, it is generally recommended to set this flag in builds to reduce warnings.