### PR TITLE
add 'TestVHACD' to vhacd executable names

### DIFF
--- a/trimesh/interfaces/vhacd.py
+++ b/trimesh/interfaces/vhacd.py
@@ -15,7 +15,7 @@ if platform.system() == 'Windows':
     log.debug('searching for vhacd in: %s', _search_path)
 
 _vhacd_executable = None
-for _name in ['vhacd', 'testVHACD']:
+for _name in ['vhacd', 'testVHACD', 'TestVHACD']:
     _vhacd_executable = which(_name, path=_search_path)
     if _vhacd_executable is not None:
         break


### PR DESCRIPTION
VHACD compiles on ubuntu to TestVHACD as opposed to testVHACD or vhacd. Unsure if the other two are needed, but at least using the instructions from the vhacd repo, it compiles to TestVHACD on ubuntu, and then trimesh won't recognize the executable. This change fixed it for me.