### PR TITLE
adapting to_planar for generic normal cases

### DIFF
--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -315,8 +315,8 @@ def minimum_cylinder(obj, sample_count=6, angle_tol=.001):
             origin = obj.convex_hull.center_mass
         # will align symmetry axis with Z and move origin to zero
         to_2D = geometry.plane_transform(
-            origin,
-            obj.symmetry_axis)
+            origin=origin,
+            normal=obj.symmetry_axis)
         # transform vertices to plane to check
         on_plane = transformations.transform_points(
             obj.vertices, to_2D)

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -315,8 +315,8 @@ def minimum_cylinder(obj, sample_count=6, angle_tol=.001):
             origin = obj.convex_hull.center_mass
         # will align symmetry axis with Z and move origin to zero
         to_2D = geometry.plane_transform(
-            origin=origin,
-            normal=obj.symmetry_axis)
+            origin,
+            obj.symmetry_axis)
         # transform vertices to plane to check
         on_plane = transformations.transform_points(
             obj.vertices, to_2D)

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -31,8 +31,10 @@ def plane_transform(origin, normal, destination_normal=None):
         destination plane
     """
     if destination_normal is None:
-        destination_normal = normal
-    transform = align_vectors(normal, destination_normal)
+        dn = normal
+    else:
+        dn = destination_normal
+    transform = align_vectors(normal, dn)
     transform[0:3, 3] = -np.dot(transform,
                                 np.append(origin, 1))[0:3]
     return transform

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -11,7 +11,7 @@ except BaseException as E:
     scipy = exceptions.ExceptionModule(E)
 
 
-def plane_transform(origin, normal, destination_normal):
+def plane_transform(origin, normal, destination_normal=None):
     """
     Given the origin and normal of a plane find the transform
     that will move that plane to be coplanar with the

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -11,10 +11,11 @@ except BaseException as E:
     scipy = exceptions.ExceptionModule(E)
 
 
-def plane_transform(origin, normal):
+def plane_transform(origin, normal, destination_normal):
     """
     Given the origin and normal of a plane find the transform
-    that will move that plane to be coplanar with the XY plane.
+    that will move that plane to be coplanar with the
+    destination plane (default is the provided normal plane).
 
     Parameters
     ----------
@@ -26,9 +27,12 @@ def plane_transform(origin, normal):
     Returns
     ---------
     transform: (4,4) float
-        Transformation matrix to move points onto XY plane
+        Transformation matrix to move points onto
+        destination plane
     """
-    transform = align_vectors(normal, [0, 0, 1])
+    if destination_normal is None:
+        destination_normal = normal
+    transform = align_vectors(normal, destination_normal)
     transform[0:3, 3] = -np.dot(transform,
                                 np.append(origin, 1))[0:3]
     return transform

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -949,7 +949,7 @@ class Path3D(Path):
         normal_test = False
         for i in [[1, 0, 0], [0, 1, 0], [0, 0, 1],
                   [-1, 0, 0], [0, -1, 0], [0, 0, -1]]:
-            if not np.any(gm.align_vectors(dn, i) - np.eye(4)) :
+            if not np.any(align_vectors(dn, i) - np.eye(4)):
                 normal_test = True
         if normal_test is False:
             raise ValueError('normal does not align with major axis')
@@ -994,7 +994,7 @@ class Path3D(Path):
 
         # create the Path2D with the same entities
         # and planar values of vertices
