### PR TITLE
Re-enable fix_inversion

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -43,6 +43,21 @@ class MeshTests(g.unittest.TestCase):
         assert len(m.vertices) == pre_len
         assert g.np.isclose(m.volume, pre_vol)
 
+    def test_validate_inversion(self):
+        """Make sure inverted meshes are fixed by `validate=True`"""
+        orig_mesh = g.get_mesh("unit_cube.STL")
+        orig_verts = orig_mesh.vertices.copy()
+        orig_faces = orig_mesh.faces.copy()
+
+        orig_face_set = {tuple(row) for row in orig_faces}
+
+        inv_faces = orig_faces[:, ::-1]
+        inv_mesh = g.Trimesh(orig_verts, inv_faces, validate=False)
+        assert {tuple(row) for row in inv_mesh.faces} != orig_face_set
+
+        fixed_mesh = g.Trimesh(orig_verts, inv_faces, validate=True)
+        assert {tuple(row) for row in fixed_mesh.faces} == orig_face_set
+
     def test_none(self):
         """
         Make sure mesh methods don't return None or crash.

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -104,6 +104,21 @@ class RepairTests(g.unittest.TestCase):
         # print timings as a warning
         g.log.warning(g.json.dumps(timing, indent=4))
 
+    def test_inversion(self):
+        """Make sure fix_inversion switches all reversed faces back"""
+        orig_mesh = g.get_mesh("unit_cube.STL")
+        orig_verts = orig_mesh.vertices.copy()
+        orig_faces = orig_mesh.faces.copy()
+
+        mesh = g.Trimesh(orig_verts, orig_faces[:, ::-1])
+        inv_faces = mesh.faces.copy()
+        # check not fixed on the way in
+        assert not g.np.allclose(inv_faces, orig_faces)
+
+        g.trimesh.repair.fix_inversion(mesh)
+        assert not g.np.allclose(mesh.faces, inv_faces)
+        assert g.np.allclose(mesh.faces, orig_faces)
+
     def test_multi(self):
         """
         Try repairing a multibody geometry

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -205,6 +205,8 @@ class Trimesh(Geometry):
             3) Remove triangles which have one edge of their rectangular 2D
                oriented bounding box shorter than tol.merge
             4) remove duplicated triangles
+            5) ensure triangles are consistently wound
+               and normals face outwards
 
         Parameters
         ------------
@@ -229,6 +231,7 @@ class Trimesh(Geometry):
             if validate:
                 self.remove_duplicate_faces()
                 self.remove_degenerate_faces()
+                self.fix_normals()
         # since none of our process operations moved vertices or faces
         # we can keep face and vertex normals in the cache without recomputing
         # if faces or vertices have been removed, normals are validated before

--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -132,9 +132,16 @@ def fix_inversion(mesh, multibody=False):
             # save wangled normals
             mesh._cache.clear(exclude=['face_normals'])
 
-    elif mesh.volume < 0.0:
-        # reverse every triangles and flip every normals
-        mesh.invert()
+    else:
+        # calculate the volume of the submesh faces
+        volume = triangles.mass_properties(
+            mesh.triangles,
+            crosses=mesh.triangles_cross,
+            skip_inertia=True
+        )['volume']
+        if volume < 0.0:
+            # reverse every triangles and flip every normals
+            mesh.invert()
 
 
 def fix_normals(mesh, multibody=False):


### PR DESCRIPTION
Some of the code makes the assumption that an inside-out trimesh will have a negative volume. However, this is not true as the `mass_properties` method returns the absolute volume if the mesh looks ok *except* for being inside-out ( https://github.com/mikedh/trimesh/commit/f0394c671a3703e08430ef7cf0c2def2652667a3 ). This means that, for single-body meshes, `fix_inversion` would never do anything.

Additionally, makes a mesh fix its winding when given `validate=True`.