### PR TITLE
Fix in the inertia moment computation.

### DIFF
--- a/tests/test_inertia.py
+++ b/tests/test_inertia.py
@@ -13,6 +13,7 @@ except BaseException:
 #    3
 
 triIdxs = g.np.ravel([[2, 1, 0], [3, 0, 1], [3, 2, 0], [3, 1, 2]])
+
 def tetToTris(tet):
     return g.np.reshape(tet[triIdxs], (-1, 3))
 
@@ -172,7 +173,7 @@ class InertiaTest(g.unittest.TestCase):
                                  [-1, -1, -1],
                                  [-1, 1, -1],
                                  [1, 1, -1],
-                                 [1,-1, -1]]) * 0.5
+                                 [1, -1, -1]]) * 0.5
 
         # 6 quad faces for the cube
         quads = g.np.int32([[3, 2, 1, 0],
@@ -238,6 +239,6 @@ class InertiaTest(g.unittest.TestCase):
             assert g.np.allclose(MI_gt, MI)
 
 
-if __name__ == '__main__':   
+if __name__ == '__main__':
     g.trimesh.util.attach_to_log()
     g.unittest.main()

--- a/tests/test_inertia.py
+++ b/tests/test_inertia.py
@@ -3,11 +3,9 @@ try:
 except BaseException:
     import generic as g
 
-tdxs = g.np.ravel(g.np.int32([[2,1,0], [3,0,1], [3,2,0], [3,1,2]]))
-tetToTris = lambda tet: g.np.reshape(tet[tdxs], (-1,3))
 
 class InertiaTest(g.unittest.TestCase):
-    """
+
     def test_inertia(self):
         t0 = g.np.array([[-0.419575686853, -0.898655215203, -0.127965023308, 0.],
                          [0.712589964872, -0.413418145015, 0.566834172697, 0.],
@@ -100,18 +98,16 @@ class InertiaTest(g.unittest.TestCase):
                     p.primitive.transform = matrix
                 elif hasattr(p.primitive, 'center'):
                     p.primitive.center = g.np.random.random(3)
-    """
 
     def test_tetrahedron(self):
-
         # Based on the 'numerical example' of the paper:
 
         # Explicit Exact Formulas for the 3-D Tetrahedron Inertia Tensor
-        # in Terms of its Vertex Coorindates, [F. Tonon, 2004]
-        # http://docsdrive.com/pdfs/sciencepublications/jmssp/2005/8-11.pdf
+        # in Terms of its Vertex Coordinates, [F. Tonon, 2004]
+        # http://thescipub.com/pdf/jmssp.2005.8.11.pdf
 
         # set up given vertices
-        vertices = g.np.float32([[8.33220, -11.86875, 0.93355],
+        vertices = g.np.float32([[8.3322, -11.86875, 0.93355],
                                  [0.75523, 5., 16.37072],
                                  [52.61236, 5., -5.3858],
                                  [2., 5., 3.]])
@@ -230,7 +226,10 @@ class InertiaTest(g.unittest.TestCase):
             assert g.np.allclose(MI_gt, MI)
     
 
-
 if __name__ == '__main__':
+
+    triIdxs = g.np.ravel([[2,1,0], [3,0,1], [3,2,0], [3,1,2]])
+    tetToTris = lambda tet: g.np.reshape(tet[triIdxs], (-1,3))
+    
     g.trimesh.util.attach_to_log()
     g.unittest.main()

--- a/tests/test_inertia.py
+++ b/tests/test_inertia.py
@@ -12,8 +12,9 @@ except BaseException:
 #  \ | /
 #    3
 
-triIdxs = g.np.ravel([[2,1,0], [3,0,1], [3,2,0], [3,1,2]])
-tetToTris = lambda tet: g.np.reshape(tet[triIdxs], (-1,3))
+triIdxs = g.np.ravel([[2, 1, 0], [3, 0, 1], [3, 2, 0], [3, 1, 2]])
+def tetToTris(tet):
+    return g.np.reshape(tet[triIdxs], (-1, 3))
 
 
 class InertiaTest(g.unittest.TestCase):
@@ -125,13 +126,12 @@ class InertiaTest(g.unittest.TestCase):
                                  [2., 5., 3.]])
 
         # set up a simple trimesh tetrahedron
-        tris = tetToTris(g.np.int32([0,1,2,3]))
+        tris = tetToTris(g.np.int32([0, 1, 2, 3]))
         tm_tet = g.trimesh.Trimesh(vertices, tris)
-
 
         # 'ground truth' values from the paper
         # however, there are some minor flaws
-        
+
         # a small deviation in the last decimal of the mass-centers' x:
         CM_gt = g.np.float32([15.92492, 0.78281, 3.72962])
 
@@ -148,7 +148,7 @@ class InertiaTest(g.unittest.TestCase):
         MI_gt = g.np.float32([[a_mi, -c_pi, -b_pi],
                               [-c_pi, b_mi, -a_pi],
                               [-b_pi, -a_pi, c_mi]])
-        
+
         # check center of mass
         assert g.np.allclose(CM_gt, tm_tet.center_mass)
 
@@ -165,37 +165,37 @@ class InertiaTest(g.unittest.TestCase):
         # |/    |/
         # 4-----7
 
-        vertices = g.np.float32([[-1,-1, 1],
+        vertices = g.np.float32([[-1, -1, 1],
                                  [-1, 1, 1],
-                                 [ 1, 1, 1],
-                                 [ 1,-1, 1],
-                                 [-1,-1,-1],
-                                 [-1, 1,-1],
-                                 [ 1, 1,-1],
-                                 [ 1,-1,-1]]) * 0.5
+                                 [1, 1, 1],
+                                 [1, -1, 1],
+                                 [-1, -1, -1],
+                                 [-1, 1, -1],
+                                 [1, 1, -1],
+                                 [1,-1, -1]]) * 0.5
 
         # 6 quad faces for the cube
-        quads = g.np.int32([[3,2,1,0],
-                            [0,1,5,4],
-                            [1,2,6,5],
-                            [2,3,7,6],
-                            [3,0,4,7],
-                            [4,5,6,7]])
+        quads = g.np.int32([[3, 2, 1, 0],
+                            [0, 1, 5, 4],
+                            [1, 2, 6, 5],
+                            [2, 3, 7, 6],
+                            [3, 0, 4, 7],
+                            [4, 5, 6, 7]])
 
         # set up two different tetraherdalizations of a cube
         # using 5 tets (1 in the middle and 4 around)
-        tetsA = g.np.int32([[0,1,3,4],
-                            [1,2,3,6],
-                            [1,4,5,6],
-                            [3,4,6,7],
-                            [1,3,4,6]])
+        tetsA = g.np.int32([[0, 1, 3, 4],
+                            [1, 2, 3, 6],
+                            [1, 4, 5, 6],
+                            [3, 4, 6, 7],
+                            [1, 3, 4, 6]])
         # using 6 sets (around the cube diagonal)
-        tetsB = g.np.int32([[0,1,2,6],
-                            [0,1,6,5],
-                            [0,4,5,6],
-                            [0,4,6,7],
-                            [0,3,7,6],
-                            [0,2,3,6]])
+        tetsB = g.np.int32([[0, 1, 2, 6],
+                            [0, 1, 6, 5],
+                            [0, 4, 5, 6],
+                            [0, 4, 6, 7],
+                            [0, 3, 7, 6],
+                            [0, 2, 3, 6]])
 
         # create a trimesh cube from vertices and faces
         tm_cube = g.trimesh.Trimesh(vertices, quads)
@@ -225,19 +225,18 @@ class InertiaTest(g.unittest.TestCase):
             assert g.np.abs(tm_cube.mass - mass) < 1e-6
             assert g.np.allclose(tm_cube.center_mass, center_mass)
 
-
             # the moment of inertia tensors for the individual tetrahedra
             # have to be re-assembled, using the parallel-axis-theorem
             # https://en.wikipedia.org/wiki/Parallel_axis_theorem#Tensor_generalization
 
             E = g.np.eye(3)
-            MI = g.np.zeros((3,3), g.np.float32)
+            MI = g.np.zeros((3, 3), g.np.float32)
             for i in range(len(tm_tets)):
                 R = CMs[i] - center_mass
-                MI += MIs[i] + Ms[i] * (g.np.dot(R,R) * E - g.np.outer(R,R))
+                MI += MIs[i] + Ms[i] * (g.np.dot(R, R) * E - g.np.outer(R, R))
 
             assert g.np.allclose(MI_gt, MI)
-    
+
 
 if __name__ == '__main__':   
     g.trimesh.util.attach_to_log()

--- a/tests/test_inertia.py
+++ b/tests/test_inertia.py
@@ -4,6 +4,18 @@ except BaseException:
     import generic as g
 
 
+# tetToTris extracts outward facing triangles
+# of a tetrahedron given in this order
+#    1
+#  / | \
+# 0-----2
+#  \ | /
+#    3
+
+triIdxs = g.np.ravel([[2,1,0], [3,0,1], [3,2,0], [3,1,2]])
+tetToTris = lambda tet: g.np.reshape(tet[triIdxs], (-1,3))
+
+
 class InertiaTest(g.unittest.TestCase):
 
     def test_inertia(self):
@@ -185,9 +197,8 @@ class InertiaTest(g.unittest.TestCase):
                             [0,3,7,6],
                             [0,2,3,6]])
 
