### PR TITLE
Release: Reuse unique_name logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     name: Check Code Formatting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install Formatting
@@ -55,9 +55,9 @@ jobs:
           - os: macos-latest
             python-version: 2.7
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install APT On Linux
@@ -86,9 +86,9 @@ jobs:
     needs: [tests, containers]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install publishing dependencies
@@ -108,7 +108,7 @@ jobs:
     needs: [tests, containers]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build Docs
       run: |
          # build docs in docker image
@@ -127,7 +127,7 @@ jobs:
     - name: Login to Docker Hub
       run: echo ${{ secrets.DH_PASS }} | docker login --username mikedh --password-stdin
     - name: Checkout trimesh
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build Images
       env:
         GIT_SHA: ${{ github.sha }}
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - name: Tag Version
         id: set_tag
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install Formatting
@@ -40,9 +40,9 @@ jobs:
           - os: ubuntu-latest
             python-version: 2.7
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Test a minimal install

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,16 @@ import sys
 from setuptools import setup
 
 # load __version__ without importing anything
-version_file = os.path.join(
+_version_file = os.path.join(
     os.path.dirname(__file__),
-    'trimesh/version.py')
-with open(version_file, 'r') as f:
-    # use eval to get a clean string of version from file
-    __version__ = eval(f.readline().strip().split('=')[-1])
+    'trimesh', 'version.py')
+with open(_version_file, 'r') as f:
+    _version_raw = f.read()
+# use eval to get a clean string of version from file
+__version__ = eval(next(
+    line.strip().split('=')[-1]
+    for line in str.splitlines(_version_raw)
+    if '_version_' in line))
 
 # load README.md as long_description
 long_description = ''
@@ -129,6 +133,22 @@ elif '--list-easy' in sys.argv:
     exit()
 elif '--format' in sys.argv:
     format_all()
+    exit()
+elif '--bump' in sys.argv:
+    # bump the version number
+    # convert current version to integers
+    bumped = [int(i) for i in __version__.split('.')]
+    # increment the last field by one
+    bumped[-1] += 1
+    # re-combine into a version string
+    version_new = '.'.join(str(i) for i in bumped)
+    print('version bump `{}` => `{}`'.format(
+        __version__, version_new))
+    # write back the original version file with
+    # just the value replaced with the new one
+    raw_new = _version_raw.replace(__version__, version_new)
+    with open(_version_file, 'w') as f:
+        f.write(raw_new)
     exit()
 
 

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -66,10 +66,30 @@ class MinimalTest(unittest.TestCase):
                 assert hash(m) != initial
 
     def test_load_path(self):
-        scene = trimesh.Scene()
+        # should be able to load a path and export it as a GLB
+        # try with a Path3D
         path = trimesh.load_path(np.asarray([(0, 0, 0), (1, 0, 0), (1, 1, 0)]))
-        scene.add_geometry(path)
+        assert isinstance(path, trimesh.path.Path3D)
+        scene = trimesh.Scene(path)
         assert len(scene.geometry) == 1
+        glb = scene.export(file_type='glb')
+        assert len(glb) > 0
+
+        # now create a Path2D
+        path = trimesh.load_path(np.asarray([(0, 0), (1, 0), (1, 1)]))
+        assert isinstance(path, trimesh.path.Path2D)
+
+        # export to an SVG
+        svg = path.export(file_type='svg')
+        assert len(svg) > 0
+
+        dxf = path.export(file_type='dxf')
+        assert len(dxf) > 0
+
+        scene = trimesh.Scene(path)
+        assert len(scene.geometry) == 1
+        glb = scene.export(file_type='glb')
+        assert len(glb) > 0
 
 
 if __name__ == '__main__':

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -333,8 +333,6 @@ class SceneTests(g.unittest.TestCase):
         set_ori = set([len(i) * 2 for i in s.duplicate_nodes])
         set_dbl = set([len(i) for i in r.duplicate_nodes])
 
-        from IPython import embed
-        embed()
         assert set_ori == set_dbl
 
     def test_empty_scene(self):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -332,6 +332,9 @@ class SceneTests(g.unittest.TestCase):
         # duplicate node groups should be twice as long
         set_ori = set([len(i) * 2 for i in s.duplicate_nodes])
         set_dbl = set([len(i) for i in r.duplicate_nodes])
+
+        from IPython import embed
+        embed()
         assert set_ori == set_dbl
 
     def test_empty_scene(self):

