### PR TITLE
Allow gltf tree postprocessing during export

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -467,7 +467,7 @@ class GLTFTest(g.unittest.TestCase):
         gltf_2 = g.trimesh.exchange.gltf.export_gltf(scene, tree_postprocessor=add_unlit)
 
         def extract_materials(gltf_files):
-            return g.json.loads(gltf_files['model.gltf'])['materials']
+            return g.json.loads(gltf_files['model.gltf'].decode('utf8'))['materials']
 
         assert "extensions" not in extract_materials(gltf_1)[-1]
         assert "extensions" in extract_materials(gltf_2)[-1]

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -455,7 +455,7 @@ class GLTFTest(g.unittest.TestCase):
         sphere.visual.material = g.trimesh.visual.material.PBRMaterial(name='unlit_test')
         scene.add_geometry(sphere)
 
-        def example_tree_postprocessor(gltf_tree):
+        def add_unlit(gltf_tree):
             for material_dict in gltf_tree['materials']:
                 if 'unlit' in material_dict.get('name', '').lower():
                     material_dict["extensions"] = {
@@ -464,16 +464,13 @@ class GLTFTest(g.unittest.TestCase):
             gltf_tree["extensionsUsed"] = ["KHR_materials_unlit"]
 
         gltf_1 = g.trimesh.exchange.gltf.export_gltf(scene)
-        gltf_2 = g.trimesh.exchange.gltf.export_gltf(scene, tree_postprocessor=example_tree_postprocessor)
+        gltf_2 = g.trimesh.exchange.gltf.export_gltf(scene, tree_postprocessor=add_unlit)
 
         def extract_materials(gltf_files):
             return g.json.loads(gltf_files['model.gltf'])['materials']
-        
+
         assert "extensions" not in extract_materials(gltf_1)[-1]
         assert "extensions" in extract_materials(gltf_2)[-1]
-
-
-
 
 
 if __name__ == '__main__':

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -449,6 +449,32 @@ class GLTFTest(g.unittest.TestCase):
         assert g.np.allclose(
             r.visual.vertex_attributes['color'], colors)
 
+    def test_export_postprocess(self):
+        scene = g.trimesh.Scene()
+        sphere = g.trimesh.primitives.Sphere()
+        sphere.visual.material = g.trimesh.visual.material.PBRMaterial(name='unlit_test')
+        scene.add_geometry(sphere)
+
+        def example_tree_postprocessor(gltf_tree):
+            for material_dict in gltf_tree['materials']:
+                if 'unlit' in material_dict.get('name', '').lower():
+                    material_dict["extensions"] = {
+                        "KHR_materials_unlit": {}
+                    }
+            gltf_tree["extensionsUsed"] = ["KHR_materials_unlit"]
+
+        gltf_1 = g.trimesh.exchange.gltf.export_gltf(scene)
+        gltf_2 = g.trimesh.exchange.gltf.export_gltf(scene, tree_postprocessor=example_tree_postprocessor)
+
+        def extract_materials(gltf_files):
+            return g.json.loads(gltf_files['model.gltf'])['materials']
+        
+        assert "extensions" not in extract_materials(gltf_1)[-1]
+        assert "extensions" in extract_materials(gltf_2)[-1]
+
+
+
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -62,7 +62,8 @@ uint8 = np.dtype("<u1")
 def export_gltf(scene,
                 extras=None,
                 include_normals=None,
-                merge_buffers=False):
+                merge_buffers=False,
+                tree_postprocessor=None):
     """
     Export a scene object as a GLTF directory.
 
@@ -89,6 +90,10 @@ def export_gltf(scene,
         scene=scene,
         extras=extras,
         include_normals=include_normals)
+
+    # allow custom postprocessing
+    if tree_postprocessor is not None:
+        tree_postprocessor(tree)
 
     # store files as {name : data}
     files = {}
@@ -129,7 +134,7 @@ def export_gltf(scene,
     return files
 
 
-def export_glb(scene, extras=None, include_normals=None):
+def export_glb(scene, extras=None, include_normals=None, tree_postprocessor=None):
     """
     Export a scene as a binary GLTF (GLB) file.
 
@@ -141,6 +146,8 @@ def export_glb(scene, extras=None, include_normals=None):
       Will be stored in the extras field
     include_normals : bool
       Include vertex normals in output file?
+    tree_postprocessor : func
+      Custom function to (in-place) post-process the tree before exporting.
 
     Returns
     ----------
@@ -157,6 +164,10 @@ def export_glb(scene, extras=None, include_normals=None):
         scene=scene,
         extras=extras,
         include_normals=include_normals)
+
+    # allow custom postprocessing
+    if tree_postprocessor is not None:
+        tree_postprocessor(tree)
 
     # A bufferView is a slice of a file
     views = _build_views(buffer_items)


### PR DESCRIPTION
This allows the user of the library to add custom properties (for example, GLTF extensions to materials) during export. I am using this to add the https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit extension to materials containing the string "unlit" in their name, but this is only one example.