### PR TITLE
Add color attribute to path gltf export

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -810,12 +810,12 @@ def _append_path(path, name, tree, buffer_items):
 
     # the vertex color accessor data
     tree["accessors"].append({
-            "bufferView": len(buffer_items),
-            "componentType": 5121,
-            "count": vxlist[0],
-            "normalized": True,
-            "type": "VEC4",
-            "byteOffset": 0})
+        "bufferView": len(buffer_items),
+        "componentType": 5121,
+        "count": vxlist[0],
+        "normalized": True,
+        "type": "VEC4",
+        "byteOffset": 0})
 
     # the actual color data
     buffer_items.append(_byte_pad(

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -807,7 +807,7 @@ def _append_path(path, name, tree, buffer_items):
 
     # add color to attributes
     tree["meshes"][-1]["primitives"][0]["attributes"]["COLOR_0"] = len(tree["accessors"])
-    
+
     # the vertex color accessor data
     tree["accessors"].append({
             "bufferView": len(buffer_items),

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -800,10 +800,26 @@ def _append_path(path, name, tree, buffer_items):
     # this is just exporting everying as black
     tree["materials"].append(_default_material)
 
-    # data is the second value of the fourth field
+    # data is the second value of the fifth field
     # which is a (data type, data) tuple
     buffer_items.append(_byte_pad(
         vxlist[4][1].astype(float32).tobytes()))
+
+    # add color to attributes
+    tree["meshes"][-1]["primitives"][0]["attributes"]["COLOR_0"] = len(tree["accessors"])
+    
+    # the vertex color accessor data
+    tree["accessors"].append({
+            "bufferView": len(buffer_items),
+            "componentType": 5121,
+            "count": vxlist[0],
+            "normalized": True,
+            "type": "VEC4",
+            "byteOffset": 0})
+
+    # the actual color data
+    buffer_items.append(_byte_pad(
+        np.array(vxlist[5][1]).astype(uint8).tobytes()))
 
 
 def _parse_materials(header, views, resolver=None):


### PR DESCRIPTION
The Path Entity contains vertex color data.
I've added this data as the COLOR_0 attribute for gltf export.
This allows uses to export Paths and maintain the color data in other software