+        # create a trimesh cube from vertices and faces
         tm_cube = g.trimesh.Trimesh(vertices, quads)
-        tm_tetsA = [g.trimesh.Trimesh(vertices, tetToTris(t)) for t in tetsA]
-        tm_tetsB = [g.trimesh.Trimesh(vertices, tetToTris(t)) for t in tetsB]
 
         # https://en.wikipedia.org/wiki/List_of_moments_of_inertia
         # ground truth for a unit cube with side length s = mass m = 1
@@ -197,7 +208,9 @@ class InertiaTest(g.unittest.TestCase):
 
         # compare both tetrahedralizations
         # should be equivalent to each other and to the cube
-        for tm_tets in [tm_tetsA, tm_tetsB]:
+        for tets in [tetsA, tetsB]:
+            # create trimesh tets from vertices and triangles
+            tm_tets = [g.trimesh.Trimesh(vertices, tetToTris(t)) for t in tets]
 
             # get mass, center of mass, and moment of inertia for each tet
             Ms = [tm_tet.mass for tm_tet in tm_tets]
@@ -226,10 +239,6 @@ class InertiaTest(g.unittest.TestCase):
             assert g.np.allclose(MI_gt, MI)
     
 
-if __name__ == '__main__':
-
-    triIdxs = g.np.ravel([[2,1,0], [3,0,1], [3,2,0], [3,1,2]])
-    tetToTris = lambda tet: g.np.reshape(tet[triIdxs], (-1,3))
-    
+if __name__ == '__main__':   
     g.trimesh.util.attach_to_log()
     g.unittest.main()

