### PR TITLE
Fix VoxelGrid.bounds for half voxel shift

### DIFF
--- a/tests/test_binvox.py
+++ b/tests/test_binvox.py
@@ -29,7 +29,9 @@ class BinvoxTest(g.unittest.TestCase):
             [0, 0, 0, 1]
         ]))
         dense = dense.transpose((0, 2, 1))
-        np.testing.assert_allclose(base.bounds, [translate, translate + scale])
+        bound_min = translate - 0.5 * s
+        bound_max = translate + scale + 0.5 * s
+        np.testing.assert_allclose(base.bounds, [bound_min, bound_max])
         np.testing.assert_equal(base.encoding.dense, dense)
 
         if binvox.binvox_encoder is None:

--- a/trimesh/voxel/base.py
+++ b/trimesh/voxel/base.py
@@ -11,6 +11,7 @@ from . import transforms
 from . import morphology
 from . import encoding as enc
 
+from .. import bounds as bounds_module
 from .. import caching
 from .. import transformations as tr
 
@@ -142,9 +143,13 @@ class VoxelGrid(Geometry):
     @caching.cache_decorator
     def bounds(self):
         indices = self.sparse_indices
-        bounds = np.array([indices.min(axis=0) - 0.5,
-                           indices.max(axis=0) + 0.5])
-        bounds = self._transform.transform_points(bounds)
+        # get all 8 corners of the AABB
+        corners = bounds_module.corners([indices.min(axis=0) - 0.5,
+                                         indices.max(axis=0) + 0.5])
+        # transform these corners to a new frame
+        corners = self._transform.transform_points(corners)
+        # get the AABB of corners in-frame
+        bounds = np.array([corners.min(axis=0), corners.max(axis=0)])
         bounds.flags.writeable = False
         return bounds
 

--- a/trimesh/voxel/base.py
+++ b/trimesh/voxel/base.py
@@ -141,8 +141,10 @@ class VoxelGrid(Geometry):
 
     @caching.cache_decorator
     def bounds(self):
-        points = self.points
-        bounds = np.array([points.min(axis=0), points.max(axis=0)])
+        indices = self.sparse_indices
+        bounds = np.array([indices.min(axis=0) - 0.5,
+                           indices.max(axis=0) + 0.5])
+        bounds = self._transform.transform_points(bounds)
         bounds.flags.writeable = False
         return bounds
 


### PR DESCRIPTION
```python
#!/usr/bin/env python

import trimesh
import trimesh.transformations as ttf

import morefusion


models = morefusion.datasets.YCBVideoModels()
voxel = models.get_solid_voxel_grid(class_id=2)

scene = trimesh.Scene()
scene.add_geometry(voxel.as_boxes())
if 0:
    scene.add_geometry(
        trimesh.path.creation.box_outline(voxel.extents),
        transform=ttf.translation_matrix(voxel.bounds.mean(axis=0)),
    )
else:
    scene.add_geometry(voxel.bounding_box.as_box_outline())
scene.show(resolution=(640, 480))
```

**Before**
![Screenshot from 2020-04-15 00-45-54](https://user-images.githubusercontent.com/4310419/79284499-bdb11900-7eb2-11ea-991a-52b9acd4ee70.png)

**After**
![Screenshot from 2020-04-15 00-46-57](https://user-images.githubusercontent.com/4310419/79284500-be49af80-7eb2-11ea-9af5-e2388c3e68d9.png)
