### PR TITLE
Fix export of ASCII ply with attributes

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -364,6 +364,170 @@ class CommentTests(unittest.TestCase):
         assert f(text) == 'hey whats up\n hi'
 
 
+class ArrayToString(unittest.TestCase):
+    def test_converts_an_unstructured_1d_array(self):
+        self.assertEqual(
+            g.trimesh.util.array_to_string(np.array([1, 2, 3])),
+            '1 2 3'
+        )
+
+    def test_converts_an_unstructured_int_array(self):
+        self.assertEqual(
+            g.trimesh.util.array_to_string(np.array([[1, 2, 3], [4, 5, 6]])),
+            '1 2 3\n4 5 6'
+        )
+
+    def test_converts_an_unstructured_float_array(self):
+        self.assertEqual(
+            g.trimesh.util.array_to_string(
+                np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float)
+            ),
+            '1.00000000 2.00000000 3.00000000\n4.00000000 5.00000000 6.00000000'
+        )
+
+    def test_uses_the_specified_column_delimiter(self):
+        self.assertEqual(
+            g.trimesh.util.array_to_string(
+                np.array([[1, 2, 3], [4, 5, 6]]), col_delim='col'),
+            '1col2col3\n4col5col6'
+        )
+
+    def test_uses_the_specified_row_delimiter(self):
+        self.assertEqual(
+            g.trimesh.util.array_to_string(
+                np.array([[1, 2, 3], [4, 5, 6]]), row_delim='row'),
+            '1 2 3row4 5 6'
+        )
+
+    def test_uses_the_specified_value_format(self):
+        self.assertEqual(
+            g.trimesh.util.array_to_string(
+                np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float),
+                value_format='{:.1f}'),
+            '1.0 2.0 3.0\n4.0 5.0 6.0'
+        )
+
+    def test_supports_uints(self):
+        self.assertEqual(
+            g.trimesh.util.array_to_string(
+                np.array([1, 2, 3], dtype=np.uint8)),
+            '1 2 3'
+        )
+
+    def test_supports_repeat_format(self):
+        self.assertEqual(
+            g.trimesh.util.array_to_string(
+                np.array([[1, 2, 3], [4, 5, 6]]), value_format='{} {}'),
+            '1 1 2 2 3 3\n4 4 5 5 6 6'
+        )
+
+    def test_raises_if_array_is_structured(self):
+        with self.assertRaises(ValueError):
+            g.trimesh.util.array_to_string(np.array(
+                [(1, 1.1), (2, 2.2)],
+                dtype=[('some_int', np.int), ('some_float', np.float)]
+            ))
+
+    def test_raises_if_array_is_not_flat(self):
+        with self.assertRaises(ValueError):
+            g.trimesh.util.array_to_string(np.array([[[1, 2, 3], [4, 5, 6]]]))
+
+
+class StructuredArrayToString(unittest.TestCase):
+
+    def test_converts_a_structured_array_with_1d_elements(self):
+        self.assertEqual(
+            g.trimesh.util.structured_array_to_string(
+                np.array(
+                    [(1, 1.1), (2, 2.2)],
+                    dtype=[('some_int', np.int), ('some_float', np.float)]
+                )
+            ),
+            '1 1.10000000\n2 2.20000000'
+        )
+
+    def test_converts_a_structured_array_with_2d_elements(self):
+        self.assertEqual(
+            g.trimesh.util.structured_array_to_string(
+                np.array(
+                    [([1, 2], 1.1), ([3, 4], 2.2)],
+                    dtype=[('some_int', np.int, 2), ('some_float', np.float)]
+                )
+            ),
+            '1 2 1.10000000\n3 4 2.20000000'
+        )
+
+    def test_uses_the_specified_column_delimiter(self):
+        self.assertEqual(
+            g.trimesh.util.structured_array_to_string(
+                np.array(
+                    [(1, 1.1), (2, 2.2)],
+                    dtype=[('some_int', np.int), ('some_float', np.float)]
+                ),
+                col_delim='col'
+            ),
+            '1col1.10000000\n2col2.20000000'
+        )
+
+    def test_uses_the_specified_row_delimiter(self):
+        self.assertEqual(
+            g.trimesh.util.structured_array_to_string(
+                np.array(
+                    [(1, 1.1), (2, 2.2)],
+                    dtype=[('some_int', np.int), ('some_float', np.float)]
+                ),
+                row_delim='row'
+            ),
+            '1 1.10000000row2 2.20000000'
+        )
+
+    def test_uses_the_specified_value_format(self):
+        self.assertEqual(
+            g.trimesh.util.structured_array_to_string(
+                np.array(
+                    [(1, 1.1), (2, 2.2)],
+                    dtype=[('some_int', np.int), ('some_float', np.float)]
+                ),
+                value_format='{:.1f}'
+            ),
+            '1.0 1.1\n2.0 2.2'
+        )
+
+    def test_supports_uints(self):
+        self.assertEqual(
+            g.trimesh.util.structured_array_to_string(
+                np.array(
+                    [(1, 1.1), (2, 2.2)],
+                    dtype=[('some_int', np.uint8), ('some_float', np.float)]
+                )
+            ),
+            '1 1.10000000\n2 2.20000000'
+        )
+
+    def test_raises_if_array_is_unstructured(self):
+        with self.assertRaises(ValueError):
+            g.trimesh.util.structured_array_to_string(np.ndarray([1, 2, 3]))
+
+    def test_raises_if_value_format_specifies_repeats(self):
+        with self.assertRaises(ValueError):
+            g.trimesh.util.structured_array_to_string(
+                np.array(
+                    [(1, 1.1), (2, 2.2)],
+                    dtype=[('some_int', np.int), ('some_float', np.float)]
+                ),
+                value_format='{} {}'
+            )
+
+    def test_raises_if_array_is_not_flat(self):
+        with self.assertRaises(ValueError):
+            g.trimesh.util.structured_array_to_string(
+                np.array(
+                    [[(1, 1.1), (2, 2.2)], [(1, 1.1), (2, 2.2)]],
+                    dtype=[('some_int', np.int), ('some_float', np.float)]
+                )
+            )
+
+
 if __name__ == '__main__':
     trimesh.util.attach_to_log()
     unittest.main()

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -337,29 +337,15 @@ def export_ply(mesh,
         if hasattr(mesh, 'faces'):
             export += faces.tobytes()
     elif encoding == 'ascii':
+        export_data = util.structured_array_to_string(vertex,
+                                                      col_delim=' ',
+                                                      row_delim='\n')
         if hasattr(mesh, 'faces'):
-            # ply format is: (face count, v0, v1, v2)
-            fstack = np.column_stack(
-                (np.ones(len(mesh.faces), dtype=np.int64) * 3,
-                 mesh.faces))
-        else:
-            fstack = []
-
-        # if we're exporting vertex normals they get stacked
-        if vertex_normal:
-            vstack = np.column_stack((mesh.vertices,
-                                      mesh.vertex_normals))
-        else:
-            vstack = mesh.vertices
-
-        # add the string formatted vertices and faces
-        export += (util.array_to_string(vstack,
-                                        col_delim=' ',
-                                        row_delim='\n') +
-                   '\n' +
-                   util.array_to_string(fstack,
-                                        col_delim=' ',
-                                        row_delim='\n')).encode('utf-8')
+            export_data += '\n'
+            export_data += util.structured_array_to_string(faces,
+                                                           col_delim=' ',
+                                                           row_delim='\n')
+        export += export_data.encode('utf-8')
     else:
         raise ValueError('encoding must be ascii or binary!')
 


### PR DESCRIPTION
**Summary**
Exporting a mesh with attributes with ASCII encoding would result in a malformed ply file which specified the attributes in the header but did not include them in the data section. This fix was facilitated by a new `unstructured_array_to_string` method. I originally looked at generalizing the existing method but decided upon a bespoke method instead due to the implications of mixed data type rows.

Also fixed a couple bugs in the existing `array_to_string` method

**Test Plan**
- Added tests for `array_to_string`
- Added tests for `unstructured_array_to_string`