-        planar_columns = [0,1,2]
+        planar_columns = [0, 1, 2]
         planar_columns.remove(axis)
         planar = Path2D(entities=copy.deepcopy(self.entities),
                         vertices=flat[:, planar_columns],

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -935,7 +935,7 @@ class Path3D(Path):
                 dn = N
             # eliminate calculation errors
             C, N, dn = util.snap_to(C), util.snap_to(N),
-                                            util.snap_to(dn)
+                                    util.snap_to(dn)
             # create a transform from fit plane to destination plane
             to_2D = plane_transform(origin=C,
                                     normal=N,

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -933,7 +933,7 @@ class Path3D(Path):
                 dn = N
             # create a transform from fit plane to destination plane
             to_2D = plane_transform(origin=C,
-                                    normal=N
+                                    normal=N,
                                     destination_normal=dn)
 
         # make sure we've extracted a transform

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -12,7 +12,6 @@ import collections
 
 from ..points import plane_fit
 from ..geometry import plane_transform
-from ..geometry import align_vectors
 from ..visual import to_rgba
 from ..constants import log
 from ..constants import tol_path as tol
@@ -935,7 +934,7 @@ class Path3D(Path):
 
         # align to normal if included
         if normal is not None:
-            normal = np.asanyarray(unitize(normal), dtype=np.float64)
+            normal = np.asanyarray(utilunitize(normal), dtype=np.float64)
             if normal.shape == (3,):
                 dn = normal.copy()
             else:
@@ -944,17 +943,17 @@ class Path3D(Path):
                         normal.shape))
         # otherwise use normal from fit plane
         else:
-            dn = unitize(N)
+            dn = util.unitize(N)
 
         # check if destination normal is a unit normal
         # and see if normal aligns with X, Y, or Z axis
         axis = []
-        normal_check = isclose(np.abs(unitize(dn)), np.eye(3)).all(axis=1)
+        normal_check = uitl.isclose(np.abs(util.unitize(dn)), np.eye(3)).all(axis=1)
         if normal_check.any():
             axis = list(np.flatnonzero(normal_check))[0]
         elif default_Z:
             axis = 2
