### PR TITLE
clean up gmsh API

### DIFF
--- a/trimesh/interfaces/gmsh.py
+++ b/trimesh/interfaces/gmsh.py
@@ -63,7 +63,8 @@ def load_gmsh(file_name, gmsh_args=None):
         raise ValueError('No import since no file was provided!')
 
     # if we initialize with sys.argv it could be anything
-    gmsh.initialize()
+    if not gmsh.isInitialized():
+        gmsh.initialize()
     gmsh.option.setNumber("General.Terminal", 1)
     gmsh.model.add('Surface_Mesh_Generation')
     gmsh.open(file_name)
@@ -92,6 +93,8 @@ def load_gmsh(file_name, gmsh_args=None):
     # load the data from the temporary outfile
     with open(out_data.name, 'rb') as f:
         kwargs = load_stl(f)
+
+    gmsh.finalize()
 
     return kwargs
 


### PR DESCRIPTION
This seems to me to be a bug. I am currently trying to convert many thousands of .stp files via the gmsh interface.
After converting about 50 files, the API gives a warning that it has already been initialized and that it's currently busy and starts exporting empty .obj files:

```txt
# https://github.com/mikedh/trimesh
v
f
```

I first thought it was related to my script using multiprocessing, but after testing it in a regular for loop, it's safe to say it's related.

The official gmsh Python API also says to always terminate the API, here [https://gitlab.onelab.info/gmsh/gmsh/blob/gmsh_4_10_4/api/gmsh.py#L267](https://gitlab.onelab.info/gmsh/gmsh/blob/gmsh_4_10_4/api/gmsh.py#L267).