### PR TITLE
Add test and fix for preserving colors when adding point clouds

### DIFF
--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -225,6 +225,35 @@ class PointsTest(g.unittest.TestCase):
         assert culled.shape == (100, 3)
         assert mask.shape == (200,)
 
+    def test_add_operator(self):
+        points_1 = g.np.random.random((10, 3))
+        points_2 = g.np.random.random((20, 3))
+        colors_1 = [[123, 123, 123, 255]] * len(points_1)
+        colors_2 = [[255, 0, 123, 255]] * len(points_2)
+
+        # Test: Both cloud's colors are preserved
+        cloud_1 = g.trimesh.points.PointCloud(points_1, colors=colors_1)
+        cloud_2 = g.trimesh.points.PointCloud(points_2, colors=colors_2)
+
+        cloud_sum = cloud_1 + cloud_2
+        assert g.np.allclose(cloud_sum.colors, g.np.vstack((cloud_1.colors, cloud_2.colors)))
+
+        # Next test: Only second cloud has colors
+        cloud_1 = g.trimesh.points.PointCloud(points_1)
+        cloud_2 = g.trimesh.points.PointCloud(points_2, colors=colors_2)
+
+        cloud_sum = cloud_1 + cloud_2
+        assert g.np.allclose(cloud_sum.colors[len(cloud_1.vertices):], cloud_2.colors)
+
+        # Next test: Only first cloud has colors
+        cloud_1 = g.trimesh.points.PointCloud(points_1, colors=colors_1)
+        cloud_2 = g.trimesh.points.PointCloud(points_2)
+
+        cloud_sum = cloud_1 + cloud_2
+        assert g.np.allclose(cloud_sum.colors[:len(cloud_1.vertices)], cloud_1.colors)
+
+
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -236,7 +236,9 @@ class PointsTest(g.unittest.TestCase):
         cloud_2 = g.trimesh.points.PointCloud(points_2, colors=colors_2)
 
         cloud_sum = cloud_1 + cloud_2
-        assert g.np.allclose(cloud_sum.colors, g.np.vstack((cloud_1.colors, cloud_2.colors)))
+        assert g.np.allclose(
+            cloud_sum.colors, g.np.vstack(
+                (cloud_1.colors, cloud_2.colors)))
 
         # Next test: Only second cloud has colors
         cloud_1 = g.trimesh.points.PointCloud(points_1)
@@ -251,8 +253,6 @@ class PointsTest(g.unittest.TestCase):
 
         cloud_sum = cloud_1 + cloud_2
         assert g.np.allclose(cloud_sum.colors[:len(cloud_1.vertices)], cloud_1.colors)
-
-
 
 
 if __name__ == '__main__':

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -651,7 +651,10 @@ class PointCloud(Geometry3D):
         else:
             # preserve colors
             # if one point cloud has no color property use black
-            other_colors = [[0, 0, 0, 255]] * len(other.vertices) if len(other.colors) == 0 else other.colors
-            self_colors = [[0, 0, 0, 255]] * len(self.vertices) if len(self.colors) == 0 else self.colors
+            other_colors = [[0, 0, 0, 255]] * \
+                len(other.vertices) if len(other.colors) == 0 else other.colors
+            self_colors = [[0, 0, 0, 255]] * \
+                len(self.vertices) if len(self.colors) == 0 else self.colors
             colors = np.vstack((self_colors, other_colors))
-        return PointCloud(vertices=np.vstack((self.vertices, other.vertices)), colors=colors)
+        return PointCloud(vertices=np.vstack(
+            (self.vertices, other.vertices)), colors=colors)

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -646,4 +646,12 @@ class PointCloud(Geometry3D):
                            **kwargs)
 
     def __add__(self, other):
-        return PointCloud(vertices=np.vstack((self.vertices, other.vertices)))
+        if len(other.colors) == len(self.colors) == 0:
+            colors = None
+        else:
+            # preserve colors
+            # if one point cloud has no color property use black
+            other_colors = [[0, 0, 0, 255]] * len(other.vertices) if len(other.colors) == 0 else other.colors
+            self_colors = [[0, 0, 0, 255]] * len(self.vertices) if len(self.colors) == 0 else self.colors
+            colors = np.vstack((self_colors, other_colors))
+        return PointCloud(vertices=np.vstack((self.vertices, other.vertices)), colors=colors)


### PR DESCRIPTION
This fixes the problem with:
```
pc1 = trimesh.PointCloud(np.random.rand(10, 3), colors=[[255, 0, 0, 255]] * 10)
pc2 = trimesh.PointCloud(np.random.rand(10, 3), colors=[[0, 255, 0, 255]] * 10)
(pc1 + pc2).show()   # this currently won't show any colored point clouds
```