### PR TITLE
Fix dae parsing for uv condition and BaseColor normalization

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -115,7 +115,7 @@ def export_collada(mesh, **kwargs):
         input_list.addInput(0, 'VERTEX', '#verts-array')
         input_list.addInput(1, 'NORMAL', '#normals-array')
         arrays = [vertices, normals]
-        if uv is not None:
+        if ((uv is not None) and (len(uv) > 0)):
             texcoords = collada.source.FloatSource(
                 'texcoords-array', uv.flatten(), ('U', 'V'))
             input_list.addInput(2, 'TEXCOORD', '#texcoords-array')
@@ -345,6 +345,7 @@ def _unparse_material(material):
     # TODO EXPORT TEXTURES
     if isinstance(material, visual.material.PBRMaterial):
         diffuse = material.baseColorFactor
+        diffuse = diffuse / 255.0
         if diffuse is not None:
             diffuse = list(diffuse)
 


### PR DESCRIPTION
This PR contains two small changes:

1. Previously textcoords were added to collada file  `if UV is not None`. However, pycollada fails if UV coordinates is an empty array. Thus I added another check before trying to parse UV i.e.` (len(uv) > 0))` that expands the original intention of UV not having any value.

2. Visualization of the mesh fails when is exported and then reloaded. It seems that it has to do with the base color being incorrectly parsed when it has values bigger than 1.0. Thus I normalized the value of diffuse.

A minimal test of both errors can be seen using the dae mesh blue_cube.dae found inside the trimesh repository.
 
```
# this fails for me when exporting the cube because of what was discussed in 1.
scene = trimesh.load('blue_cube.dae')
viewer.windowed.SceneViewer(scene)
mesh.export('blue_cube2.dae')

# visualization is incorrectly displayed because of what is discussed in 2.
scene2 = trimesh.load('blue_cube2.dae')
viewer.windowed.SceneViewer(scene2)
```
