### PR TITLE
Update openctm.py

### DIFF
--- a/trimesh/exchange/openctm.py
+++ b/trimesh/exchange/openctm.py
@@ -44,7 +44,7 @@ try:
     else:
         _ctm_loader = ctypes.CDLL
 except BaseException:
-    pass
+    _ctm_lib_name = None
 
 
 def load_ctm(file_obj, file_type=None, **kwargs):


### PR DESCRIPTION
fix issue where find_library throws an exception, causing an uncaught exception at line 163 when _ctm_lib_name is not defined