### PR TITLE
Adding __radd__ method for multiple concatenation

### DIFF
--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2849,3 +2849,25 @@ class Trimesh(Geometry):
         """
         concat = util.concatenate(self, other)
         return concat
+
+    def __radd__(self, other):
+        """
+        Concatenate the mesh with 0.
+        This method provides multiple concatenation with sum() function
+        sum(Iterable[trimesh.Trimesh])
+
+        Parameters
+        ------------
+        other : trimesh.Trimesh object
+          Mesh or 0 to be concatenated with self
+
+        Returns
+        ----------
+        concat : trimesh.Trimesh
+          Mesh object of combined result
+        """
+
+        if other == 0:
+            return self
+        else:
+            return self.__add__(type(self)(other))


### PR DESCRIPTION
if you override only __add__ then you can only concatenate two meshes at once.

when you try to do sum([mesh1, mesh2, mesh3]) sum starts with 0 + mesh1 and fails.
this will provide concatenations with sum:
now sum starts with "0 + mesh1" then fails and run mesh1 + 0 = mesh1.