### PR TITLE
Add without_world axis state to the viewer

### DIFF
--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -469,7 +469,7 @@ class SceneViewer(pyglet.window.Window):
         off, world frame, every frame
         """
         # cycle through three axis states
-        states = [False, 'world', 'all']
+        states = [False, 'world', 'all', 'without_world']
         # the state after toggling
         index = (states.index(self.view['axis']) + 1) % len(states)
         # update state to next index
@@ -686,7 +686,7 @@ class SceneViewer(pyglet.window.Window):
         count = -1
 
         # if we are rendering an axis marker at the world
-        if self._axis:
+        if self._axis and not self.view['axis'] == 'without_world':
             # we stored it as a vertex list
             self._axis.draw(mode=gl.GL_TRIANGLES)
         if self._grid:
@@ -740,6 +740,9 @@ class SceneViewer(pyglet.window.Window):
             # draw an axis marker for each mesh frame
             if self.view['axis'] == 'all':
                 self._axis.draw(mode=gl.GL_TRIANGLES)
+            elif self.view['axis'] == 'without_world':
+                if count > 0:
+                    self._axis.draw(mode=gl.GL_TRIANGLES)
 
             # transparent things must be drawn last
             if (hasattr(mesh, 'visual') and


### PR DESCRIPTION
The current viewer has 'world' and 'all' in the display state of axis. If set it to'all', it can display all coordinates I added with the world axis. But I'm confused because I don't know which one I added. So in this PR I added a state of 'without_world' so that I can only see added coordinates.

![world](https://user-images.githubusercontent.com/39142679/84399869-51e1f700-ac3c-11ea-9fde-f3da7ca795b0.png)
state 'world'  

![all](https://user-images.githubusercontent.com/39142679/84399884-54445100-ac3c-11ea-894e-72ef927b7063.png)
state 'all'  

![without_world](https://user-images.githubusercontent.com/39142679/84399895-56a6ab00-ac3c-11ea-8b06-96ac571582c7.png)
state 'without_world'
