### PR TITLE
Fix without_world axis state

### DIFF
--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -741,7 +741,7 @@ class SceneViewer(pyglet.window.Window):
             if self.view['axis'] == 'all':
                 self._axis.draw(mode=gl.GL_TRIANGLES)
             elif self.view['axis'] == 'without_world':
-                if count > 0:
+                if not np.all(transform == np.eye(4)):
                     self._axis.draw(mode=gl.GL_TRIANGLES)
 
             # transparent things must be drawn last


### PR DESCRIPTION
I'm sorry to make a bug.
In #873, I added `without_world` axis state. 
I thought the first element of `node_names` was the world, but in reality it wasn't always the case.
Therefore, it was modified to judge whether it is world from the value of transform.