--- a/tests/test_inertia.py
+++ b/tests/test_inertia.py
@@ -3,9 +3,11 @@ try:
 except BaseException:
     import generic as g
 
+tdxs = g.np.ravel(g.np.int32([[2,1,0], [3,0,1], [3,2,0], [3,1,2]]))
+tetToTris = lambda tet: g.np.reshape(tet[tdxs], (-1,3))
 
 class InertiaTest(g.unittest.TestCase):
-
+    """
     def test_inertia(self):
         t0 = g.np.array([[-0.419575686853, -0.898655215203, -0.127965023308, 0.],
                          [0.712589964872, -0.413418145015, 0.566834172697, 0.],
@@ -98,6 +100,135 @@ class InertiaTest(g.unittest.TestCase):
                     p.primitive.transform = matrix
                 elif hasattr(p.primitive, 'center'):
                     p.primitive.center = g.np.random.random(3)
+    """
+
+    def test_tetrahedron(self):
+
+        # Based on the 'numerical example' of the paper:
+
+        # Explicit Exact Formulas for the 3-D Tetrahedron Inertia Tensor
+        # in Terms of its Vertex Coorindates, [F. Tonon, 2004]
+        # http://docsdrive.com/pdfs/sciencepublications/jmssp/2005/8-11.pdf
+
+        # set up given vertices
+        vertices = g.np.float32([[8.33220, -11.86875, 0.93355],
+                                 [0.75523, 5., 16.37072],
+                                 [52.61236, 5., -5.3858],
+                                 [2., 5., 3.]])
+
+        # set up a simple trimesh tetrahedron
+        tris = tetToTris(g.np.int32([0,1,2,3]))
+        tm_tet = g.trimesh.Trimesh(vertices, tris)
+
+
+        # 'ground truth' values from the paper
+        # however, there are some minor flaws
+        
+        # a small deviation in the last decimal of the mass-centers' x:
+        CM_gt = g.np.float32([15.92492, 0.78281, 3.72962])
+
+        # moment of inertia values
+        a_mi, b_mi, c_mi = [43520.33257, 194711.28938, 191168.76173]
+        # principle inertia values
+        a_pi, b_pi, c_pi = [4417.6615, -46343.16662, 11996.20119]
+
+        # NOTE: I guess there is a mistake in the paper
+        # b' (Eq. 9e) computes from x and z values
+        # c' (Eq. 9f) computes from x and y values
+        # therefore the given matrix E_Q (Eq. 2) is not correct
+        # b' and c' need to be swapped like this:
+        MI_gt = g.np.float32([[a_mi, -c_pi, -b_pi],
+                              [-c_pi, b_mi, -a_pi],
+                              [-b_pi, -a_pi, c_mi]])
+        
+        # check center of mass
+        assert g.np.allclose(CM_gt, tm_tet.center_mass)
+
+        # check moment of inertia tensor
+        assert g.np.allclose(MI_gt, tm_tet.moment_inertia)
+
+    def test_cube_with_tetras(self):
+
+        # set up a unit cube, vertices in this order:
+        #   1-----2
+        #  /|    /|
+        # 0-+---3 |
+        # | 5---+-6
+        # |/    |/
+        # 4-----7
+
+        vertices = g.np.float32([[-1,-1, 1],
+                                 [-1, 1, 1],
+                                 [ 1, 1, 1],
+                                 [ 1,-1, 1],
+                                 [-1,-1,-1],
+                                 [-1, 1,-1],
+                                 [ 1, 1,-1],
+                                 [ 1,-1,-1]]) * 0.5
+
+        # 6 quad faces for the cube
+        quads = g.np.int32([[3,2,1,0],
+                            [0,1,5,4],
+                            [1,2,6,5],
+                            [2,3,7,6],
+                            [3,0,4,7],
+                            [4,5,6,7]])
+
+        # set up two different tetraherdalizations of a cube
+        # using 5 tets (1 in the middle and 4 around)
+        tetsA = g.np.int32([[0,1,3,4],
+                            [1,2,3,6],
+                            [1,4,5,6],
+                            [3,4,6,7],
+                            [1,3,4,6]])
+        # using 6 sets (around the cube diagonal)
+        tetsB = g.np.int32([[0,1,2,6],
+                            [0,1,6,5],
+                            [0,4,5,6],
+                            [0,4,6,7],
+                            [0,3,7,6],
+                            [0,2,3,6]])
+
+        tm_cube = g.trimesh.Trimesh(vertices, quads)
+        tm_tetsA = [g.trimesh.Trimesh(vertices, tetToTris(t)) for t in tetsA]
+        tm_tetsB = [g.trimesh.Trimesh(vertices, tetToTris(t)) for t in tetsB]
+
+        # https://en.wikipedia.org/wiki/List_of_moments_of_inertia
+        # ground truth for a unit cube with side length s = mass m = 1
+        # I = 1/6 * m * s^2
+        MI_gt = g.np.eye(3) / 6
+        assert g.np.allclose(MI_gt, tm_cube.moment_inertia)
+
+        # compare both tetrahedralizations
+        # should be equivalent to each other and to the cube
+        for tm_tets in [tm_tetsA, tm_tetsB]:
+
+            # get mass, center of mass, and moment of inertia for each tet
+            Ms = [tm_tet.mass for tm_tet in tm_tets]
+            CMs = [tm_tet.center_mass for tm_tet in tm_tets]
+            MIs = [tm_tet.moment_inertia for tm_tet in tm_tets]
+
+            # compute total mass and center of mass
+            mass = g.np.sum(Ms)
+            center_mass = g.np.dot(Ms, CMs)
+
+            # compare with unit cube
+            assert g.np.abs(tm_cube.mass - mass) < 1e-6
+            assert g.np.allclose(tm_cube.center_mass, center_mass)
+
+
+            # the moment of inertia tensors for the individual tetrahedra
+            # have to be re-assembled, using the parallel-axis-theorem
+            # https://en.wikipedia.org/wiki/Parallel_axis_theorem#Tensor_generalization
+
+            E = g.np.eye(3)
+            MI = g.np.zeros((3,3), g.np.float32)
+            for i in range(len(tm_tets)):
+                R = CMs[i] - center_mass
+                MI += MIs[i] + Ms[i] * (g.np.dot(R,R) * E - g.np.outer(R,R))
+
+            assert g.np.allclose(MI_gt, MI)
+    
 
 
 if __name__ == '__main__':

