### PR TITLE
Support non-standard file objects, e.g. from io

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -298,6 +298,8 @@ class ExportTest(g.unittest.TestCase):
         assert args[1] == 'stl'
 
     def test_buffered_random(self):
+        """Test writing to non-standard file
+        """
         mesh = list( g.get_meshes(1) )[0]
         with io.BufferedRandom(io.BytesIO()) as rw:
             mesh.export( rw, 'STL' )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -5,6 +5,7 @@ except BaseException:
 
 import io
 
+
 class ExportTest(g.unittest.TestCase):
 
     def test_export(self):
@@ -300,12 +301,12 @@ class ExportTest(g.unittest.TestCase):
     def test_buffered_random(self):
         """Test writing to non-standard file
         """
-        mesh = list( g.get_meshes(1) )[0]
+        mesh = list(g.get_meshes(1))[0]
         with io.BufferedRandom(io.BytesIO()) as rw:
-            mesh.export( rw, 'STL' )
-            rw.seek( 0 )
+            mesh.export(rw, 'STL')
+            rw.seek(0)
             binary_stl = rw.read()
-            self.assertLess( 0, len( binary_stl ) )
+            self.assertLess(0, len(binary_stl))
 
 
 if __name__ == '__main__':

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -307,6 +307,7 @@ class ExportTest(g.unittest.TestCase):
             binary_stl = rw.read()
             self.assertLess( 0, len( binary_stl ) )
 
+
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()
     g.unittest.main()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -3,6 +3,7 @@ try:
 except BaseException:
     import generic as g
 
+import io
 
 class ExportTest(g.unittest.TestCase):
 
@@ -296,6 +297,13 @@ class ExportTest(g.unittest.TestCase):
         # should have used manually passed type over .obj
         assert args[1] == 'stl'
 
+    def test_buffered_random(self):
+        mesh = list( g.get_meshes(1) )[0]
+        with io.BufferedRandom(io.BytesIO()) as rw:
+            mesh.export( rw, 'STL' )
+            rw.seek( 0 )
+            binary_stl = rw.read()
+            self.assertLess( 0, len( binary_stl ) )
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -2096,6 +2096,9 @@ def write_encoded(file_obj,
     If a file is open in text mode and bytes are
     passed decode bytes to str and write.
 
+    Assumes binary mode if file_obj does not have
+    a 'mode' attribute (e.g. io.BufferedRandom).
+
     Parameters
     -----------
     file_obj : file object
@@ -2105,7 +2108,9 @@ def write_encoded(file_obj,
     encoding : str
       Encoding of text
     """
-    binary_file = 'b' in file_obj.mode
+    binary_file = True
+    if hasattr(file_obj, 'mode'):
+        binary_file = 'b' in file_obj.mode
     string_stuff = isinstance(stuff, basestring)
     binary_stuff = isinstance(stuff, bytes)
 


### PR DESCRIPTION
I'm sending binary STL data over the network and I want to avoid using a temporary file like this:

            with io.BufferedRandom(io.BytesIO()) as rw:
                mesh.export( rw, 'STL' )
                rw.seek( 0 )
                binary_stl = rw.read()
                r = requests.post( url, data = binary_stl )


. However, util.write_encoded() and by extension Trimesh.export() expect file objects to have a 'mode' attribute, which io.BufferedRandom does not.

As a solution, I propose assuming binary mode, unless there is a 'mode' attribute present on the file object.