### PR TITLE
Also move draco_decoder executable to local path to allow reading goo…

### DIFF
--- a/docker/builds/draco.bash
+++ b/docker/builds/draco.bash
@@ -18,6 +18,7 @@ make -j$(nproc)
 
 # Move executables to local path.
 mv /tmp/draco_build/draco_encoder /usr/local/bin
+mv /tmp/draco_build/draco_decoder /usr/local/bin
 
 # Remove temporary build directories.
 rm -rf /tmp/draco_build /tmp/draco_source /tmp/draco.tar.gz


### PR DESCRIPTION
Hi,
so far, the draco_decoder executable isn't moved to local path. Without it, reading Google draco files isn't possible.

