### PR TITLE
ci: update import path for scipy coo_matrix

### DIFF
--- a/trimesh/curvature.py
+++ b/trimesh/curvature.py
@@ -9,7 +9,7 @@ import numpy as np
 from . import util
 
 try:
-    from scipy.sparse.coo import coo_matrix
+    from scipy.sparse import coo_matrix
 except ImportError:
     pass
 


### PR DESCRIPTION
Newer version of scipy prints error messages for the older path to `coo_matrix` that is currently used in trimesh. Simple fix in this PR.

https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.coo_matrix.html