### PR TITLE
apad/rpad in polygons.projected

### DIFF
--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -805,7 +805,7 @@ def projected(mesh,
             # extract the model scale from the maximum AABB side length
             scale = extrema.ptp(axis=0).max()
             # pad each polygon proportionally to that scale
-            distance = abs(scale * pad)
+            distance = abs(scale * rpad)
         # inflate each polygon before unioning to remove zero-size
         # gaps then deflate the result after unioning by the same amount
         polygon = ops.unary_union(


### PR DESCRIPTION
In some cases, we want an absolute padding size in projection. The old `pad` parameter is a relative padding size and the final padding size applied is not predictable.