### PR TITLE
camera.look_at() example

### DIFF
--- a/trimesh/scene/cameras.py
+++ b/trimesh/scene/cameras.py
@@ -298,7 +298,7 @@ def look_at(points, fov, rotation=None, distance=None, center=None, pad=None):
     points = np.array([0, 0, 0], [1, 1, 1])
     scene.camera_transform = scene.camera.look_at(points)
     ```
-    
+
     Parameters
     -------------
     points : (n, 3) float

--- a/trimesh/scene/cameras.py
+++ b/trimesh/scene/cameras.py
@@ -292,6 +292,13 @@ def look_at(points, fov, rotation=None, distance=None, center=None, pad=None):
     Generate transform for a camera to keep a list
     of points in the camera's field of view.
 
+    Examples
+    ------------
+    ```python
+    points = np.array([0, 0, 0], [1, 1, 1])
+    scene.camera_transform = scene.camera.look_at(points)
+    ```
+    
     Parameters
     -------------
     points : (n, 3) float


### PR DESCRIPTION
Took me a while to find the [one example](https://github.com/mikedh/trimesh/blob/ee58b616cfebf2d1e9066a57388ef028ceb86cd0/examples/outlined.py#L29) where `camera.look_at()` is used. Thought it might be useful to have a small example in the docs.