### PR TITLE
Keeping STL Vertex Order

### DIFF
--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -287,7 +287,7 @@ class GroupTests(g.unittest.TestCase):
         # shouldn't error because there are no vertices
         # even though faces are wrong
         mesh.merge_vertices()
-    
+
     def test_unique_ordered(self):
         a = g.np.array([9, 9, 9, 8, 8, 7, 7, 6,
                         6, 5, 5, 4, 4, 3, 3, 0,
@@ -299,7 +299,7 @@ class GroupTests(g.unittest.TestCase):
             return_index=True,
             return_inverse=True
         )
-        
+
         # indices are increasing, because we kept original order
         assert (g.np.diff(ind) > 0).all()
         # we can reconstruct original data

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -287,6 +287,23 @@ class GroupTests(g.unittest.TestCase):
         # shouldn't error because there are no vertices
         # even though faces are wrong
         mesh.merge_vertices()
+    
+    def test_unique_ordered(self):
+        a = g.np.array([9, 9, 9, 8, 8, 7, 7, 6,
+                        6, 5, 5, 4, 4, 3, 3, 0,
+                        2, 1, 1, 0, 0, -1, -1, -1],
+                       dtype=g.np.int64)
+
+        u, ind, inv = g.trimesh.grouping.unique_ordered(
+            a,
+            return_index=True,
+            return_inverse=True
+        )
+        
+        # indices are increasing, because we kept original order
+        assert (g.np.diff(ind) > 0).all()
+        # we can reconstruct original data
+        assert (u[inv] == a).all()
 
 
 def check_roll_wrap(**kwargs):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -93,7 +93,7 @@ class STLTests(g.unittest.TestCase):
     def test_vertex_order(self):
         # removing doubles should respect the vertex order
         m_raw = g.get_mesh('featuretype.STL', process=False)
-        m_proc = g.get_mesh('featuretype.STL', process=True)
+        m_proc = g.get_mesh('featuretype.STL', process=True, keep_vertex_order=True)
 
         verts_raw = g.trimesh.grouping.hashable_rows(m_raw.vertices)
         verts_proc = g.trimesh.grouping.hashable_rows(m_proc.vertices)        

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -89,14 +89,14 @@ class STLTests(g.unittest.TestCase):
             except BaseException:
                 return
             raise ValueError("Shouldn't export empty scenes!")
-    
+
     def test_vertex_order(self):
         # removing doubles should respect the vertex order
         m_raw = g.get_mesh('featuretype.STL', process=False)
         m_proc = g.get_mesh('featuretype.STL', process=True, keep_vertex_order=True)
 
         verts_raw = g.trimesh.grouping.hashable_rows(m_raw.vertices)
-        verts_proc = g.trimesh.grouping.hashable_rows(m_proc.vertices)        
+        verts_proc = g.trimesh.grouping.hashable_rows(m_proc.vertices)
 
         # go through all processed verts
         # find index in unprocessed mesh
@@ -106,8 +106,6 @@ class STLTests(g.unittest.TestCase):
 
         # indices should be increasing
         assert (g.np.diff(idxs) >= 0).all()
-
-
 
 
 if __name__ == '__main__':

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -89,6 +89,25 @@ class STLTests(g.unittest.TestCase):
             except BaseException:
                 return
             raise ValueError("Shouldn't export empty scenes!")
+    
+    def test_vertex_order(self):
+        # removing doubles should respect the vertex order
+        m_raw = g.get_mesh('featuretype.STL', process=False)
+        m_proc = g.get_mesh('featuretype.STL', process=True)
+
+        verts_raw = g.trimesh.grouping.hashable_rows(m_raw.vertices)
+        verts_proc = g.trimesh.grouping.hashable_rows(m_proc.vertices)        
+
+        # go through all processed verts
+        # find index in unprocessed mesh
+        idxs = []
+        for vert in verts_proc:
+            idxs.append(g.np.where(verts_raw == vert)[0][0])
+
+        # indices should be increasing
+        assert (g.np.diff(idxs) >= 0).all()
+
+
 
 
 if __name__ == '__main__':

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -91,21 +91,30 @@ class STLTests(g.unittest.TestCase):
             raise ValueError("Shouldn't export empty scenes!")
 
     def test_vertex_order(self):
-        # removing doubles should respect the vertex order
-        m_raw = g.get_mesh('featuretype.STL', process=False)
-        m_proc = g.get_mesh('featuretype.STL', process=True, keep_vertex_order=True)
+        for stl in ['featuretype.STL', 'ADIS16480.STL', '1002_tray_bottom.STL']:
+            # removing doubles should respect the vertex order
+            m_raw = g.get_mesh(stl, process=False)
+            m_proc = g.get_mesh(stl, process=True, keep_vertex_order=True)
 
-        verts_raw = g.trimesh.grouping.hashable_rows(m_raw.vertices)
-        verts_proc = g.trimesh.grouping.hashable_rows(m_proc.vertices)
+            verts_raw = g.trimesh.grouping.hashable_rows(m_raw.vertices)
+            verts_proc = g.trimesh.grouping.hashable_rows(m_proc.vertices)
 
-        # go through all processed verts
-        # find index in unprocessed mesh
-        idxs = []
-        for vert in verts_proc:
-            idxs.append(g.np.where(verts_raw == vert)[0][0])
+            # go through all processed verts
+            # find index in unprocessed mesh
+            idxs = []
+            for vert in verts_proc:
+                idxs.append(g.np.where(verts_raw == vert)[0][0])
 
-        # indices should be increasing
-        assert (g.np.diff(idxs) >= 0).all()
+            # indices should be increasing
+            assert (g.np.diff(idxs) > 0).all()
+
+            tris_raw = m_raw.triangles
+            tris_proc = m_proc.triangles
+
+            # of course mesh needs to have same faces as before
+            assert g.np.allclose(
+                g.np.sort(tris_raw, axis=0), g.np.sort(tris_proc, axis=0)
+            )
 
 
 if __name__ == '__main__':

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1109,6 +1109,8 @@ class Trimesh(Geometry3D):
           Number of digits to consider for unit normals
         digits_uv : int
           Number of digits to consider for UV coordinates
+        keep_vertex_order: bool
+          If True, vertex order will be preserved
         """
         if 'textured' in kwargs:
             kwargs['merge_tex'] = not kwargs.pop('textured')

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -26,6 +26,7 @@ def merge_vertices(mesh,
                    digits_vertex=None,
                    digits_norm=2,
                    digits_uv=4,
+                   keep_vertex_order=False,
                    **kwargs):
     """
     Removes duplicate vertices, grouped by position and
@@ -47,6 +48,8 @@ def merge_vertices(mesh,
       Number of digits to consider for unit normals
     digits_uv : int
       Number of digits to consider for UV coordinates
+    keep_vertex_order: bool
+      If True, vertex order will be preserved
     """
     # no vertices so exit early
     if len(mesh.vertices) == 0:
@@ -88,7 +91,7 @@ def merge_vertices(mesh,
     stacked = np.column_stack(stacked).round().astype(np.int64)
 
     # check unique rows of referenced vertices
-    u, i = unique_rows(stacked[referenced])
+    u, i = unique_rows(stacked[referenced], keep_order=keep_vertex_order)
 
     # construct an inverse using the subset
     inverse = np.zeros(len(mesh.vertices), dtype=np.int64)
@@ -416,7 +419,7 @@ def unique_float(data,
     return tuple(result)
 
 
-def unique_rows(data, digits=None):
+def unique_rows(data, digits=None, keep_order=False):
     """
     Returns indices of unique rows. It will return the
     first occurrence of a row that is duplicated:
@@ -438,7 +441,10 @@ def unique_rows(data, digits=None):
       Example: data[unique][inverse] == data
     """
     rows = hashable_rows(data, digits=digits)
-    _, unique, inverse = unique_ordered(
+
+    unique_fun = unique_ordered if keep_order else np.unique
+
+    _, unique, inverse = unique_fun(
         rows,
         return_index=True,
         return_inverse=True)

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -252,7 +252,7 @@ def float_to_int(data, digits=None, dtype=np.int32):
     return as_int
 
 
-def unique_ordered(data):
+def unique_ordered(data, return_index=False, return_inverse=False):
     """
     Returns the same as np.unique, but ordered as per the
     first occurrence of the unique value in data.
@@ -268,9 +268,23 @@ def unique_ordered(data):
     Out[3]: array([0, 3, 4, 1, 2])
     """
     data = np.asanyarray(data)
-    order = np.sort(np.unique(data, return_index=True)[1])
-    result = data[order]
-    return result
+    if not return_index and not return_inverse:
+        order = np.sort(np.unique(data, return_index=True)[1])
+        result = data[order]
+        return result 
+
+    uniques, uidxs, inverse = np.unique(data, return_index=True, return_inverse=True)
+    
+    sorted2ordered = np.argsort(uidxs)
+    uniques_ordered = uniques[sorted2ordered]
+    
+    ordered2sorted = np.argsort(sorted2ordered)
+    inv_ordered = ordered2sorted[inverse]
+    
+    if return_index and not return_inverse:
+        return uniques_ordered, uidxs[sorted2ordered]
+
+    return uniques_ordered, uidxs[sorted2ordered], inv_ordered
 
 
 def unique_bincount(values,
@@ -424,7 +438,7 @@ def unique_rows(data, digits=None):
       Example: data[unique][inverse] == data
     """
     rows = hashable_rows(data, digits=digits)
-    _, unique, inverse = np.unique(
+    _, unique, inverse = unique_ordered(
         rows,
         return_index=True,
         return_inverse=True)

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -274,16 +274,16 @@ def unique_ordered(data, return_index=False, return_inverse=False):
     if not return_index and not return_inverse:
         order = np.sort(np.unique(data, return_index=True)[1])
         result = data[order]
-        return result 
+        return result
 
     uniques, uidxs, inverse = np.unique(data, return_index=True, return_inverse=True)
-    
+
     sorted2ordered = np.argsort(uidxs)
     uniques_ordered = uniques[sorted2ordered]
-    
+
     ordered2sorted = np.argsort(sorted2ordered)
     inv_ordered = ordered2sorted[inverse]
-    
+
     if return_index and not return_inverse:
         return uniques_ordered, uidxs[sorted2ordered]
 


### PR DESCRIPTION
Hey Mike,

thank you for this fantastic library. As mentioned by another user in #1310, STL vertex ordering can be important to some use cases. In this PR, I have implemented a `unique_ordered` function that also returns the `inverse` list, which means we can use it in `merge_vertices`.

I have attached some timings, with one of the test models, and a subdivided suzanne model that has ~30k vertices. What do you think about this?

```python
In [2]: import trimesh_fork.trimesh as tmf

In [3]: import trimesh as tm

In [4]: import numpy as np

In [5]: data = np.random.random((500_000, 3))

In [9]: %timeit -n 10 tm.grouping.unique_rows(data)
155 ms ± 5.79 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [10]: %timeit -n 10 tmf.grouping.unique_rows(data)
276 ms ± 8.31 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [12]: %timeit -n 10 tm.load("./trimesh_fork/models/featuretype.STL")
4.35 ms ± 1.61 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [13]: %timeit -n 10 tmf.load("./trimesh_fork/models/featuretype.STL")
4.02 ms ± 320 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [14]: %timeit -n 10 tm.load("...snip.../suzanne-30000v.stl")
66 ms ± 611 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [15]: %timeit -n 10 tmf.load("...snip.../suzanne-30000v.stl")
69.8 ms ± 1 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

...

In [3]: %timeit -n 10 tm.load("...snip.../suzanne-500_000v.stl")
1.69 s ± 47 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [4]: %timeit -n 10 tmf.load("...snip.../suzanne-500_000v.stl")
1.8 s ± 36.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

```