### PR TITLE
add return_index of subdivided old faces

### DIFF
--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -15,7 +15,8 @@ from .geometry import faces_to_edges
 def subdivide(vertices,
               faces,
               face_index=None,
-              vertex_attributes=None):
+              vertex_attributes=None,
+              return_index=False):
     """
     Subdivide a mesh into smaller triangles.
 
@@ -34,6 +35,8 @@ def subdivide(vertices,
       if (n,) int array of indices: only specified faces
     vertex_attributes : dict
       Contains (n, d) attribute data
+    return_index : bool
+      If True, return index of original face for new faces
 
     Returns
     ----------
@@ -41,6 +44,9 @@ def subdivide(vertices,
       Vertices in space
     new_faces : (p, 3) int
       Remeshed faces
+    index_dict : dict
+      Only returned if `return_index`, {index of
+      original face : index of new faces}.
     """
     if face_index is None:
         face_index = np.arange(len(faces))
@@ -90,6 +96,10 @@ def subdivide(vertices,
             new_attributes[key] = np.vstack((
                 values, attr_mid))
         return new_vertices, new_faces, new_attributes
+        
+    if return_index:
+        index_dict = {f: [f] + [len(faces) + 3 * fidx + i for i in range(3)] for fidx,f in enumerate(face_index)}
+        return new_vertices, new_faces, index_dict
 
     return new_vertices, new_faces
 

--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -96,9 +96,10 @@ def subdivide(vertices,
             new_attributes[key] = np.vstack((
                 values, attr_mid))
         return new_vertices, new_faces, new_attributes
-        
+
     if return_index:
-        index_dict = {f: [f] + [len(faces) + 3 * fidx + i for i in range(3)] for fidx,f in enumerate(face_index)}
+        index_dict = {f: [f] + [len(faces) + 3 * fidx + i for i in range(3)] 
+                      for fidx, f in enumerate(face_index)}
         return new_vertices, new_faces, index_dict
 
     return new_vertices, new_faces


### PR DESCRIPTION
Hi! Thanks for this very useful library. 
I needed for a project to relate the indexes of the old and new faces after a remesh.subdivide and implemented it. 
I tried to be minimalist with my changes, but please have a look and see if it is: 1. correct; 2. potentially interesting for other users; 3. not "dangerous".
Also, please let me know if this is not the correct branch or procedure for a PR.

Description: Add an option to return a dict providing for each old face index the set of newly derived face indexes (only for faces undergoing subdivision).