### PR TITLE
added support for Close commands in svg path import

### DIFF
--- a/trimesh/path/exchange/svg_io.py
+++ b/trimesh/path/exchange/svg_io.py
@@ -230,7 +230,7 @@ def _svg_path_convert(paths, metadata=None, force=None):
         def __init__(self, lines):
             if tol.strict:
                 # in unit tests make sure we only have lines
-                assert all(type(L).__name__ == 'Line'
+                assert all(type(L).__name__ in ('Line', 'Close')
                            for L in lines)
             # get the starting point of every line
             points = [L.start for L in lines]

--- a/trimesh/path/exchange/svg_io.py
+++ b/trimesh/path/exchange/svg_io.py
@@ -254,8 +254,8 @@ def _svg_path_convert(paths, metadata=None, force=None):
         path_string = attrib['d']
         # get parsed entities from svg.path
         raw = np.array(list(parse_path(path_string)))
-        # check to see if each entity is a Line
-        is_line = np.array([type(i).__name__ == 'Line'
+        # check to see if each entity is "line-like"
+        is_line = np.array([type(i).__name__ in ('Line', 'Close')
                             for i in raw])
         # find groups of consecutive lines so we can combine them
         blocks = grouping.blocks(
@@ -268,7 +268,7 @@ def _svg_path_convert(paths, metadata=None, force=None):
         # Combine consecutive lines into a single MultiLine
         parsed = []
         for b in blocks:
-            if type(raw[b[0]]).__name__ == 'Line':
+            if type(raw[b[0]]).__name__ in ('Line', 'Close'):
                 # if entity consists of lines add a multiline
                 parsed.append(MultiLine(raw[b]))
             else:


### PR DESCRIPTION
this adds SVG import support for the SVG close path command (https://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand), which functions as a Line command to the initial point in the current subpath.

this prevents SVG paths ending in a Close command from missing their final line segment.