### PR TITLE
fix "reversed not subscriptable" bug

### DIFF
--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -329,7 +329,7 @@ class CollisionManager(object):
 
                 names = (name, '__external')
                 if cg == contact.o2:
-                    names = reversed(names)
+                    names = tuple(reversed(names))
 
                 if return_names:
                     objs_in_collision.add(name)
@@ -455,7 +455,7 @@ class CollisionManager(object):
                     objs_in_collision.add(names)
                 if return_data:
                     if reverse:
-                        names = reversed(names)
+                        names = tuple(reversed(names))
                     contact_data.append(ContactData(names, contact))
 
         if return_names and return_data:
@@ -532,7 +532,7 @@ class CollisionManager(object):
 
             names = (name, '__external')
             if cg == ddata.result.o2:
-                names = reversed(names)
+                names = tuple(reversed(names))
             data = DistanceData(names, ddata.result)
 
         if return_name and return_data:
@@ -651,7 +651,7 @@ class CollisionManager(object):
 
             dnames = tuple(names)
             if reverse:
-                dnames = reversed(dnames)
+                dnames = tuple(reversed(dnames))
             data = DistanceData(dnames, ddata.result)
 
         if return_names and return_data:


### PR DESCRIPTION
I think this may not be easily testable so not caught, but it seems like `reversed` should be wrapped in `tuple`, otherwise it is not subscriptable since it creates an iterator.
![image](https://user-images.githubusercontent.com/7028710/178576554-bba95fb7-31ee-4924-8670-51dfbdb7a28a.png)
