### PR TITLE
proximity.closest_point returns correct point in ambiguous cases

### DIFF
--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -204,6 +204,24 @@ class NearestTest(g.unittest.TestCase):
         g.trimesh.proximity.nearby_faces(
             mesh=mesh, points=points)
 
+    def test_returns_correct_point_in_ambiguous_cases(self):
+        mesh = g.trimesh.Trimesh(
+            vertices=[
+                [0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [0.0, 0.0, -1.0],
+            ],
+            faces=[[0, 1, 2], [0, 1, 3]],
+            process=False,
+        )
+        # Query point is closer to face 0 but lies in face 1 normal direction
+        closest, _, closest_face_index = g.trimesh.proximity.closest_point(
+            mesh, [[-0.25 - 1e-9, 0.0, -0.25]]
+        )
+        g.np.testing.assert_almost_equal(closest[0], [0.0, 0.0, -0.25])
+        self.assertEqual(closest_face_index[0], 1)
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/proximity.py
+++ b/trimesh/proximity.py
@@ -160,7 +160,8 @@ def closest_point(mesh, points):
     idxs = np.int32([qd.argsort()[:2] if len(qd) > 1 else [0, 0] for qd in qds])
     idxs[1:] += query_group.reshape(-1, 1)
 
-    # distances and traingle ids for best two candidates
+    # points, distances and triangle ids for best two candidates
+    two_points = query_close[idxs]
     two_dists = query_distance[idxs]
     two_candidates = all_candidates[idxs]
 
@@ -192,6 +193,8 @@ def closest_point(mesh, points):
     # correct triangle ids where necessary
     # closest point and distance remain valid
     result_tid[c_mask] = two_candidates[c_mask, c_idxs]
+    result_distance[c_mask] = two_dists[c_mask, c_idxs]
+    result_close[c_mask] = two_points[c_mask, c_idxs]
 
     # we were comparing the distance squared so
     # now take the square root in one vectorized operation


### PR DESCRIPTION
When computing the closest point on a mesh to a query point, we first get a list of nearby triangles and the closest points on those triangles. If the closest two points are both within some tolerance distance from the query point, then an additional test is made to select the point that lies in the direction closest to each respective triangle normal.

While the additional test is appropriate, the closest point returned may not correspond the the closest triangle, and instead to the other candidate triangle.

This change updates the closest point and distance to that point to correspond with the closest triangle chosen in teh ambiguous case. A unit test was added to ensure this is working, which fails before this change.