### PR TITLE
Fix: subdivide crocodile patterns

### DIFF
--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -68,6 +68,7 @@ class SubDivideTest(g.unittest.TestCase):
     def test_uv(self):
         # get a mesh with texture
         m = g.get_mesh('fuze.obj')
+        #m.show()
         # get the shape of the initial mesh
         shape = m.vertices.shape
         # subdivide the mesh
@@ -79,6 +80,7 @@ class SubDivideTest(g.unittest.TestCase):
         assert s.vertices.shape[0] > shape[0]
         # should have UV coordinates matching vertices
         assert s.vertices.shape[0] == s.visual.uv.shape[0]
+        #s.show()
 
 
 if __name__ == '__main__':

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1888,24 +1888,31 @@ class Trimesh(Geometry3D):
         """
         # subdivide vertex attributes
         vertex_attributes = {}
+        visual = None
         if (hasattr(self.visual, 'uv') and
                 np.shape(self.visual.uv) == (len(self.vertices), 2)):
-            # only subdivide if
-            vertex_attributes['uv'] = self.visual.uv
 
-        # perform the subdivision with vertex attributes
-        vertices, faces, attr = remesh.subdivide(
-            vertices=self.vertices,
-            faces=self.faces,
-            face_index=face_index,
-            vertex_attributes=vertex_attributes)
-        # if we had texture reconstruct it here
-        visual = None
-        if 'uv' in attr:
+            # uv coords divided along with vertices
+            vertices, faces, attr = remesh.subdivide(
+                vertices=np.hstack((self.vertices, self.visual.uv)),
+                faces=self.faces,
+                face_index=face_index,
+                vertex_attributes=vertex_attributes)
+
             # get a copy of the current visuals
             visual = self.visual.copy()
-            # assign the subdivided UV's and remove them
-            visual.uv = attr.pop('uv')
+
+            # seperate uv coords and vertices
+            vertices, visual.uv = vertices[:, :3], vertices[:, 3:]            
+          
+        else:
+            # perform the subdivision with vertex attributes
+            vertices, faces, attr = remesh.subdivide(
+                vertices=self.vertices,
+                faces=self.faces,
+                face_index=face_index,
+                vertex_attributes=vertex_attributes)
+
         # create a new mesh
         result = Trimesh(
             vertices=vertices,


### PR DESCRIPTION
In reference to https://github.com/mikedh/trimesh/issues/1265.

Rewrote base.subdivide. 
Seems like the visual was only kept if: 
1) the visual was an instance of trimesh.visual.texture.TextureVisuals and
2) the uv coordinates were the same shape as the vertex coordinates. 

The rewrite keeps this behavior. 

Changes pass the test_remesh.py unittset. 

Wasn't really sure how to write a unittest for pattern correctness, but uncommenting the mesh.show() in test_remesh.py will demonstrate that the patterns are gone.  

Followup question - is there any reason that subdivide_to_size isn't implemented in trimesh.base? As I mentioned in my original issue subdivide_to_size is really what I'm after, and I'd be happy to add that as well if it's not missing for a specific reason. 