--- a/trimesh/comparison.py
+++ b/trimesh/comparison.py
@@ -143,8 +143,8 @@ def identifier_hash(identifier):
 
     Returns
     ----------
-    hash : (32,) str
-      First 32 characters hash of identifier
+    hash : (64,) str
+      A SHA256 of the identifier vector at hand-tuned precision.
     """
 
     # convert identifier to integers and order of magnitude
@@ -155,7 +155,7 @@ def identifier_hash(identifier):
     if (multiplier < 0).any():
         multiplier += np.abs(multiplier.min())
     data = (as_int * (10 ** multiplier)).astype(np.int64)
-    return sha256(data.tobytes()).hexdigest()[-32:]
+    return sha256(data.tobytes()).hexdigest()
 
 
 def face_ordering(mesh):

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -745,7 +745,7 @@ def _append_mesh(mesh,
             current["extras"]["units"] = str(mesh.units)
     except BaseException:
         log.debug('metadata not serializable, dropping!',
-                    exc_info=True)
+                  exc_info=True)
 
     # check to see if we have vertex or face colors
     # or if a TextureVisual has colors included as an attribute
@@ -1018,7 +1018,7 @@ def _append_path(path, name, tree, buffer_items):
         current["extras"] = _jsonify(path.metadata)
     except BaseException:
         log.debug('failed to serialize metadata, dropping!',
-                    exc_info=True)
+                  exc_info=True)
 
     if path.colors is not None:
         acc_color = _data_append(acc=tree['accessors'],

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -809,8 +809,10 @@ def _append_mesh(mesh,
             norms = np.linalg.norm(normals, axis=1)
             if not util.allclose(norms, 1.0, atol=1e-4):
                 normals /= norms.reshape((-1, 1))
-            else:
-                normals = mesh.vertex_normals
+        else:
+            # we don't have to copy them since
+            # they aren't being altered
+            normals = mesh.vertex_normals
 
         acc_norm = _data_append(
             acc=tree['accessors'],

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -611,7 +611,7 @@ def _create_gltf_structure(scene,
             # only export the extras if there is something there
             tree['scenes'][0]['extras'] = _jsonify(scene.metadata)
         except BaseException:
-            log.warning(
+            log.debug(
                 'failed to export scene metadata!', exc_info=True)
 
     # store materials as {hash : index} to avoid duplicates
@@ -704,7 +704,7 @@ def _append_mesh(mesh,
     """
     # return early from empty meshes to avoid crashing later
     if len(mesh.faces) == 0 or len(mesh.vertices) == 0:
-        log.warning('skipping empty mesh!')
+        log.debug('skipping empty mesh!')
         return
     # convert mesh data to the correct dtypes
     # faces: 5125 is an unsigned 32 bit integer
