### PR TITLE
bugfix: avoid division by zero

### DIFF
--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -249,6 +249,7 @@ def k_means(points, k, **kwargs):
 
     points = np.asanyarray(points, dtype=np.float64)
     points_std = points.std(axis=0)
+    points_std[points_std == 0] = 1
     whitened = points / points_std
     centroids_whitened, distortion = kmeans(whitened, k, **kwargs)
     centroids = centroids_whitened * points_std


### PR DESCRIPTION
If points are on a planar, points.std(axis=0) will result a zero value in points_std:

~~~python
points=np.random.rand(300).reshape((-1,3))
points[:,2]=0
trimesh.points.k_means(points,10)
~~~

Error:
~~~python
site-packages/trimesh/points.py:252: RuntimeWarning: invalid value encountered in true_divide
  whitened = points / points_std

---------------------------------------------------------------------------
site-packages/trimesh/points.py in k_means(points, k, **kwargs)
    251     points_std = points.std(axis=0)
    252     whitened = points / points_std
--> 253     centroids_whitened, distortion = kmeans(whitened, k, **kwargs)
    254     centroids = centroids_whitened * points_std
    255 

site-packages/scipy/cluster/vq.py in kmeans(obs, k_or_guess, iter, thresh, check_finite, seed)
    453 
    454     """
--> 455     obs = _asarray_validated(obs, check_finite=check_finite)
    456     if iter < 1:
    457         raise ValueError("iter must be at least 1, got %s" % iter)

site-packages/scipy/_lib/_util.py in _asarray_validated(a, check_finite, sparse_ok, objects_ok, mask_ok, as_inexact)
    291             raise ValueError('masked arrays are not supported')
    292     toarray = np.asarray_chkfinite if check_finite else np.asarray
--> 293     a = toarray(a)
    294     if not objects_ok:
    295         if a.dtype is np.dtype('O'):

site-packages/numpy/lib/function_base.py in asarray_chkfinite(a, dtype, order)
    487     if a.dtype.char in typecodes['AllFloat'] and not np.isfinite(a).all():
    488         raise ValueError(
--> 489             "array must not contain infs or NaNs")
    490     return a
    491 

ValueError: array must not contain infs or NaNs
~~~
