### PR TITLE
use convex fcl class when mesh is convex, add signed distance flag

### DIFF
--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -118,12 +118,18 @@ class CollisionTest(g.unittest.TestCase):
         tf4 = g.np.eye(4)
         tf4[:3, 3] = g.np.array([-2, 0, 0])
 
+        tf5 = g.np.eye(4)
+        tf5[:3, 3] = g.np.array([5.75, 0, 0])
+
         # Test one-to-many distance checking
         m = g.trimesh.collision.CollisionManager()
         m.add_object('cube1', cube, tf1)
 
         dist = m.min_distance_single(cube)
         assert g.np.isclose(dist, 4.0)
+
+        dist = m.min_distance_single(cube, tf5)
+        assert g.np.isclose(dist, -0.25)
 
         dist, name = m.min_distance_single(cube, return_name=True)
         assert g.np.isclose(dist, 4.0)
@@ -168,15 +174,23 @@ class CollisionTest(g.unittest.TestCase):
         n = g.trimesh.collision.CollisionManager()
         n.add_object('cube0', cube, tf2)
 
-        dist, names = m.min_distance_other(n, return_names=True)
+        dist, names, data = m.min_distance_other(n, return_names=True, return_data=True)
         assert g.np.isclose(dist, 4.0)
         assert names == ('cube0', 'cube0')
+        assert g.np.isclose(
+            g.np.linalg.norm(data.point(names[0]) - data.point(names[1])),
+            dist
+        )
 
         n.add_object('cube4', cube, tf4)
 
-        dist, names = m.min_distance_other(n, return_names=True)
+        dist, names, data = m.min_distance_other(n, return_names=True, return_data=True)
         assert g.np.isclose(dist, 1.0)
         assert names == ('cube0', 'cube4')
+        assert g.np.isclose(
+            g.np.linalg.norm(data.point(names[0]) - data.point(names[1])),
+            dist
+        )
 
     def test_scene(self):
         try:


### PR DESCRIPTION
This PR incorporates the changes from [my PR in python-fcl](https://github.com/BerkeleyAutomation/python-fcl/pull/50) and adds/fixes a few main points around collision checking and minimum distance calculations:

1. python-fcl now supports bindings for the `Convex` primitive, which is much more efficient and accurate than BVH models both for collision checking and min distance computation if a mesh is convex (see [here](https://github.com/flexible-collision-library/fcl/blob/97455a46de121fb7c0f749e21a58b1b54cd2c6be/include/fcl/narrowphase/distance_request.h#L66) - signed distance calculations can be computed with convexity-based methods and nearest point computations are guaranteed to be on the surface of the mesh). This PR adds a check in the `CollisionManager` class for convexity and uses the `Convex` primitive if the mesh is convex.
3. The signed distance flag is used by default for min distance queries - this flag will have no effect on queries with BVH models  but allows for signed distance computation for convex models.
4. Exposed the `normal` field in the `ContactData` class.
5. Implemented the cache for BVH/Convex models so they aren't recomputed (it looked like this was unfinished from an earlier commit).

Additionally, the linked python-fcl PR fixes an issue where nearest points during distance queries were often incorrect and did not match the returned min distance value; this may have been the issue in #1055.

Hoping you might have time to review this and the linked python-fcl PR - I think they will greatly help out with mesh-mesh collisions and signed distances! Thanks Mike!