### PR TITLE
Fix transparency bug in DAE exchange

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -312,7 +312,7 @@ def _parse_material(effect, resolver):
     # Compute opacity
     if (effect.transparent is not None
             and not isinstance(effect.transparent, collada.material.Map)):
-        baseColorFactor = tuple(np.append(baseColorFactor[:3], effect.transparent[3]))
+        baseColorFactor = tuple(np.append(baseColorFactor[:3], float(int(255 * effect.transparent[3]))))
 
     return visual.material.PBRMaterial(
         emissiveFactor=emissiveFactor,


### PR DESCRIPTION
Hi Mike,

Happy Memorial Day! I noticed that my prior PR introduced a bug in the DAE importer/exporter. I assumed that transparency was listed as 0-255, but it's actually 0-1. This bug resulted in loaded/saved meshes "disappearing" unexpectedly. This simple PR should fix the issue.

Best,
Matt