@@ -744,7 +744,7 @@ def _append_mesh(mesh,
         if mesh.units not in [None, 'm', 'meters', 'meter']:
             current["extras"]["units"] = str(mesh.units)
     except BaseException:
-        log.warning('metadata not serializable, dropping!',
+        log.debug('metadata not serializable, dropping!',
                     exc_info=True)
 
     # check to see if we have vertex or face colors
@@ -1017,7 +1017,7 @@ def _append_path(path, name, tree, buffer_items):
     try:
         current["extras"] = _jsonify(path.metadata)
     except BaseException:
-        log.warning('failed to serialize metadata, dropping!',
+        log.debug('failed to serialize metadata, dropping!',
                     exc_info=True)
 
     if path.colors is not None:
@@ -1155,7 +1155,7 @@ def _parse_materials(header, views, resolver=None):
     try:
         import PIL.Image
     except ImportError:
-        log.warning("unable to load textures without pillow!")
+        log.debug("unable to load textures without pillow!")
         return None
 
     # load any images
@@ -1172,7 +1172,7 @@ def _parse_materials(header, views, resolver=None):
                 # will get bytes from filesystem or base64 URI
                 blob = _uri_to_bytes(uri=img['uri'], resolver=resolver)
             else:
-                log.warning('unable to load image from: {}'.format(
+                log.debug('unable to load image from: {}'.format(
                     img.keys()))
                 continue
             # i.e. 'image/jpeg'
@@ -1392,7 +1392,7 @@ def _read_buffers(header,
                     visuals = None
                     if "material" in p:
                         if materials is None:
-                            log.warning('no materials! `pip install pillow`')
+                            log.debug('no materials! `pip install pillow`')
                         else:
                             uv = None
                             if "TEXCOORD_0" in attr:
@@ -1436,7 +1436,7 @@ def _read_buffers(header,
                     if len(custom) > 0:
                         kwargs["vertex_attributes"] = custom
                 else:
-                    log.warning('skipping primitive with mode %s!', mode)
+                    log.debug('skipping primitive with mode %s!', mode)
                     continue
                 # this should absolutely not be stomping on itself
                 assert name not in meshes

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -87,7 +87,7 @@ def load_obj(file_obj,
         except BaseException:
             # something else happened so log a warning
             log.debug('unable to load materials from: {}'.format(mtl_path),
-                        exc_info=True)
+                      exc_info=True)
 
     # extract vertices from raw text
     v, vn, vt, vc = _parse_vertices(text=text)

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -83,10 +83,10 @@ def load_obj(file_obj,
                          for k, v in material_kwargs.items()}
         except IOError:
             # usually the resolver couldn't find the asset
-            log.warning('unable to load materials from: {}'.format(mtl_path))
+            log.debug('unable to load materials from: {}'.format(mtl_path))
         except BaseException:
             # something else happened so log a warning
-            log.warning('unable to load materials from: {}'.format(mtl_path),
+            log.debug('unable to load materials from: {}'.format(mtl_path),
                         exc_info=True)
 
     # extract vertices from raw text
@@ -199,7 +199,7 @@ def load_obj(file_obj,
                 # want materials without UV coordinates
                 uv = vt[mask_vt]
             except BaseException:
-                log.warning('index failed on UV coordinates, skipping!')
+                log.debug('index failed on UV coordinates, skipping!')
                 uv = None
 
             # mask vertices and use new faces

--- a/trimesh/path/exchange/svg_io.py
+++ b/trimesh/path/exchange/svg_io.py
@@ -110,7 +110,7 @@ def svg_to_path(file_obj, file_type=None):
         pass
     except BaseException:
         # no metadata stored with trimesh ns
-        log.warning('failed metadata', exc_info=True)
+        log.debug('failed metadata', exc_info=True)
 
     # if the result is a scene try to get the metadata
     # for each subgeometry here
@@ -128,7 +128,7 @@ def svg_to_path(file_obj, file_type=None):
             pass
         except BaseException:
             # failed to load existing metadata
-            log.warning('failed metadata', exc_info=True)
+            log.debug('failed metadata', exc_info=True)
 
     return result
 
@@ -196,7 +196,7 @@ def transform_to_matrices(transform):
             mat[:2, :2] *= values
             matrices.append(mat)
         else:
-            log.warning('unknown SVG transform: {}'.format(key))
+            log.debug('unknown SVG transform: {}'.format(key))
 
     return matrices
 
@@ -276,7 +276,7 @@ def _svg_path_convert(paths, force=None):
         # the path string is stored under `d`
         path_string = attrib.get('d', '')
         if len(path_string) == 0:
-            log.warning('empty path string!')
+            log.debug('empty path string!')
             continue
 
         # get the name of the geometry if trimesh specified it
@@ -525,7 +525,7 @@ def export_svg(drawing,
         attribs['metadata'] = _encode(drawing.metadata)
     except BaseException:
         # log failed metadata encoding
-        log.warning('failed to encode', exc_info=True)
+        log.debug('failed to encode', exc_info=True)
 
     subs = {'elements': '\n'.join(elements),
             'min_x': drawing.bounds[0][0],

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -879,7 +879,7 @@ class Path3D(Path):
                     N *= np.sign(np.dot(N, normal))
                     N = normal
                 else:
-                    log.warning(
+                    log.debug(
                         "passed normal not used: {}".format(
                             normal.shape))
             # create a transform from fit plane to XY

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -1464,11 +1464,11 @@ class Path2D(Path):
 
         Returns
         ----------
-        hashed : str
-          Hashed identifier.
+        hashed : (64,) str
+          SHA256 hash of the identifier vector.
         """
         as_int = (self.identifier * 1e4).astype(np.int64)
-        return sha256(as_int.tobytes(order='C')).hexdigest()[-32:]
+        return sha256(as_int.tobytes(order='C')).hexdigest()
 
     @property
     def identifier_md5(self):

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -38,20 +38,29 @@ from . import traversal
 
 from .exchange.export import export_path
 
+# now import things which require non-minimal install of Trimesh
+# create a dummy module which will raise the ImportError
+# or other exception only when someone tries to use that function
 try:
     from . import repair
+except BaseException as E:
+    repair = exceptions.ExceptionModule(E)
+try:
     from . import polygons
+except BaseException as E:
+    polygons = exceptions.ExceptionModule(E)
+try:
     from scipy.spatial import cKDTree
+except BaseException as E:
+    cKDTree = exceptions.closure(E)
+try:
     from shapely.geometry import Polygon
+except BaseException as E:
+    Polygon = exceptions.closure(E)
+try:
     import networkx as nx
 except BaseException as E:
-    # create a dummy module which will raise the ImportError
-    # or other exception only when someone tries to use networkx
     nx = exceptions.ExceptionModule(E)
-    repair = exceptions.ExceptionModule(E)
-    polygons = exceptions.ExceptionModule(E)
-    cKDTree = exceptions.ExceptionModule(E)
-    Polygon = exceptions.ExceptionModule(E)
 
 
 class Path(parent.Geometry):

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -178,7 +178,7 @@ class Scene(Geometry3D):
         self.geometry[name] = geometry
 
         # create a unique node name if not passed
-        if True or node_name is None:
+        if node_name is None:
             # if the name of the geometry is also a transform node
             # which graph nodes already exist
             existing = self.graph.transforms.node_data.keys()

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -141,9 +141,9 @@ class Scene(Geometry3D):
                 extras=extras) for value in geometry]
         elif isinstance(geometry, dict):
             # if someone passed us a dict of geometry
-            for key, value in geometry.items():
-                self.add_geometry(value, geom_name=key, extras=extras)
-            return
+            return {k: self.add_geometry(v, geom_name=k, extras=extras)
+                    for k, v in geometry.items()}
+
         elif isinstance(geometry, Scene):
             # concatenate current scene with passed scene
             concat = self + geometry
@@ -153,9 +153,11 @@ class Scene(Geometry3D):
             # replace graph data with concatenated graph
             self.graph.transforms = concat.graph.transforms
             return
-        elif not hasattr(geometry, 'vertices'):
+
+        if not hasattr(geometry, 'vertices'):
             util.log.warning('unknown type ({}) added to scene!'.format(
                 type(geometry).__name__))
+            return
 
         # get or create a name to reference the geometry by
         if geom_name is not None:
@@ -172,12 +174,11 @@ class Scene(Geometry3D):
 
         # if its already taken use our unique name logic
         name = unique_name(start=name, contains=self.geometry.keys())
-
         # save the geometry reference
         self.geometry[name] = geometry
 
         # create a unique node name if not passed
-        if node_name is None:
+        if True or node_name is None:
             # if the name of the geometry is also a transform node
             # which graph nodes already exist
             existing = self.graph.transforms.node_data.keys()
@@ -1210,7 +1211,7 @@ def append_scenes(iterable, common=['world'], base_frame='world'):
         # we're going to hold common between scenes remap it
         if node not in common and node in consumed:
             # generate a name not in consumed
-            name = unique_name(str(node), consumed)
+            name = node + util.unique_id()
             map_node[node] = name
             node = name
 

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -38,7 +38,7 @@ class SceneGraph(object):
         # hashable, the base or root frame
         self.base_frame = base_frame
         # cache transformation matrices keyed with tuples
-        self._cache = caching.Cache(self.modified)
+        self._cache = caching.Cache(self.__hash__)
 
     def update(self, frame_to, frame_from=None, **kwargs):
         """

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -569,6 +569,7 @@ try:
     multi_dot = np.linalg.multi_dot
 except AttributeError:
     log.debug('np.linalg.multi_dot not available, using fallback')
+
     def multi_dot(arrays):
         """
         Compute the dot product of two or more arrays in a single function call.

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -2382,3 +2382,47 @@ def is_ccw(points):
     ccw = area < 0
 
     return ccw
+
+
+def unique_name(start, contains):
+    """
+    Deterministically generate a unique name not
+    contained in a dict, set or other grouping with
+    `__includes__` defined. Will create names of the
+    form "start_10" and increment accordingly.
+
+    Parameters
+    -----------
+    start : str
+      Initial guess for name.
+    contains : dict, set, or list
+      Bundle of existing names we can *not* use.
+
+    Returns
+    ---------
+    unique : str
+      A name that is not contained in `contains`
+    """
+    # exit early if name is not in bundle
+    if len(contains) == 0 or (len(start) > 0 and start not in contains):
+        return start
+
+    increment = 0
+    formatter = start + '_{}'
+    if len(start) > 0:
+        # split by our delimiter once
+        split = start.rsplit('_', 1)
+        if len(split) == 2 and split[1].isnumeric():
+            if split[0] not in contains:
+                return split[0]
+            # start incrementing from the passed value
+            increment = int(split[1])
+            formatter = split[0] + '_{}'
+
+    # if contains is empty we will only need to check once
+    for i in range(increment + 1, 2 + increment + len(contains)):
+        check = formatter.format(i)
+        if check not in contains:
+            return check
+
+    raise ValueError('unable to establish unique name!')

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -2412,12 +2412,16 @@ def unique_name(start, contains):
     if len(start) > 0:
         # split by our delimiter once
         split = start.rsplit('_', 1)
-        if len(split) == 2 and split[1].isnumeric():
+        if len(split) == 2:
             if split[0] not in contains:
                 return split[0]
-            # start incrementing from the passed value
-            increment = int(split[1])
-            formatter = split[0] + '_{}'
+            try:
+                # start incrementing from the passed value
+                # if it is not an integer this will fail
+                increment = int(split[1])
+                formatter = split[0] + '_{}'
+            except BaseException:
+                pass
 
     # if contains is empty we will only need to check once
     for i in range(increment + 1, 2 + increment + len(contains)):

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -2414,14 +2414,12 @@ def unique_name(start, contains):
         # split by our delimiter once
         split = start.rsplit('_', 1)
         if len(split) == 2:
-            if split[0] not in contains:
-                return split[0]
-            # include the first split value
-            formatter = split[0] + '_{}'
             try:
                 # start incrementing from the existing trailing value
                 # if it is not an integer this will fail
                 increment = int(split[1])
+                # include the first split value
+                formatter = split[0] + '_{}'
             except BaseException:
                 pass
 

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -2407,19 +2407,22 @@ def unique_name(start, contains):
     if len(contains) == 0 or (len(start) > 0 and start not in contains):
         return start
 
+    # start checking with zero index
     increment = 0
     formatter = start + '_{}'
+
     if len(start) > 0:
         # split by our delimiter once
         split = start.rsplit('_', 1)
         if len(split) == 2:
             if split[0] not in contains:
                 return split[0]
+            # include the first split value
+            formatter = split[0] + '_{}'
             try:
-                # start incrementing from the passed value
+                # start incrementing from the existing trailing value
                 # if it is not an integer this will fail
                 increment = int(split[1])
-                formatter = split[0] + '_{}'
             except BaseException:
                 pass
 
@@ -2429,4 +2432,6 @@ def unique_name(start, contains):
         if check not in contains:
             return check
 
-    raise ValueError('unable to establish unique name!')
+    # this should really never happen since we looped
+    # through the full length of contains
+    raise ValueError('Unable to establish unique name!')

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -568,8 +568,7 @@ try:
     # only included in recent-ish version of numpy
     multi_dot = np.linalg.multi_dot
 except AttributeError:
-    log.warning('np.linalg.multi_dot not available, using fallback')
-
+    log.debug('np.linalg.multi_dot not available, using fallback')
     def multi_dot(arrays):
         """
         Compute the dot product of two or more arrays in a single function call.
@@ -2320,7 +2319,7 @@ def decode_text(text, initial='utf-8'):
         # try to detect the encoding of the file
         detect = chardet.detect(text)
         # warn on files that aren't UTF-8
-        log.warning(
+        log.debug(
             'Data not {}! Trying {} (confidence {})'.format(
                 initial,
                 detect['encoding'],

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.15.3'
+__version__ = '3.15.4'
 
 # print version if run directly
 if __name__ == '__main__':


### PR DESCRIPTION
Also avoids thrashing the cache during multiple 2D path loads. 

- release #1712 
- fix #1710 
- fix an issue where `scene.transforms.nodes` was cleared every iteration of the loop in an internal function
- change a bunch of `log.warning` calls to `log.debug` calls, as the warnings often get confused for errors where in most cases it's just going to return a mesh without texture. 
- add test for minimal path use including DXF, SVG, and GLB export
- switch to `unique_name` in many cases to avoid appending UUID4's everywhere
- switch `geom.identifier_hash` to return the full 64 characters of the sha256 rather than clipping it arbitrarily
- add a version bump helper to setup.py: `python setup.py --bump`
- update github actions for `setup-python` and `checkout` to the latest version because it started emitting node 12 deprecation warnings :eyes: 
