### PR TITLE
deal with StopIteration error when calling next in sorted_brle_gather_1d

### DIFF
--- a/trimesh/voxel/runlength.py
+++ b/trimesh/voxel/runlength.py
@@ -514,7 +514,10 @@ def sorted_brle_gather_1d(brle_data, ordered_indices):
     """
     data_iter = iter(brle_data)
     index_iter = iter(ordered_indices)
-    index = next(index_iter)
+    try:
+        index = next(index_iter)
+    except StopIteration:
+        return
     start = 0
     value = True
     while True:


### PR DESCRIPTION
```python
def fff():
    for i in range(10):
        raise StopIteration
        yield i

print(tuple(fff()))
```
In Python 3.6, the program above prints `()` with normal exit. It seems that Python 3.6 can suppress the `StopIteration` error in a generator function.

However, in Python 3.8, the program will raise a `StopIteration` error.

So, try - except should be used to wrap `index = next(index_iter)` in case `ordered_indices` is an empty list or array, which leads to `StopIteration` error.