### PR TITLE
Add base_frame parameter to append_scenes method

### DIFF
--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -390,6 +390,15 @@ class SceneTests(g.unittest.TestCase):
         # nothing should have changed
         assert original.identifier_md5 == original_hash
 
+    def test_append_scenes(self):
+        scene_0 = g.trimesh.Scene(base_frame='not_world')
+        scene_1 = g.trimesh.Scene(base_frame='not_world')
+
+        scene_sum = g.trimesh.scene.scene.append_scenes(
+            (scene_0, scene_1), common=['not_world'], base_frame='not_world')
+
+        assert scene_sum.graph.base_frame == 'not_world'
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -1174,7 +1174,7 @@ def split_scene(geometry, **kwargs):
     return scene
 
 
-def append_scenes(iterable, common=['world']):
+def append_scenes(iterable, common=['world'], base_frame='world'):
     """
     Concatenate multiple scene objects into one scene.
 
@@ -1184,6 +1184,8 @@ def append_scenes(iterable, common=['world']):
        Geometries that should be appended
     common : (n,) str
        Nodes that shouldn't be remapped
+    base_frame : str
+       Base frame of the resulting scene
 
     Returns
     ------------
@@ -1278,7 +1280,7 @@ def append_scenes(iterable, common=['world']):
         consumed.update(current)
 
     # add all data to a new scene
-    result = Scene()
+    result = Scene(base_frame=base_frame)
     result.graph.from_edgelist(edges)
     result.geometry.update(geometry)
 


### PR DESCRIPTION
When using `append_scenes` the base frame of the scenes are ignored and the resulting scene always has the standard `world` base frame.  To enable a meaningful merge in a situation like this:
```
scene_0 = g.trimesh.Scene(base_frame='not_world')
scene_1 = g.trimesh.Scene(base_frame='not_world')

scene_sum = g.trimesh.scene.scene.append_scenes((scene_0, scene_1), common=['not_world'])
scene_sum.show() # will break
```
this MR adds a `base_frame` argument to the `append_scenes` method.

Alternatively, the first element of `common` could be used, but this would be ill-defined in case the variable is empty and might lead to less intuitive behavior.  Let me know which solution is preferred.