### PR TITLE
fix quadratic node_name lookup

### DIFF
--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -497,6 +497,7 @@ class EnforcedForest(object):
         self.edge_data = collections.defaultdict(dict)
         # {u: data}
         self.node_data = collections.defaultdict(dict)
+        self.node_names = set()
 
         # if multiple calls are made for the same path
         # but the connectivity hasn't changed return cached
@@ -545,6 +546,8 @@ class EnforcedForest(object):
                 {'geometry': kwargs['geometry']})
         else:
             self.node_data[v].update({})
+        
+        self.node_names.add(u)
 
         return True
 
@@ -583,6 +586,7 @@ class EnforcedForest(object):
             del self.edge_data[e]
 
         # delete node data
+        self.node_names.remove(u)
         del self.node_data[u]
 
         return True
@@ -650,7 +654,7 @@ class EnforcedForest(object):
         nodes : set
           Every node currently stored.
         """
-        return set(self.node_data.keys())
+        return self.node_names
 
     @property
     def children(self):

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -545,7 +545,6 @@ class EnforcedForest(object):
                 {'geometry': kwargs['geometry']})
         else:
             self.node_data[v].update({})
-        
         return True
 
     def remove_node(self, u):

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -545,6 +545,7 @@ class EnforcedForest(object):
                 {'geometry': kwargs['geometry']})
         else:
             self.node_data[v].update({})
+
         return True
 
     def remove_node(self, u):

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -497,7 +497,6 @@ class EnforcedForest(object):
         self.edge_data = collections.defaultdict(dict)
         # {u: data}
         self.node_data = collections.defaultdict(dict)
-        self.node_names = set()
 
         # if multiple calls are made for the same path
         # but the connectivity hasn't changed return cached
@@ -547,8 +546,6 @@ class EnforcedForest(object):
         else:
             self.node_data[v].update({})
         
-        self.node_names.add(u)
-
         return True
 
     def remove_node(self, u):
@@ -586,7 +583,6 @@ class EnforcedForest(object):
             del self.edge_data[e]
 
         # delete node data
-        self.node_names.remove(u)
         del self.node_data[u]
 
         return True
@@ -654,7 +650,7 @@ class EnforcedForest(object):
         nodes : set
           Every node currently stored.
         """
-        return self.node_names
+        return self.node_data.keys()
 
     @property
     def children(self):


### PR DESCRIPTION
Fixes an issue when using `Scene.add_geometry()`. Because the set of node names is created each time `graph.nodes` (line 183 in scene.py) is called, the lookup speed slows down quadratically. This makes adding thousands of geometries expensive - see graph.
<img width="658" alt="Screenshot 2022-04-11 at 09 00 43" src="https://user-images.githubusercontent.com/32762874/162691588-074b8e51-82cd-43ad-b1fc-f2c2533da9a7.png">

The fix is to keep track of the nodes names continually rather that recreating the set each time. 
