### PR TITLE
Added support for 'extras' metadata to nodes and glTF/glb import/export.

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1071,6 +1071,12 @@ def _read_buffers(header, buffers, mesh_kwargs, merge_primitives=False, resolver
                 # GLTF spec indicates the default units are meters
                 metadata['units'] = 'meters'
 
+            try:
+                # load extras metadata if available
+                metadata['extras'] = str(m["extras"])
+            except BaseException:
+                pass
+
             for j, p in enumerate(m["primitives"]):
                 # if we don't have a triangular mesh continue
                 # if not specified assume it is a mesh
@@ -1273,6 +1279,9 @@ def _read_buffers(header, buffers, mesh_kwargs, merge_primitives=False, resolver
             kwargs["matrix"] = np.dot(
                 kwargs["matrix"],
                 np.diag(np.concatenate((child['scale'], [1.0]))))
+
+        if "extras" in child:
+            kwargs["extras"] = child["extras"]
 
         if "mesh" in child:
             geometries = mesh_prim[child["mesh"]]

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -96,7 +96,8 @@ class Scene(Geometry3D):
                      node_name=None,
                      geom_name=None,
                      parent_node_name=None,
-                     transform=None):
+                     transform=None,
+                     extras=None):
         """
         Add a geometry to the scene.
 
@@ -108,17 +109,17 @@ class Scene(Geometry3D):
         ----------
         geometry : Trimesh, Path2D, Path3D PointCloud or list
           Geometry to initially add to the scene
-        base_frame : str or hashable
-          Name of base frame
-        metadata : dict
-          Any metadata about the scene
-        graph : TransformForest or None
-          A passed transform graph to use
+        node_name: Name of the added node.
+        geom_name: Name of the added geometry.
+        parent_node_name: Name of the parent node in the graph.
+        transform: Transform that applies to the added node.
+        extras: Optional metadata for the node.
 
         Returns
         ----------
         node_name : str
-          Name of node in self.graph
+          Name of single node in self.graph (passed in) or None if
+          node was not added (eg. geometry was null or a Scene).
         """
 
         if geometry is None:
@@ -131,11 +132,12 @@ class Scene(Geometry3D):
                 node_name=node_name,
                 geom_name=geom_name,
                 parent_node_name=parent_node_name,
-                transform=transform) for value in geometry]
+                transform=transform,
+                extras=extras) for value in geometry]
         elif isinstance(geometry, dict):
             # if someone passed us a dict of geometry
             for key, value in geometry.items():
-                self.add_geometry(value, geom_name=key)
+                self.add_geometry(value, geom_name=key, extras=extras)
             return
         elif isinstance(geometry, Scene):
             # concatenate current scene with passed scene
@@ -190,7 +192,9 @@ class Scene(Geometry3D):
                           frame_from=parent_node_name,
                           matrix=transform,
                           geometry=name,
-                          geometry_flags={'visible': True})
+                          geometry_flags={'visible': True},
+                          extras=extras)
+
         return node_name
 
     def delete_geometry(self, names):

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -55,6 +55,9 @@ class TransformForest(object):
           Distance to translate
         geometry : hashable
           Geometry object name, e.g. 'mesh_0'
+        extras: dictionary
+          Optional metadata attached to the new frame
+          (expors to glTF node 'extras').
         """
 
         self._updated = str(np.random.random())
@@ -72,6 +75,9 @@ class TransformForest(object):
         if 'geometry' in kwargs:
             attr['geometry'] = kwargs['geometry']
 
+        if 'extras' in kwargs:
+            attr['extras'] = kwargs['extras']
+
         # add the edges
         changed = self.transforms.add_edge(frame_from,
                                            frame_to,
@@ -82,6 +88,7 @@ class TransformForest(object):
                 self.transforms,
                 name='geometry',
                 values={frame_to: kwargs['geometry']})
+
         # if the edge update changed our structure
         # dump our cache of shortest paths
         if changed:
@@ -171,6 +178,7 @@ class TransformForest(object):
             # check to see if we have camera node
             if node == scene.camera.name:
                 info['camera'] = 0
+
             try:
                 # try to ignore KeyError and StopIteration
                 # parent-child transform is stored in child
@@ -182,6 +190,14 @@ class TransformForest(object):
                     info['matrix'] = matrix.T.reshape(-1).tolist()
             except BaseException:
                 continue
+
+            try:
+                extras = graph.get_edge_data(parent, node)['extras']
+                if extras:
+                    info['extras'] = extras
+            except BaseException:
+                pass
+
         return {'nodes': result}
 
     def to_edgelist(self):


### PR DESCRIPTION
The current version allows for glTF `extras` metadata at scene level only.

This PR adds support for 'extras' metadata at node level through the scene graph. These are exported and imported to/from glTF/glb.

![image](https://user-images.githubusercontent.com/2786867/110097958-ef1f2580-7d9f-11eb-8328-10f0bed0b85b.png)

What do you think?