### PR TITLE
bugfix: reserve current result if max_iter is too small

### DIFF
--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -179,6 +179,9 @@ def subdivide_to_size(vertices,
     # stack sequence into nice (n, 3) arrays
     final_vertices, final_faces = util.append_faces(
         done_vert, done_face)
+    if len(final_vertices) == 0:
+        # max_iter is too small to generate short-enough edges, thus reserve current result
+        final_vertices, final_faces = current_vertices, current_faces
 
     if return_index:
         final_index = np.concatenate(done_idx)


### PR DESCRIPTION
When edges is too long but max_edge and max_iter are set too small, `trimesh.remesh.subdivide_to_size` will produce an empty mesh. 
I don't know if this works as @mikedh designed, but in my opinion it goes beyond my expectation. A better solution to remind user about the uncompleted subdivision may be a returned flag if user really want to know it.

Example
~~~python
vertices=np.array([0,0,0,
                  1,0,0,
                  1,1,0,
                  0,1,0,]).reshape((-1,3))*1000
faces=np.array([0,1,2,
                0,2,3]).reshape((-1,3))
mesh=trimesh.Trimesh(vertices,faces)
sub=mesh.subdivide_to_size(max_edge=1)
print(sub)
~~~

Result:
~~~
<trimesh.Trimesh(vertices.shape=(0,), faces.shape=(0, 3))>
~~~