### PR TITLE
Use tobytes instead of tostring

### DIFF
--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -35,8 +35,8 @@ def get_readonly(model_name):
     verts = original.vertices
     faces = original.faces
     # use the buffer interface to generate read-only arrays
-    verts = g.np.ndarray(verts.shape, verts.dtype, bytes(verts.tostring()))
-    faces = g.np.ndarray(faces.shape, faces.dtype, bytes(faces.tostring()))
+    verts = g.np.ndarray(verts.shape, verts.dtype, bytes(verts.tobytes()))
+    faces = g.np.ndarray(faces.shape, faces.dtype, bytes(faces.tobytes()))
     # everything should be read only now
     assert not verts.flags['WRITEABLE']
     assert not faces.flags['WRITEABLE']

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -232,7 +232,7 @@ class IOWrapTests(unittest.TestCase):
         util = g.trimesh.util
 
         # check wrap_as_stream
-        test_b = g.np.random.random(1).tostring()
+        test_b = g.np.random.random(1).tobytes()
         test_s = 'this is a test yo'
         res_b = util.wrap_as_stream(test_b).read()
         res_s = util.wrap_as_stream(test_s).read()
@@ -250,7 +250,7 @@ class IOWrapTests(unittest.TestCase):
             assert f.read() == hi
 
     def test_file_hash(self):
-        data = g.np.random.random(10).tostring()
+        data = g.np.random.random(10).tobytes()
         path = g.os.path.join(g.dir_data, 'nestable.json')
 
         for file_obj in [g.trimesh.util.wrap_as_stream(data),

--- a/trimesh/exchange/binvox.py
+++ b/trimesh/exchange/binvox.py
@@ -150,7 +150,7 @@ def binvox_bytes(rle_data, shape, translate=(0, 0, 0), scale=1):
             "rle_data.dtype must be np.uint8, got %s" % rle_data.dtype)
 
     header = binvox_header(shape, translate, scale).encode()
-    return header + rle_data.tostring()
+    return header + rle_data.tobytes()
 
 
 def voxel_from_binvox(

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -180,9 +180,9 @@ def export_ply(mesh,
     export = Template(header).substitute(header_params).encode('utf-8')
 
     if encoding == 'binary_little_endian':
-        export += vertex.tostring()
+        export += vertex.tobytes()
         if hasattr(mesh, 'faces'):
-            export += faces.tostring()
+            export += faces.tobytes()
     elif encoding == 'ascii':
         if hasattr(mesh, 'faces'):
             # ply format is: (face count, v0, v1, v2)

--- a/trimesh/exchange/stl.py
+++ b/trimesh/exchange/stl.py
@@ -216,8 +216,8 @@ def export_stl(mesh):
     packed['normals'] = mesh.face_normals
     packed['vertices'] = mesh.triangles
 
-    export = header.tostring()
-    export += packed.tostring()
+    export = header.tobytes()
+    export += packed.tobytes()
 
     return export
 

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -521,7 +521,7 @@ def group_rows(data, require_count=None, digits=None):
         observed = dict()
         hashable = hashable_rows(data, digits=digits)
         for index, key in enumerate(hashable):
-            key_string = key.tostring()
+            key_string = key.tobytes()
             if key_string in observed:
                 observed[key_string].append(index)
             else:

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -1489,7 +1489,7 @@ class Path2D(Path):
         Return an MD5 of the identifier
         """
         as_int = (self.identifier * 1e4).astype(np.int64)
-        hashed = util.md5_object(as_int.tostring(order='C'))
+        hashed = util.md5_object(as_int.tobytes(order='C'))
         return hashed
 
     @property

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1199,12 +1199,12 @@ def array_to_encoded(array, dtype=None, encoding='base64'):
     encoded = {'dtype': np.dtype(dtype).str,
                'shape': shape}
     if encoding in ['base64', 'dict64']:
-        packed = base64.b64encode(flat.astype(dtype).tostring())
+        packed = base64.b64encode(flat.astype(dtype).tobytes())
         if hasattr(packed, 'decode'):
             packed = packed.decode('utf-8')
         encoded['base64'] = packed
     elif encoding == 'binary':
-        encoded['binary'] = array.tostring(order='C')
+        encoded['binary'] = array.tobytes(order='C')
     else:
         raise ValueError('encoding {} is not available!'.format(encoding))
     return encoded
@@ -1297,7 +1297,7 @@ def encoded_to_array(encoded):
         dtype: string of dtype
         shape: int tuple of shape
         base64: base64 encoded string of flat array
-        binary:  decode result coming from numpy.tostring
+        binary:  decode result coming from numpy.tobytes
 
     Returns
     ----------
@@ -2060,9 +2060,9 @@ def unique_id(length=12, increment=0):
     # head the identifier with 16 bits of time information
     # this provides locality and reduces collision chances
     head = np.array((increment + now() * 10) % 2**16,
-                    dtype=np.uint16).tostring()
+                    dtype=np.uint16).tobytes()
     # get a bunch of random bytes
-    random = np.random.random(int(np.ceil(length / 5))).tostring()
+    random = np.random.random(int(np.ceil(length / 5))).tobytes()
     # encode the time header and random information as base64
     # replace + and / with spaces
     unique = base64.b64encode(head + random,


### PR DESCRIPTION
`tostring` is alias of `tobytes`, and `tostring` is deprecated from numpy ver 1.19.0. I replaced `tostring` with `tobytes`.
https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tostring.html

Note that `tobytes` is implemented in ver 1.9.0. In an old environment, this fix may causes an error.
https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tobytes.html#numpy.ndarray.tobytes