### PR TITLE
Configure build with pyproject.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,13 +86,13 @@ jobs:
     - name: Install publishing dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        pyproject-build --outdir dist .
         twine upload dist/*
 
   docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools >= 40.8",
+    "wheel",
+]


### PR DESCRIPTION
Also known as PEP 517 (and PEP 518), explicitly specify build backend and requirements. Also use `build` in CI to build package for upload to PyPI.

See [the pip docs on pyproject.toml](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/) for more details.