### PR TITLE
Add cap argument to slice_plane

### DIFF
--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -140,7 +140,7 @@ class SliceTest(g.unittest.TestCase):
         mesh = g.trimesh.creation.box()
 
         # Cut corner off of box and make sure the bounds and number of faces is correct
-        # (Tests new triangles, but not new quads or triangles contained entirely)
+        # Tests new triangles, but not new quads or triangles contained entirely
         plane_origin = mesh.bounds[1] - 0.05
         plane_normal = mesh.bounds[1]
 
@@ -150,6 +150,16 @@ class SliceTest(g.unittest.TestCase):
         assert g.np.isclose(sliced.bounds[0], mesh.bounds[1] - 0.15).all()
         assert g.np.isclose(sliced.bounds[1], mesh.bounds[1]).all()
         assert len(sliced.faces) == 5
+
+        # Same test with capping (should only add three more triangles)
+        sliced_capped = mesh.slice_plane(plane_origin=plane_origin,
+                                         plane_normal=plane_normal,
+                                         cap=True)
+
+        assert len(sliced_capped.faces) == 8
+        assert g.np.isclose(sliced_capped.bounds[0], mesh.bounds[1] - 0.15).all()
+        assert g.np.isclose(sliced_capped.bounds[1], mesh.bounds[1]).all()
+        assert sliced_capped.is_watertight
 
         # Cut top off of box and make sure bounds and number of faces is correct
         # Tests new quads and entirely contained triangles
@@ -163,6 +173,17 @@ class SliceTest(g.unittest.TestCase):
             sliced.bounds[0], mesh.bounds[0] + g.np.array([0, 0, 0.95])).all()
         assert g.np.isclose(sliced.bounds[1], mesh.bounds[1]).all()
         assert len(sliced.faces) == 14
+
+        # Same test with capping (should only add six triangles)
+        sliced_capped = mesh.slice_plane(plane_origin=plane_origin,
+                                         plane_normal=plane_normal,
+                                         cap=True)
+
+        assert len(sliced_capped.faces) == 20
+        assert g.np.isclose(
+            sliced_capped.bounds[0], mesh.bounds[0] + g.np.array([0, 0, 0.95])).all()
+        assert g.np.isclose(sliced_capped.bounds[1], mesh.bounds[1]).all()
+        assert sliced_capped.is_watertight
 
         # non- watertight more complex mesh
         bunny = g.get_mesh('bunny.ply')
@@ -192,6 +213,18 @@ class SliceTest(g.unittest.TestCase):
         assert g.np.isclose(sliced.bounds[1], mesh.bounds[1]).all()
         assert len(sliced.faces) == 11
 
+        # Test cap for multiple slices to check watertightness 
+        # (should add nine triangles)
+        sliced_capped = mesh.slice_plane(plane_origin=plane_origins,
+                                         plane_normal=plane_normals,
+                                         cap=True)
+        
+        assert len(sliced_capped.faces) == 20
+        assert g.np.isclose(
+            sliced_capped.bounds[0], mesh.bounds[0] + g.np.array([0, 0.95, 0.95])).all()
+        assert g.np.isclose(sliced_capped.bounds[1], mesh.bounds[1]).all()
+        assert sliced_capped.is_watertight
+
         # Try with more complicated mesh and make sure we get correct projections
         # and some faces
         origins = [bunny.bounds.mean(axis=0), bunny.bounds.mean(
@@ -205,6 +238,27 @@ class SliceTest(g.unittest.TestCase):
         for o, n in zip(origins, normals):
             # check the projections manually
             dot = g.np.dot(n, (sliced.vertices - o).T)
+            # should be lots of stuff at the plane and nothing behind
+            assert g.np.isclose(dot.min(), 0.0)
+
+        
+        # Test cap on more complicated watertight mesh to make sure the 
+        # resulting mesh is still watertight and slice is correct
+        featuretype = g.get_mesh('featuretype.STL')
+        
+        origins = [featuretype.center_mass, featuretype.center_mass 
+                    + 0.01 * g.trimesh.unitize([1, 0, 2])]
+        normals = [g.trimesh.unitize([1, 1, 1]), g.trimesh.unitize([1, 2, 3])]
+
+        sliced_capped = featuretype.slice_plane(plane_origin=origins,
+                                                plane_normal=normals,
+                                                cap=True)
+        
+        assert len(sliced_capped.faces) > 0
+        assert sliced_capped.is_watertight
+        for o, n in zip(origins, normals):
+            # check the projections manually
+            dot = g.np.dot(n, (sliced_capped.vertices - o).T)
             # should be lots of stuff at the plane and nothing behind
             assert g.np.isclose(dot.min(), 0.0)
 

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1982,7 +1982,8 @@ class Trimesh(Geometry):
 
     def section(self,
                 plane_normal,
-                plane_origin):
+                plane_origin,
+                **kwargs):
         """
         Returns a 3D cross section of the current mesh and a plane
         defined by origin and normal.
@@ -2007,7 +2008,8 @@ class Trimesh(Geometry):
             mesh=self,
             plane_normal=plane_normal,
             plane_origin=plane_origin,
-            return_faces=True)
+            return_faces=True,
+            **kwargs)
 
         # if the section didn't hit the mesh return None
         if len(lines) == 0:


### PR DESCRIPTION
Adds the cap argument to allow for watertight meshes after slicing. Some minor other updates for consistency (replaced try/except with unique_bincount, allow section to take cached dots). 

There is probably a faster way to implement this cap arg; open to suggestions! Right now, it takes the slice_plane function from  ~2 ms on my laptop to ~85 ms when adding a cap. From some basic profiling, it seems like this could be significantly faster if there was a good way to triangulate without the sectioning/polygon conversion. The sectioning can already be done in slice_faces_plane (we can easily get the edges that make up the 3D path), but I couldn't think of a good way to replace the polygon creation. 

```python
In [1]: import trimesh                                               
In [2]: m = trimesh.load('models/featuretype.STL')               
In [3]: origin = [m.center_mass, m.center_mass]
In [4]: normal = [trimesh.unitize([1,1,1]), trimesh.unitize([1,2,3])]
In [5]: %timeit sliced = m.slice_plane(plane_origin=origin, plane_normal=normal, cap=True)                                        
85.5 ms ± 477 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
In [6]: %timeit sliced = m.slice_plane(plane_origin=origin, plane_normal=normal)                                                  
2.35 ms ± 29.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

```python
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
681         6         25.0      4.2      0.0              path = sliced_mesh.section(plane_normal=normal,
682         6         15.0      2.5      0.0                                         plane_origin=origin,
683         6      44398.0   7399.7     20.5                                         cached_dots=dots)
684                                                       
685                                                       # transform Path3D onto XY plane for triangulation
686         6      10778.0   1796.3      5.0              on_plane, to_3D = path.to_planar()
687                                           
688                                                       # triangulate each closed region of 2D cap
689                                                       # without adding any new vertices
690         6         29.0      4.8      0.0              v, f = [], []
691        12      61019.0   5084.9     28.2              for polygon in on_plane.polygons_full:
692         6         31.0      5.2      0.0                  t = triangulate_polygon(polygon, 
693         6         18.0      3.0      0.0                                          triangle_args='p', 
694         6      30608.0   5101.3     14.1                                          allow_boundary_steiner=False)
695         6         37.0      6.2      0.0                  v.append(t[0])
696         6         25.0      4.2      0.0                  f.append(t[1])
```

