### PR TITLE
Feature: added subdivide_to_size to base

### DIFF
--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -144,8 +144,8 @@ def subdivide_to_size(vertices,
     for i in range(max_iter + 1):
         # compute the length of every triangle edge
         edge_length = (np.diff(
-            current_vertices[current_faces[:, [0, 1, 2, 0]]],
-            axis=1) ** 2).sum(axis=2) ** .5
+            current_vertices[current_faces[:, [0, 1, 2, 0]], :3], 
+            axis=1) ** 2).sum(axis=2) ** 0.5
         # check edge length against maximum
         too_long = (edge_length > max_edge).any(axis=1)
         # faces that are OK


### PR DESCRIPTION
In reference to https://github.com/mikedh/trimesh/issues/1265.

Added subdivide_to_size to the trimesh base class. 
Added 3 unit tests that mimic the checks for the original subdivide_to_size fn.
Needed to update remesh to prevent it from requiring vertices are of size nx3 (to allow passing hstacked vertices and uv coords). 

Changes pass the test_remesh.py unittest.

Thanks!