### PR TITLE
Plane_transform modified for passing explicit normal

### DIFF
--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -11,10 +11,10 @@ except BaseException as E:
     scipy = exceptions.ExceptionModule(E)
 
 
-def plane_transform(origin, normal, destination_normal=[0,0,1]):
+def plane_transform(origin, normal, destination_normal=normal):
     """
     Given the origin and normal of a plane find the transform
-    that will move that plane to be coplanar with the destination plane (default is the XY plane).
+    that will move that plane to be coplanar with the destination plane (default is the provided normal plane).
 
     Parameters
     ----------

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -11,10 +11,10 @@ except BaseException as E:
     scipy = exceptions.ExceptionModule(E)
 
 
-def plane_transform(origin, normal):
+def plane_transform(origin, normal, destination_normal=[0,0,1]):
     """
     Given the origin and normal of a plane find the transform
-    that will move that plane to be coplanar with the XY plane.
+    that will move that plane to be coplanar with the destination plane (default is the XY plane).
 
     Parameters
     ----------
@@ -28,7 +28,8 @@ def plane_transform(origin, normal):
     transform: (4,4) float
         Transformation matrix to move points onto XY plane
     """
-    transform = align_vectors(normal, [0, 0, 1])
+    
+    transform = align_vectors(normal, destination_normal)
     transform[0:3, 3] = -np.dot(transform,
                                 np.append(origin, 1))[0:3]
     return transform

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -27,7 +27,7 @@ def plane_transform(origin, normal, destination_normal):
     Returns
     ---------
     transform: (4,4) float
-        Transformation matrix to move points onto 
+        Transformation matrix to move points onto
         destination plane
     """
     if destination_normal is None:

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -29,8 +29,8 @@ def plane_transform(origin, normal, destination_normal):
     transform: (4,4) float
         Transformation matrix to move points onto XY plane
     """
-    if destination_normal==None:
-        destination_normal=normal
+    if destination_normal is None:
+        destination_normal = normal
     transform = align_vectors(normal, destination_normal)
     transform[0:3, 3] = -np.dot(transform,
                                 np.append(origin, 1))[0:3]

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -11,10 +11,11 @@ except BaseException as E:
     scipy = exceptions.ExceptionModule(E)
 
 
-def plane_transform(origin, normal, destination_normal=normal):
+def plane_transform(origin, normal, destination_normal):
     """
     Given the origin and normal of a plane find the transform
-    that will move that plane to be coplanar with the destination plane (default is the provided normal plane).
+    that will move that plane to be coplanar with the 
+    destination plane (default is the provided normal plane).
 
     Parameters
     ----------
@@ -28,7 +29,8 @@ def plane_transform(origin, normal, destination_normal=normal):
     transform: (4,4) float
         Transformation matrix to move points onto XY plane
     """
-    
+    if destination_normal==None:
+        destination_normal=normal
     transform = align_vectors(normal, destination_normal)
     transform[0:3, 3] = -np.dot(transform,
                                 np.append(origin, 1))[0:3]

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -14,7 +14,7 @@ except BaseException as E:
 def plane_transform(origin, normal, destination_normal):
     """
     Given the origin and normal of a plane find the transform
-    that will move that plane to be coplanar with the 
+    that will move that plane to be coplanar with the
     destination plane (default is the provided normal plane).
 
     Parameters
@@ -27,7 +27,8 @@ def plane_transform(origin, normal, destination_normal):
     Returns
     ---------
     transform: (4,4) float
-        Transformation matrix to move points onto XY plane
+        Transformation matrix to move points onto 
+        destination plane
     """
     if destination_normal is None:
         destination_normal = normal


### PR DESCRIPTION
Modified plane_transform so the transform defaults to the provided plane normal, but which allows for a destination normal to be included in the transform. I'm not entirely clear on why anybody would want to modify the normal of the plane this far downstream; I would personally think people would have modified the normal before this point, but decided to maintain the functionality of plane_transform in order to avoid functionality conflicts I'm not aware of. 