### PR TITLE
Add support for per-vertex texture coordinates for ply files

### DIFF
--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -524,6 +524,13 @@ def elements_to_kwargs(elements,
             # accessing numpy arrays with named fields
             # incorrectly is a ValueError
             pass
+    
+    # If texture coordinates are defined with vertices
+    if texcoord is None and 'texture_u' in elements['vertex']['data'] and 'texture_v' in elements['vertex']['data']:
+        texture_u = elements['vertex']['data']['texture_u']
+        texture_v = elements['vertex']['data']['texture_v']
+        texcoord = np.stack((texture_u[faces.reshape(-1)], texture_v[faces.reshape(-1)]), axis=-1)
+        texcoord = texcoord.reshape((faces.shape[0], -1))
 
     if faces is not None:
         shape = np.shape(faces)


### PR DESCRIPTION
Problem: to load the png texture for ply file, the code assumes there is `texcoord` in the ply file for each face. But for some ply files [generated by MeshLab](https://www.agisoft.com/forum/index.php?topic=16.0) (one example mesh model is attached), the texture coordinates are stored for each vertex as 'texture_u' and 'texture_v'. Therefore, the code failed to create the texture without any complaints. 

Fix: Check if related keys are in the vertex data, the code converts the texture coordinates from vertices to faces. 

[example mesh.zip](https://github.com/mikedh/trimesh/files/6650881/example.mesh.zip)
