### PR TITLE
Fix a bug loading color of dae files.

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -192,7 +192,7 @@ def _parse_node(node,
                     color = s['COLOR'][0][4].data
                     color_index = primitive.index[:, :, s['COLOR'][0][0]]
                     colors = color[color_index].reshape(
-                        len(color_index) * 3, 3)
+                        len(color_index) * 3, -1)
 
                 faces = np.arange(
                     vertices.shape[0]).reshape(


### PR DESCRIPTION
Code was crashing for 4 channel colors.
    
trimesh/exchange/dae.py", line 203, in _parse_node
        len(color_index) * 3, 3)
    ValueError: cannot reshape array of size 10020 into shape (2505,3)