### PR TITLE
tiny fix in triangulate_quads()

### DIFF
--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -168,7 +168,7 @@ def triangulate_quads(quads, dtype=np.int64):
     elif len(quads.shape) == 2 and quads.shape[1] == 3:
         # if they are just triangles return immediately
         return quads.astype(dtype)
-    elif quads.shape == 2 and quads.shape[1] == 4:
+    elif len(quads.shape) == 2 and quads.shape[1] == 4:
         # if they are just quads stack and return
         return np.vstack((quads[:, [0, 1, 2]],
                           quads[:, [2, 3, 0]])).astype(dtype)


### PR DESCRIPTION
the case for pure quad meshes was never used prior to this fix