### PR TITLE
Added a check for convex to avoid Qhull error

### DIFF
--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2109,8 +2109,10 @@ class Trimesh(Geometry):
         convex : trimesh.Trimesh
           Mesh of convex hull of current mesh
         """
-        hull = convex.convex_hull(self)
-        return hull
+        if self.is_convex:
+            hull = convex.convex_hull(self)
+            return hull
+        return None
 
     def sample(self, count, return_index=False):
         """

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -135,7 +135,7 @@ def oriented_bounds(obj, angle_digits=1, ordered=True, normal=None):
     # extract a set of convex hull vertices and normals from the input
     # we bother to do this to avoid recomputing the full convex hull if
     # possible
-    if hasattr(obj, 'convex_hull'):
+    if hasattr(obj, 'convex_hull') and obj.is_convex:
         # if we have been passed a mesh, use its existing convex hull to pull from
         # cache rather than recomputing. This version of the cached convex hull has
         # normals pointing in arbitrary directions (straight from qhull)


### PR DESCRIPTION
A zero-z (i.e. flat) mesh still has the `convex_hull` attribute, but is not convex.  This results in errors with, for example, getting the `bounding_box_oriented` attribute:
```
QhullError: QH6022 qhull input error: 2'th dimension's new bounds [-0.5, 0.5] too wide for
existing bounds [ 0,  0]
```
This PR just adds two checks to avoid some errors I've come across.  Not sure if there's enough need to look elsewhere since this was created for 3D meshes, but let me know and I might give it a whirl.