### PR TITLE
Fix: change early stop part to loop continue instead of return.

### DIFF
--- a/trimesh/intersections.py
+++ b/trimesh/intersections.py
@@ -735,8 +735,7 @@ def slice_mesh_plane(mesh,
                 # if path is None it means this plane didn't
                 # intersect anything so we can exit early without
                 # doing anything to cap the result
-
-                return Trimesh(vertices=vertices, faces=faces, **kwargs)
+                continue
             # transform Path3D onto XY plane for triangulation
             on_plane, to_3D = path.to_planar()
             # triangulate each closed region of 2D cap


### PR DESCRIPTION
Hi, 
`slice_mesh_plane` seems to have been written considering the multi-plane case.
However, early stopping part(`return`) is for only one-plane case.
To support the multi-plane case with the for loop, I changed `return` to `continue`
