### PR TITLE
Triangulation engine handling fixes in library and tests

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -142,8 +142,9 @@ class CreationTest(g.unittest.TestCase):
         path = g.np.c_[x, y, z]
 
         # Extrude
-        mesh = g.trimesh.creation.sweep_polygon(poly, path)
-        assert mesh.is_volume
+        for engine in self.engines:
+            mesh = g.trimesh.creation.sweep_polygon(poly, path, engine=engine)
+            assert mesh.is_volume
 
     def test_annulus(self):
         """
@@ -264,8 +265,9 @@ class CreationTest(g.unittest.TestCase):
         if len(self.engines) == 0:
             return
         p = g.get_mesh('2D/ChuteHolderPrint.DXF')
-        v, f = p.triangulate()
-        check_triangulation(v, f, p.area)
+        for engine in self.engines:
+            v, f = p.triangulate(engine=engine)
+            check_triangulation(v, f, p.area)
 
     def test_truncated(self, count=10):
         # create some random triangles

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -300,7 +300,7 @@ def sweep_polygon(polygon,
     vecs = verts_3d - path[-1]
     coords = np.c_[np.einsum('ij,j->i', vecs, x),
                    np.einsum('ij,j->i', vecs, y)]
-    base_verts_2d, faces_2d = triangulate_polygon(Polygon(coords))
+    base_verts_2d, faces_2d = triangulate_polygon(Polygon(coords), **kwargs)
     base_verts_3d = (np.einsum('i,j->ij', base_verts_2d[:, 0], x) +
                      np.einsum('i,j->ij', base_verts_2d[:, 1], y)) + path[-1]
     faces = np.vstack((faces, faces_2d + len(vertices)))


### PR DESCRIPTION
In `test_path_sweep` and `test_triangulate_plumbing`, use all available triangulation engines (and no unavailable ones). This specifically allows the tests to run when the `earcut` engine is available but the non-free `triangle` engine is not. It also provides coverage of the `earcut` engine even when `triangle` (the implicit default) is *also* available.

This came to light since I just added [mapbox-earcut](https://src.fedoraproject.org/rpms/python-mapbox-earcut) to Fedora Linux—so these tests are no longer skipped—but [triangle](https://pypi.org/project/triangle/) is not packaged because it requires the non-free [Triangle](https://www.cs.cmu.edu/~quake/triangle.html) library.

In fixing the tests to work in this configuration, I found that `trimesh.creation.sweep_polygon` was calling `triangulate_polygon` without passing along keyword parameters, which meant `sweep_polygon(engine=…)` was only partially respected. I fixed this in a separate commit.