-            dn = np.asanyarray([0,0,1])
+            dn = np.asanyarray([0, 0, 1])
 
         # find final transform to 2D
         to_2D = plane_transform(origin=C,
@@ -984,7 +983,6 @@ class Path3D(Path):
         else:
             raise ValueError(
                 "points may be flat but normal does not align with major axis")
-
 
         # the transform from 2D to 3D
         to_3D = np.linalg.inv(to_2D)

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -934,8 +934,7 @@ class Path3D(Path):
             else:
                 dn = N
             # eliminate calculation errors
-            C, N, dn = util.snap_to(C), util.snap_to(N),
-                                    util.snap_to(dn)
+            C, N, dn = util.snap_to(C), util.snap_to(N), util.snap_to(dn)
             # create a transform from fit plane to destination plane
             to_2D = plane_transform(origin=C,
                                     normal=N,

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -933,6 +933,8 @@ class Path3D(Path):
             # otherwise use normal from fit plane
             else:
                 dn = N
+            #eliminate calculation errors
+            C, N, dn = snap_to(C), snap_to(N), snap_to(dn)
             # create a transform from fit plane to destination plane
             to_2D = plane_transform(origin=C,
                                     normal=N,

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -948,7 +948,7 @@ class Path3D(Path):
         # check if destination normal is a unit normal
         # and see if normal aligns with X, Y, or Z axis
         axis = []
-        normal_check = util.isclose(np.abs(util.unitize(dn)), np.eye(3)).all(axis=1)
+        normal_check = util.isclose(np.abs(util.unitize(dn)), np.eye(3), tol.zero).all(axis=1)
         if normal_check.any():
             axis = list(np.flatnonzero(normal_check))[0]
         elif default_Z:

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -12,6 +12,7 @@ import collections
 
 from ..points import plane_fit
 from ..geometry import plane_transform
+from ..geometry import align_vectors
 from ..visual import to_rgba
 from ..constants import log
 from ..constants import tol_path as tol

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -948,7 +948,8 @@ class Path3D(Path):
         # check if destination normal is a unit normal
         # and see if normal aligns with X, Y, or Z axis
         axis = []
-        normal_check = util.isclose(np.abs(util.unitize(dn)), np.eye(3), tol.zero).all(axis=1)
+        normal_check = util.isclose(np.abs(util.unitize(dn)),
+                                    np.eye(3), tol.zero).all(axis=1)
         if normal_check.any():
             axis = list(np.flatnonzero(normal_check))[0]
         elif default_Z:

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -934,7 +934,7 @@ class Path3D(Path):
 
         # align to normal if included
         if normal is not None:
-            normal = np.asanyarray(utilunitize(normal), dtype=np.float64)
+            normal = np.asanyarray(util.unitize(normal), dtype=np.float64)
             if normal.shape == (3,):
                 dn = normal.copy()
             else:
@@ -948,7 +948,7 @@ class Path3D(Path):
         # check if destination normal is a unit normal
         # and see if normal aligns with X, Y, or Z axis
         axis = []
-        normal_check = uitl.isclose(np.abs(util.unitize(dn)), np.eye(3)).all(axis=1)
+        normal_check = util.isclose(np.abs(util.unitize(dn)), np.eye(3)).all(axis=1)
         if normal_check.any():
             axis = list(np.flatnonzero(normal_check))[0]
         elif default_Z:

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -893,9 +893,11 @@ class Path3D(Path):
             Homogeneous transformation matrix to apply,
             If not passed a plane will be fitted to vertices.
         normal: (3,) float, or None
-           Approximate normal of direction of plane
-           If to_2D is not specified sign
-           will be applied to fit plane normal
+           Assigned normal of direction of plane.
+           If to_2D is not specified
+           and normal not specified, it
+           will be to fit plane normal
+           of passed points.
         check:  bool
             If True: Raise a ValueError if
             points aren't coplanar
@@ -922,15 +924,17 @@ class Path3D(Path):
             if normal is not None:
                 normal = np.asanyarray(normal, dtype=np.float64)
                 if normal.shape == (3,):
-                    N *= np.sign(np.dot(N, normal))
-                    N = normal
+                    dn = normal
                 else:
                     log.warning(
                         "passed normal not used: {}".format(
                             normal.shape))
-            # create a transform from fit plane to XY
+            else:
+                dn = N
+            # create a transform from fit plane to destination plane
             to_2D = plane_transform(origin=C,
-                                    normal=N)
+                                    normal=N
+                                    destination_normal = dn)
 
         # make sure we've extracted a transform
         to_2D = np.asanyarray(to_2D, dtype=np.float64)

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -908,8 +908,8 @@ class Path3D(Path):
         to_3D :  (4,4) float
                    Homeogenous transformations to move planar
                    back into 3D space.
-                   
         """
+
         # which vertices are actually referenced
         referenced = self.referenced_vertices
         # if nothing is referenced return an empty path
@@ -929,14 +929,14 @@ class Path3D(Path):
                     log.warning(
                         "passed normal not used: {}".format(
                             normal.shape))
-            #otherwise use normal from fit plane
+            # otherwise use normal from fit plane
             else:
                 dn = N
             # create a transform from fit plane to destination plane
             to_2D = plane_transform(origin=C,
                                     normal=N,
                                     destination_normal=dn)
-        else if normal is not None:
+        elif normal is not None:
             log.warning("passed normal not used: {}".format(
                 normal.shape))
 
@@ -944,17 +944,18 @@ class Path3D(Path):
         to_2D = np.asanyarray(to_2D, dtype=np.float64)
         if to_2D.shape != (4, 4):
             raise ValueError('unable to create transform!')
-            
+
         # make sure normal aligns with X, Y, or Z axis
         normal_test = False
-        for i in [[1,0,0],[0,1,0],[0,0,1],[-1,0,0],[0,-1,0],[0,0,-1]]:
-            if not np.any(gm.align_vectors(dn,i) - np.eye(4)) :
+        for i in [[1, 0, 0], [0, 1, 0], [0, 0, 1],
+                  [-1, 0, 0], [0, -1, 0], [0, 0, -1]]:
+            if not np.any(gm.align_vectors(dn, i) - np.eye(4)) :
                 normal_test = True
-        if normal_test == False:
+        if normal_test is False:
             raise ValueError('normal does not align with major axis')
-            
+
         # set axis
-        axis = np.where(np.abs(dn)==1)[0][0]
+        axis = np.where(np.abs(dn) == 1)[0][0]
 
         # transform all vertices to 2D plane
         flat = tf.transform_points(self.vertices,
@@ -979,7 +980,7 @@ class Path3D(Path):
         # exactly axis=0 adjust it so the returned transform does
         if np.abs(height) > tol.planar:
             # adjust to_3D transform by height
-            height_adjust = [0,0,0]
+            height_adjust = [0, 0, 0]
             height_adjust[axis] = height
             adjust = tf.translation_matrix(
                 height_adjust)

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -933,8 +933,9 @@ class Path3D(Path):
             # otherwise use normal from fit plane
             else:
                 dn = N
-            #eliminate calculation errors
-            C, N, dn = snap_to(C), snap_to(N), snap_to(dn)
+            # eliminate calculation errors
+            C, N, dn = util.snap_to(C), util.snap_to(N),
+                                            util.snap_to(dn)
             # create a transform from fit plane to destination plane
             to_2D = plane_transform(origin=C,
                                     normal=N,

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -934,7 +934,7 @@ class Path3D(Path):
             # create a transform from fit plane to destination plane
             to_2D = plane_transform(origin=C,
                                     normal=N
-                                    destination_normal = dn)
+                                    destination_normal=dn)
 
         # make sure we've extracted a transform
         to_2D = np.asanyarray(to_2D, dtype=np.float64)

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -113,7 +113,7 @@ def unitize(vectors,
         # round away inaccuracies if close to zero
         unit_round = unit.round()
         check_if_close = isclose(unit, unit_round,
-            atol=threshold).all(axis=1).reshape((-1,1))
+                    atol=threshold).all(axis=1).reshape((-1, 1))
         unit = np.where(check_if_close, unit_round, unit.copy())
 
     elif len(vectors.shape) == 1:

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1728,6 +1728,7 @@ def snap_to(array, tolerance=TOL_ZERO):
       Array with values rounded to order of magnitude of tolerance
       value if all are within tolerance of original values.
     """
+    from .caching import tracked_array
     array = np.asanyarray(array)
     if np.log10(tolerance) <= 0:
         mod = 0
@@ -1738,7 +1739,7 @@ def snap_to(array, tolerance=TOL_ZERO):
     if isclose(array, rounded_array, atol=tolerance).all():
         array = rounded_array
 
-    return array
+    return tracked_array(array)
 
 
 def sigfig_round(values, sigfig=1):

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1735,7 +1735,7 @@ def snap_to(array, tolerance=TOL_ZERO):
         mod = 1
     rounded_array = array.round(-np.int(mod + np.fix(
                                             np.log10(tolerance))))
-    snap = isclose(array, rounded_array, atol = tolerance).all()
+    snap = isclose(array, rounded_array, atol=tolerance).all()
     if snap:
         array = rounded_array
 

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -112,9 +112,9 @@ def unitize(vectors,
         unit = vectors * norm.reshape((-1, 1))
         # round away inaccuracies if close to zero
         unit_round = unit.round()
-        check_if_close = isclose(unit, unit_round,
-                    atol=threshold).all(axis=1).reshape((-1, 1))
-        unit = np.where(check_if_close, unit_round, unit.copy())
+        close_check = isclose(unit, unit_round,
+                              atol=threshold).all(axis=1).reshape((-1, 1))
+        unit = np.where(close_check, unit_round, unit.copy())
 
     elif len(vectors.shape) == 1:
         # treat 1D arrays as a single vector

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1705,13 +1705,14 @@ def wrap_as_stream(item):
         return BytesIO(item)
     raise ValueError('{} is not wrappable!'.format(type(item).__name__))
 
+
 def snap_to(array, tolerance=TOL_ZERO):
     """
     Input array is rounded to the order of magnitude one larger than
     the order of magnitude of the tolerance value. If all elements in
     the rounded array are within the tolerance value of the original
     array, the rounded array is returned.
-    
+
     Parameters
     ---------
     array : (n, m) float
@@ -1719,7 +1720,7 @@ def snap_to(array, tolerance=TOL_ZERO):
     tolerance: (1,) float
       Tolerance used to compute rounded array and to check whether
       rounded elements are within tolerance of original array.
-      
+
     Returns
     ---------
     Array : (n,m) float
@@ -1737,8 +1738,9 @@ def snap_to(array, tolerance=TOL_ZERO):
     snap = isclose(array, rounded_array, atol = tolerance).all()
     if snap:
         array = rounded_array
-    
+
     return array
+
 
 def sigfig_round(values, sigfig=1):
     """

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1736,7 +1736,7 @@ def snap_to(array, tolerance=TOL_ZERO):
     rounded_array = array.round(-np.int(mod + np.fix(
                                             np.log10(tolerance))))
     snap = isclose(array, rounded_array, atol=tolerance).all()
-    if snap:
+    if snap is True:
         array = rounded_array
 
     return array

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -110,6 +110,11 @@ def unitize(vectors,
         norm[valid] **= -1
         # multiply by reciprocal of norm
         unit = vectors * norm.reshape((-1, 1))
+        # round away inaccuracies if close to zero
+        unit_round = unit.round()
+        check_if_close = isclose(unit,unit_round,
+                  atol=threshold).all(axis=1).reshape((-1,1))
+        unit = np.where(check_if_close,unit_round,unit.copy())
 
     elif len(vectors.shape) == 1:
         # treat 1D arrays as a single vector
@@ -117,6 +122,11 @@ def unitize(vectors,
         valid = norm > threshold
         if valid:
             unit = vectors / norm
+            # round away inaccuracies if close to zero
+            unit_round = unit.round()
+            if isclose(unit, unit_round,
+                                    atol=threshold).all():
+                unit = unit_round
         else:
             unit = vectors.copy()
     else:

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1705,6 +1705,40 @@ def wrap_as_stream(item):
         return BytesIO(item)
     raise ValueError('{} is not wrappable!'.format(type(item).__name__))
 
+def snap_to(array, tolerance=TOL_ZERO):
+    """
+    Input array is rounded to the order of magnitude one larger than
+    the order of magnitude of the tolerance value. If all elements in
+    the rounded array are within the tolerance value of the original
+    array, the rounded array is returned.
+    
+    Parameters
+    ---------
+    array : (n, m) float
+      Array of floats
+    tolerance: (1,) float
+      Tolerance used to compute rounded array and to check whether
+      rounded elements are within tolerance of original array.
+      
+    Returns
+    ---------
+    Array : (n,m) float
+      Original values if tolerance test fails.
+      Array with values rounded to order of magnitude of tolerance
+      value if all are within tolerance of original values.
+    """
+    array = np.asanyarray(array)
+    if np.log10(tolerance) <= 0:
+        mod = 0
+    else:
+        mod = 1
+    rounded_array = array.round(-np.int(mod + np.fix(
+                                            np.log10(tolerance))))
+    snap = isclose(array, rounded_array, atol = tolerance).all()
+    if snap:
+        array = rounded_array
+    
+    return array
 
 def sigfig_round(values, sigfig=1):
     """

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -112,9 +112,9 @@ def unitize(vectors,
         unit = vectors * norm.reshape((-1, 1))
         # round away inaccuracies if close to zero
         unit_round = unit.round()
-        check_if_close = isclose(unit,unit_round,
-                  atol=threshold).all(axis=1).reshape((-1,1))
-        unit = np.where(check_if_close,unit_round,unit.copy())
+        check_if_close = isclose(unit, unit_round,
+            atol=threshold).all(axis=1).reshape((-1,1))
+        unit = np.where(check_if_close, unit_round, unit.copy())
 
     elif len(vectors.shape) == 1:
         # treat 1D arrays as a single vector
@@ -124,8 +124,7 @@ def unitize(vectors,
             unit = vectors / norm
             # round away inaccuracies if close to zero
             unit_round = unit.round()
-            if isclose(unit, unit_round,
-                                    atol=threshold).all():
+            if isclose(unit, unit_round, atol=threshold).all():
                 unit = unit_round
         else:
             unit = vectors.copy()

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1736,8 +1736,8 @@ def snap_to(array, tolerance=TOL_ZERO):
         mod = 1
     rounded_array = array.round(-np.int(mod + np.fix(
                                             np.log10(tolerance))))
-    snap = util.isclose(array, rounded_array, atol=tolerance).all()
-    if snap == True:
+    snap = isclose(array, rounded_array, atol=tolerance).all()
+    if snap:
         array = rounded_array
 
     return array

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1728,7 +1728,6 @@ def snap_to(array, tolerance=TOL_ZERO):
       Array with values rounded to order of magnitude of tolerance
       value if all are within tolerance of original values.
     """
-    from .caching import tracked_array
     array = np.asanyarray(array)
     if np.log10(tolerance) <= 0:
         mod = 0
@@ -1739,7 +1738,7 @@ def snap_to(array, tolerance=TOL_ZERO):
     if isclose(array, rounded_array, atol=tolerance).all():
         array = rounded_array
 
-    return tracked_array(array)
+    return array
 
 
 def sigfig_round(values, sigfig=1):

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1728,6 +1728,7 @@ def snap_to(array, tolerance=TOL_ZERO):
       Array with values rounded to order of magnitude of tolerance
       value if all are within tolerance of original values.
     """
+    snap = False
     array = np.asanyarray(array)
     if np.log10(tolerance) <= 0:
         mod = 0
@@ -1735,8 +1736,8 @@ def snap_to(array, tolerance=TOL_ZERO):
         mod = 1
     rounded_array = array.round(-np.int(mod + np.fix(
                                             np.log10(tolerance))))
-    snap = isclose(array, rounded_array, atol=tolerance).all()
-    if snap is True:
+    snap = util.isclose(array, rounded_array, atol=tolerance).all()
+    if snap == True:
         array = rounded_array
 
     return array

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1728,16 +1728,14 @@ def snap_to(array, tolerance=TOL_ZERO):
       Array with values rounded to order of magnitude of tolerance
       value if all are within tolerance of original values.
     """
-    snap = False
     array = np.asanyarray(array)
     if np.log10(tolerance) <= 0:
         mod = 0
     else:
         mod = 1
     rounded_array = array.round(-np.int(mod + np.fix(
-                                            np.log10(tolerance))))
-    snap = isclose(array, rounded_array, atol=tolerance).all()
-    if snap:
+                                        np.log10(tolerance))))
+    if isclose(array, rounded_array, atol=tolerance).all():
         array = rounded_array
 
     return array

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1706,41 +1706,6 @@ def wrap_as_stream(item):
     raise ValueError('{} is not wrappable!'.format(type(item).__name__))
 
 
-def snap_to(array, tolerance=TOL_ZERO):
-    """
-    Input array is rounded to the order of magnitude one larger than
-    the order of magnitude of the tolerance value. If all elements in
-    the rounded array are within the tolerance value of the original
-    array, the rounded array is returned.
-
-    Parameters
-    ---------
-    array : (n, m) float
-      Array of floats
-    tolerance: (1,) float
-      Tolerance used to compute rounded array and to check whether
-      rounded elements are within tolerance of original array.
-
-    Returns
-    ---------
-    Array : (n,m) float
-      Original values if tolerance test fails.
-      Array with values rounded to order of magnitude of tolerance
-      value if all are within tolerance of original values.
-    """
-    array = np.asanyarray(array)
-    if np.log10(tolerance) <= 0:
-        mod = 0
-    else:
-        mod = 1
-    rounded_array = array.round(-np.int(mod + np.fix(
-                                        np.log10(tolerance))))
-    if isclose(array, rounded_array, atol=tolerance).all():
-        array = rounded_array
-
-    return array
-
-
 def sigfig_round(values, sigfig=1):
     """
     Round a single value to a specified number of significant figures.


### PR DESCRIPTION
Maybe not the most elegant solution, but should fix problems with plane_transform behavior for this function, and allow for rotation during planar transforms.  May have eliminated functionality with removal of (N *= np.sign(np.dot(N, normal)).