### PR TITLE
fix interpolation of attributes in subdivide()

### DIFF
--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -81,11 +81,11 @@ def subdivide(vertices,
         new_attributes = {}
         for key, values in vertex_attributes.items():
             attr_tris = values[faces_subset]
-            attr_mid = np.vstack([
+            attr_mid = np.hstack([
                 attr_tris[:, g, :].mean(axis=1)
                 for g in [[0, 1],
                           [1, 2],
-                          [2, 0]]])
+                          [2, 0]]]).reshape(-1, 4)
             attr_mid = attr_mid[unique]
             new_attributes[key] = np.vstack((
                 values, attr_mid))


### PR DESCRIPTION
current implementation with vstack() compiles the list of attributes such that they are grouped by g[0] (from all triangles) then g[1] (from all triangles) then g[2] (from all triangles). This is different to how they are grouped in faces_to_edges(). New implementation with hstack() and reshape() lists the attributes such they are grouped first by each triangle, then within each triangle by g[0] then g[1] then g[2].