### PR TITLE
Do not add camera to gltf if none exists in scene

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -142,16 +142,16 @@ class GLTFTest(g.unittest.TestCase):
         gltf_cameras_key = 'cameras'
 
         # if there's no camera in the scene, then it shouldn't be added to the gltf
-        box = g.trimesh.creation.box([1,1,1])
+        box = g.trimesh.creation.box([1 ,1, 1])
         scene = g.trimesh.Scene(box)
         export = scene.export(file_type='gltf')
         assert gltf_cameras_key not in json.loads(export['model.gltf'])
 
         # `scene.camera` creates a camera if it does not exist.
         # once in the scene, it should be added to the gltf.
-        box = g.trimesh.creation.box([1,1,1])
+        box = g.trimesh.creation.box([1, 1, 1])
         scene = g.trimesh.Scene(box)
-        camera = scene.camera
+        scene.set_camera()
         export = scene.export(file_type='gltf')
         assert gltf_cameras_key in json.loads(export['model.gltf'])
 

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -137,6 +137,24 @@ class GLTFTest(g.unittest.TestCase):
             # will assert round trip is roughly equal
             g.scene_equal(rd, scene)
 
+    def test_gltf_optional_camera(self):
+        import json
+        gltf_cameras_key = 'cameras'
+
+        # if there's no camera in the scene, then it shouldn't be added to the gltf
+        box = g.trimesh.creation.box([1,1,1])
+        scene = g.trimesh.Scene(box)
+        export = scene.export(file_type='gltf')
+        assert gltf_cameras_key not in json.loads(export['model.gltf'])
+
+        # `scene.camera` creates a camera if it does not exist.
+        # once in the scene, it should be added to the gltf.
+        box = g.trimesh.creation.box([1,1,1])
+        scene = g.trimesh.Scene(box)
+        camera = scene.camera
+        export = scene.export(file_type='gltf')
+        assert gltf_cameras_key in json.loads(export['model.gltf'])
+
     def test_gltf_pole(self):
         scene = g.get_mesh('simple_pole.glb')
 

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -142,7 +142,7 @@ class GLTFTest(g.unittest.TestCase):
         gltf_cameras_key = 'cameras'
 
         # if there's no camera in the scene, then it shouldn't be added to the gltf
-        box = g.trimesh.creation.box([1 ,1, 1])
+        box = g.trimesh.creation.box([1, 1, 1])
         scene = g.trimesh.Scene(box)
         export = scene.export(file_type='gltf')
         assert gltf_cameras_key not in json.loads(export['model.gltf'])

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -145,7 +145,7 @@ class GLTFTest(g.unittest.TestCase):
         box = g.trimesh.creation.box([1, 1, 1])
         scene = g.trimesh.Scene(box)
         export = scene.export(file_type='gltf')
-        assert gltf_cameras_key not in json.loads(export['model.gltf'])
+        assert gltf_cameras_key not in json.loads(export['model.gltf'].decode('utf8'))
 
         # `scene.camera` creates a camera if it does not exist.
         # once in the scene, it should be added to the gltf.
@@ -153,7 +153,7 @@ class GLTFTest(g.unittest.TestCase):
         scene = g.trimesh.Scene(box)
         scene.set_camera()
         export = scene.export(file_type='gltf')
-        assert gltf_cameras_key in json.loads(export['model.gltf'])
+        assert gltf_cameras_key in json.loads(export['model.gltf'].decode('utf8'))
 
     def test_gltf_pole(self):
         scene = g.get_mesh('simple_pole.glb')

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -421,7 +421,10 @@ def _create_gltf_structure(scene,
         "textures": [],
         "samplers": [{}],
         "materials": [],
-        "cameras": [_convert_camera(scene.camera)]}
+    }
+
+    if scene.has_camera:
+        tree["cameras"] = [_convert_camera(scene.camera)]
 
     # collect extras from passed arguments and metadata
     collected = {}

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -649,7 +649,7 @@ class Scene(Geometry):
           Camera object defined for the scene
         """
         # no camera set for the scene yet
-        if not hasattr(self, '_camera') or self._camera is None:
+        if not self.has_camera:
             # will create a camera with everything in view
             return self.set_camera()
         assert self._camera is not None
@@ -669,6 +669,10 @@ class Scene(Geometry):
         if camera is None:
             return
         self._camera = camera
+
+    @property
+    def has_camera(self):
+        return hasattr(self, '_camera') and self._camera is not None
 
     @property
     def lights(self):


### PR DESCRIPTION
Simply skips the camera if none is in the scene. This wasn't a big problem, but was a little messy as the gltf was being exported with a default camera regardless of whether one was added in trimesh.