### PR TITLE
Add unit "foot" to the units_to_inches dictionary

### DIFF
--- a/trimesh/resources/units_to_inches.json
+++ b/trimesh/resources/units_to_inches.json
@@ -3,6 +3,7 @@
   "mils": 0.001,
   "inches": 1.0,
   "feet": 12.0,
+  "foot": 12.0,
   "yards": 36.0,
   "miles": 63360,
   "angstroms": 3.937007874015748e-9,


### PR DESCRIPTION
I've noticed this issue when loading some 3MF files (this one I was testing with was created with 3D Builder):
```
>>> import trimesh
>>> f = trimesh.load("cube_in_feet.3mf")
>>> f.units
'foot'
>>> f.convert_units('meters')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...\trimesh\scene\scene.py", line 880, in convert_units
    scale = units.unit_conversion(
  File "...\trimesh\units.py", line 35, in unit_conversion
    conversion = to_inch[current] / to_inch[desired]
KeyError: 'foot'
```

This seems to be happening because [units_to_inches.json](https://github.com/mikedh/trimesh/blob/master/trimesh/resources/units_to_inches.json) 
only has "feet", while [3MF's Core Specification](https://github.com/3MFConsortium/spec_core/blob/master/3MF%20Core%20Specification.md#34-model)
only has "foot" as a valid value. So I just added "foot" in units_to_inches and it worked fine. 