### PR TITLE
fix index_dict in remesh.subdivide

### DIFF
--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -75,11 +75,11 @@ def subdivide(vertices,
                          faces_subset[:, 2],
                          mid_idx[:, 0],
                          mid_idx[:, 1],
-                         mid_idx[:, 2]]).reshape((-1, 3))
+                         mid_idx[:, 2]]).reshape((-1, 4, 3))
     # add the 3 new faces_subset per old face
-    new_faces = np.vstack((faces, f[len(face_index):]))
+    new_faces = np.vstack((faces, f[:, 1:].reshape((-1, 3))))
     # replace the old face with a smaller face
-    new_faces[face_index] = f[:len(face_index)]
+    new_faces[face_index] = f[:, 0]
 
     new_vertices = np.vstack((vertices, mid))
 


### PR DESCRIPTION
test code
~~~python
vertices=np.array([
    0,0,0,
    0,1,0,
    1,1,0,
    1,0,0,
]).reshape((-1,3)) * 10
faces=np.array([
    0,1,2,
    0,2,3,
]).reshape((-1,3))

def test(fidx):
    print('>>>', fidx)
    v,f,idx=trimesh.remesh.subdivide(vertices,faces,face_index=fidx,return_index=True)
    print('vertices:',v)
    print('faces:',f)
    print('idx:',idx)

test([0,1])
test([1,0])
~~~

correct:
~~~
>>> [0, 1]
vertices: [[ 0.  0.  0.]
 [ 0. 10.  0.]
 [10. 10.  0.]
 [10.  0.  0.]
 [ 0.  5.  0.]
 [ 5.  5.  0.]
 [ 5. 10.  0.]
 [ 5.  0.  0.]
 [10.  5.  0.]]
faces: [[0 4 5]
 [0 5 7]
 [4 1 6]
 [5 6 2]
 [4 6 5]
 [5 2 8]
 [7 8 3]
 [5 8 7]]
idx: {0: [0, 2, 3, 4], 1: [1, 5, 6, 7]}
>>> [1, 0]
vertices: [[ 0.  0.  0.]
 [ 0. 10.  0.]
 [10. 10.  0.]
 [10.  0.  0.]
 [ 0.  5.  0.]
 [ 5.  5.  0.]
 [ 5. 10.  0.]
 [ 5.  0.  0.]
 [10.  5.  0.]]
faces: [[0 4 5]
 [0 5 7]
 [5 2 8]
 [7 8 3]
 [5 8 7]
 [4 1 6]
 [5 6 2]
 [4 6 5]]
idx: {1: [1, 2, 3, 4], 0: [0, 5, 6, 7]}
~~~

wrong:
~~~
>>> [0, 1]
vertices: [[ 0.  0.  0.]
 [ 0. 10.  0.]
 [10. 10.  0.]
 [10.  0.  0.]
 [ 0.  5.  0.]
 [ 5.  5.  0.]
 [ 5. 10.  0.]
 [ 5.  0.  0.]
 [10.  5.  0.]]
faces: [[0 4 5]
 [4 1 6]
 [5 6 2]
 [4 6 5]
 [0 5 7]
 [5 2 8]
 [7 8 3]
 [5 8 7]]
idx: {0: [0, 2, 3, 4], 1: [1, 5, 6, 7]}
>>> [1, 0]
vertices: [[ 0.  0.  0.]
 [ 0. 10.  0.]
 [10. 10.  0.]
 [10.  0.  0.]
 [ 0.  5.  0.]
 [ 5.  5.  0.]
 [ 5. 10.  0.]
 [ 5.  0.  0.]
 [10.  5.  0.]]
faces: [[5 2 8]
 [0 5 7]
 [7 8 3]
 [5 8 7]
 [0 4 5]
 [4 1 6]
 [5 6 2]
 [4 6 5]]
idx: {1: [1, 2, 3, 4], 0: [0, 5, 6, 7]}
~~~