### PR TITLE
Fix range for baseColorFactor's transparent

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -313,7 +313,7 @@ def _parse_material(effect, resolver):
     if (effect.transparent is not None
             and not isinstance(effect.transparent, collada.material.Map)):
         baseColorFactor = tuple(
-            np.append(baseColorFactor[:3], float(int(255 * effect.transparent[3]))))
+            np.append(baseColorFactor[:3], float(effect.transparent[3])))
 
     return visual.material.PBRMaterial(
         emissiveFactor=emissiveFactor,


### PR DESCRIPTION
In case of importing collada file, 
the alpha value set is 0-255, but it should be in the range 0-1.
https://github.com/mikedh/trimesh/blob/master/trimesh/exchange/dae.py#L313-L316