### PR TITLE
Add ignore_broken argument to load_collada

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -10,7 +10,7 @@ from .. import visual
 from ..constants import log
 
 
-def load_collada(file_obj, resolver=None, **kwargs):
+def load_collada(file_obj, resolver=None, ignore_broken=False, **kwargs):
     """
     Load a COLLADA (.dae) file into a list of trimesh kwargs.
 
@@ -20,6 +20,9 @@ def load_collada(file_obj, resolver=None, **kwargs):
       Containing a COLLADA file
     resolver : trimesh.visual.Resolver or None
       For loading referenced files, like texture images
+    ignore_broken: bool
+      Ignores broken references during loading:
+      [collada.common.DaeUnsupportedError, collada.common.DaeBrokenRefError]
     kwargs : **
       Passed to trimesh.Trimesh.__init__
 
@@ -31,7 +34,9 @@ def load_collada(file_obj, resolver=None, **kwargs):
     import collada
 
     # load scene using pycollada
-    c = collada.Collada(file_obj)
+    c = collada.Collada(file_obj, 
+                        ignore=[collada.common.DaeUnsupportedError,
+                                collada.common.DaeBrokenRefError] if ignore_broken else None)
 
     # Create material map from Material ID to trimesh material
     material_map = {}


### PR DESCRIPTION
This will ignore certain two types of errors during Collada loading.

Related to #1384 