### PR TITLE
bugfix: find ply textures with spaces in filepath

### DIFF
--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -435,7 +435,7 @@ def parse_header(file_obj):
             # `comment TextureFile fuze_uv.jpg`
             index = line.index('TextureFile') + 1
             if index < len(line):
-                image_name = line[index]
+                image_name = " ".join(line[index:])
 
     return elements, is_ascii, image_name
 


### PR DESCRIPTION
I found a small bug where trimesh can't load the texturefile of a ply if there's a space in the filepath.

For example, if the header contains:
`comment TextureFile some file.jpg`
The header parser will return `"some"` instead of `"some file.jpg"` for `image_name`.

P.S. thanks for all the work on trimesh, it's an amazing library.