### PR TITLE
change gltf default material to white

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -49,7 +49,7 @@ _shapes = {
 # a default PBR metallic material
 _default_material = {
     "pbrMetallicRoughness": {
-        "baseColorFactor": [0, 0, 0, 0],
+        "baseColorFactor": [1, 1, 1, 1],
         "metallicFactor": 0,
         "roughnessFactor": 0}}
 


### PR DESCRIPTION
Now that the gltf exporter uses vertex colors for both points and paths, it would be useful for the default material base color to be [1,1,1,1]. This would display the objects as intended in most renderers without manipulation.
Currently the vertex colors are not appearing due the default color being [0,0,0,0]
The default behaviour according for the gltf spec is:

> if a primitive specifies a vertex color using the attribute semantic property COLOR_0, then this value acts as an additional linear multiplier to baseColor.

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#materials