### PR TITLE
min_distance_single function parameter nameing issue

### DIFF
--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -124,17 +124,17 @@ class CollisionTest(g.unittest.TestCase):
         dist = m.min_distance_single(cube)
         assert g.np.isclose(dist, 4.0)
 
-        dist, name = m.min_distance_single(cube, return_name=True)
+        dist, name = m.min_distance_single(cube, return_names=True)
         assert g.np.isclose(dist, 4.0)
         assert name == 'cube1'
 
         m.add_object('cube2', cube, tf2)
 
-        dist, name = m.min_distance_single(cube, tf3, return_name=True)
+        dist, name = m.min_distance_single(cube, tf3, return_names=True)
         assert g.np.isclose(dist, 2.0)
         assert name == 'cube1'
 
-        dist, name = m.min_distance_single(cube, tf4, return_name=True)
+        dist, name = m.min_distance_single(cube, tf4, return_names=True)
         assert g.np.isclose(dist, 2.0)
         assert name == 'cube2'
 

--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -441,7 +441,7 @@ class CollisionManager(object):
     def min_distance_single(self,
                             mesh,
                             transform=None,
-                            return_name=False,
+                            return_names=False,
                             return_data=False):
         """
         Get the minimum distance between a single object and any
@@ -490,7 +490,7 @@ class CollisionManager(object):
 
         # If we want to return the objects that were collision, collect them.
         name, data = None, None
-        if return_name or return_data:
+        if return_names or return_data:
             cg = ddata.result.o1
             if cg == b:
                 cg = ddata.result.o2
@@ -502,9 +502,9 @@ class CollisionManager(object):
                 names = reversed(names)
             data = DistanceData(names, ddata.result)
 
-        if return_name and return_data:
+        if return_names and return_data:
             return distance, name, data
-        elif return_name:
+        elif return_names:
             return distance, name
         elif return_data:
             return distance, data


### PR DESCRIPTION
Hi,
I think it is a minor thing but just to bring it up here.
I noticed that "min_distance_single" function has a "return_name" parameter. But in the same collision class other functions are using "return_names" as their parameters. Not sure if it is due to the return value of "min_distance_single" has only a singular "name". In my suggestion, it is better to make all functions the same so they are easier to use. Let me know what you think.
Also, I don't know how to change API webpage, could you tell me how to do that? thx

https://trimsh.org/trimesh.collision.html#trimesh.collision.CollisionManager.min_distance_single


```
def min_distance_single(self,
                            mesh,
                            transform=None,
                            return_name=False,
                            return_data=False):
```