--- a/tests/test_inertia.py
+++ b/tests/test_inertia.py
@@ -14,6 +14,7 @@ except BaseException:
 
 triIdxs = g.np.ravel([[2, 1, 0], [3, 0, 1], [3, 2, 0], [3, 1, 2]])
 
+
 def tetToTris(tet):
     return g.np.reshape(tet[triIdxs], (-1, 3))
 

--- a/trimesh/inertia.py
+++ b/trimesh/inertia.py
@@ -12,10 +12,6 @@ import numpy as np
 
 from trimesh import util
 
-# a matrix where all non- diagonal terms are -1.0
-# and all diagonal terms are 1.0
-negate_nondiagonal = 1 #(np.eye(3, dtype=np.float64) * 2) - 1
-
 
 def cylinder_inertia(mass, radius, height, transform=None):
     """
@@ -95,7 +91,7 @@ def principal_axis(inertia):
     # np.linalg.svd, np.linalg.eig, np.linalg.eigh
     # moment of inertia is square symmetric matrix
     # eigh has the best numeric precision in tests
-    components, vectors = np.linalg.eigh(inertia * negate_nondiagonal)
+    components, vectors = np.linalg.eigh(inertia)
 
     # eigh returns them as column vectors, change them to row vectors
     vectors = vectors.T
@@ -136,9 +132,8 @@ def transform_inertia(transform, inertia_tensor):
         raise ValueError('inertia_tensor must be (3, 3)!')
 
     transformed = util.multi_dot([rotation,
-                                  inertia_tensor * negate_nondiagonal,
+                                  inertia_tensor,
                                   rotation.T])
-    transformed *= negate_nondiagonal
     return transformed
 
 

--- a/trimesh/inertia.py
+++ b/trimesh/inertia.py
@@ -14,7 +14,7 @@ from trimesh import util
 
 # a matrix where all non- diagonal terms are -1.0
 # and all diagonal terms are 1.0
-negate_nondiagonal = (np.eye(3, dtype=np.float64) * 2) - 1
+negate_nondiagonal = 1 #(np.eye(3, dtype=np.float64) * 2) - 1
 
 
 def cylinder_inertia(mass, radius, height, transform=None):

--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -266,11 +266,11 @@ def mass_properties(triangles,
         (volume * (center_mass[[0, 2]]**2).sum())
     inertia[2, 2] = integrated[4] + integrated[5] - \
         (volume * (center_mass[[0, 1]]**2).sum())
-    inertia[0, 1] = (
+    inertia[0, 1] = - (
         integrated[7] - (volume * np.product(center_mass[[0, 1]])))
-    inertia[1, 2] = (
+    inertia[1, 2] = - (
         integrated[8] - (volume * np.product(center_mass[[1, 2]])))
-    inertia[0, 2] = (
+    inertia[0, 2] = - (
         integrated[9] - (volume * np.product(center_mass[[0, 2]])))
     inertia[2, 0] = inertia[0, 2]
     inertia[2, 1] = inertia[1, 2]


### PR DESCRIPTION
Hai Michael,

I have tracked down some strange behavior to the point in trimesh where the inertia moment is computed in the `mass_properties()` method of the `triangles.py`.

Compared to the literature reference, given in the comments of the method, there were actually three minus signs missing.

I have fixed that point and added two tests in the `test_inertia.py`.

With this fix the `negate_nondiagonal` matrix in `inertia.py` is also no longer required.
Or did this actually serve any purpose? I have not seen this anywhere in the literature.

Cheers,
Dennis