### PR TITLE
Added option to merge buffers

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -137,6 +137,17 @@ class GLTFTest(g.unittest.TestCase):
             # will assert round trip is roughly equal
             g.scene_equal(rd, scene)
 
+    def test_gltf_merge_buffers(self):
+        # split a multibody mesh into a scene
+        scene = g.trimesh.scene.split_scene(
+            g.get_mesh('cycloidal.ply'))
+
+        # export a gltf with the merge_buffers option set to true
+        export = scene.export(file_type='gltf', merge_buffers=True)
+
+        # We should end up with a single .bin and scene.gltf
+        assert len(export.keys()) == 2
+
     def test_gltf_pole(self):
         scene = g.get_mesh('simple_pole.glb')
 


### PR DESCRIPTION
I've added an option to `merge_buffers` when exporting to gltf. This option combines all buffers into one, similar to the glb export. The `test_gltf` export produces over a 100 binary files. Merging those buffers into one can be useful when you want to get the separate json header, but would like to reduce the number of requests required to download all data for the model.