### PR TITLE
Make scene bounds exact

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -656,8 +656,7 @@ class GLTFTest(g.unittest.TestCase):
     def test_same_name(self):
         s = g.get_mesh('TestScene.gltf')
         # hardcode correct bounds to check against
-        bounds = g.np.array([[-5., -1.82578002, -5.],
-                             [5., 1.86791301, 5.]])
+        bounds = s.dump(concatenate=True).bounds
 
         # icosahedrons have two primitives each
         print(len(s.geometry), len(s.graph.nodes_geometry))

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -4,15 +4,11 @@ except BaseException:
     import generic as g
 
 
-def random_chr():
-    return chr(ord('a') + int(round(g.np.random.random() * 25)))
-
-
 class SceneTests(g.unittest.TestCase):
 
     def test_scene(self):
-        for mesh in g.get_mesh('cycloidal.ply',
-                               'sphere.ply'):
+        for file_name in ['cycloidal.ply', 'sphere.ply']:
+            mesh = g.get_mesh(file_name)
             if mesh.units is None:
                 mesh.units = 'in'
 
@@ -401,6 +397,16 @@ class SceneTests(g.unittest.TestCase):
                                     original.volume)
         # nothing should have changed
         assert original.identifier_hash == original_hash
+
+    def test_exact_bounds(self):
+        m = g.get_mesh('cycloidal.3DXML')
+        assert isinstance(m, g.trimesh.Scene)
+
+        dump = m.dump(concatenate=True)
+        assert isinstance(dump, g.trimesh.Trimesh)
+
+        # scene bounds should exactly match mesh bounds
+        assert g.np.allclose(m.bounds, dump.bounds)
 
     def test_append_scenes(self):
         scene_0 = g.trimesh.Scene(base_frame='not_world')

--- a/trimesh/comparison.py
+++ b/trimesh/comparison.py
@@ -109,8 +109,9 @@ def identifier_simple(mesh):
             # just what we're looking for in a hash but hey
             identifier[3] = mesh_area / hull_area
             # cube side length ratio for the hull
-            identifier[4] = (((hull_area / 6.0) ** (1.0 / 2.0)) /
-                             (hull_volume ** (1.0 / 3.0)))
+            if hull_volume > 1e-12:
+                identifier[4] = (((hull_area / 6.0) ** (1.0 / 2.0)) /
+                                 (hull_volume ** (1.0 / 3.0)))
             # calculate maximum mesh radius
             vertices = mesh.vertices - mesh.centroid
             # add in max radius^2 to area ratio

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -301,20 +301,25 @@ class Scene(Geometry3D):
         # collect AABB for each geometry
         corners = {}
         # collect vertices for every mesh
-        vertices = {k: m.vertices for k, m in self.geometry.items()
-                    if hasattr(m, 'vertices') and len(m.vertices) > 0}
+        vertices = {k: m.vertices for k, m in
+                    self.geometry.items()
+                    if hasattr(m, 'vertices') and
+                    len(m.vertices) > 0}
         # handle 2D geometries
-        vertices.update({k: np.column_stack((v, np.zeros(len(v))))
-                         for k, v in vertices.items() if v.shape[1] == 2})
+        vertices.update(
+            {k: np.column_stack((v, np.zeros(len(v))))
+             for k, v in vertices.items() if v.shape[1] == 2})
+
         # loop through every node with geometry
         for node_name in self.graph.nodes_geometry:
             # access the transform and geometry name from node
             transform, geometry_name = self.graph[node_name]
+            # will be None if no vertices for this node
             points = vertices.get(geometry_name)
             # skip empty geometries
             if points is None:
                 continue
-            # apply just the rotation to skip a multiply
+            # apply just the rotation to skip N multiplies
             dot = np.dot(transform[:3, :3], points.T)
             # append the AABB with translation applied after
             corners[node_name] = np.array(
@@ -339,7 +344,8 @@ class Scene(Geometry3D):
         # combine each geometry node AABB into a larger list
         corners = np.vstack(list(self.bounds_corners.values()))
         return np.array([corners.min(axis=0),
-                         corners.max(axis=0)], dtype=np.float64)
+                         corners.max(axis=0)],
+                        dtype=np.float64)
 
     @caching.cache_decorator
     def extents(self):
@@ -796,7 +802,9 @@ class Scene(Geometry3D):
         ---------
         hull: Trimesh object, convex hull of all meshes in scene
         """
-        points = util.vstack_empty([m.vertices for m in self.dump()])
+        points = util.vstack_empty(
+            [m.vertices
+             for m in self.dump()])
         hull = convex.convex_hull(points)
         return hull
 

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -290,42 +290,34 @@ class Scene(Geometry3D):
     @caching.cache_decorator
     def bounds_corners(self):
         """
-        A list of points that represent the corners of the
-        AABB of every geometry in the scene.
-
-        This can be useful if you want to take the AABB in
-        a specific frame.
+        Get the post-transform AABB for each node
+        which has geometry defined.
 
         Returns
         -----------
-        corners: (n, 3) float
-          Points in space
+        corners : dict
+          Bounds for each node with vertices:
+           {node_name : (2, 3) float}
         """
-        # the saved corners of each instance
-        corners_inst = []
-        # (n, 3) float corners of each geometry
-        corners_geom = {k: bounds_module.corners(v.bounds)
-                        for k, v in self.geometry.items()
-                        if v.bounds is not None}
-        if len(corners_geom) == 0:
-            return np.array([])
-
+        # collect AABB for each geometry
+        corners = {}
+        vertices = {k: m.vertices for k, m in self.geometry.items()
+                    if hasattr(m, 'vertices')}
         for node_name in self.graph.nodes_geometry:
             # access the transform and geometry name from node
             transform, geometry_name = self.graph[node_name]
-            # not all nodes have associated geometry
-            if geometry_name not in corners_geom:
+            points = vertices.get(geometry_name)
+
+            if points is None or len(points) == 0:
                 continue
-            # transform geometry corners into where
-            # the instance of the geometry is located
-            corners_inst.extend(
-                transformations.transform_points(
-                    corners_geom[geometry_name],
-                    transform))
-        # make corners numpy array
-        corners_inst = np.array(corners_inst,
-                                dtype=np.float64)
-        return corners_inst
+
+            # apply just the rotation to skip a multiply
+            dot = np.dot(transform[:3, :3], points.T)
+            # append the AABB with translation applied after
+            corners[node_name] = np.array(
+                [dot.min(axis=1) + transform[:3, 3],
+                 dot.max(axis=1) + transform[:3, 3]])
+        return corners
 
     @caching.cache_decorator
     def bounds(self):
@@ -338,12 +330,13 @@ class Scene(Geometry3D):
           Position of [min, max] bounding box
           Returns None if no valid bounds exist
         """
-        corners = self.bounds_corners
-        if len(corners) == 0:
+        bounds_corners = self.bounds_corners
+        if len(bounds_corners) == 0:
             return None
-        bounds = np.array([corners.min(axis=0),
-                           corners.max(axis=0)])
-        return bounds
+        # combine each geometry node AABB into a larger list
+        corners = np.vstack(self.bounds_corners.values())
+        return np.array([corners.min(axis=0),
+                         corners.max(axis=0)], dtype=np.float64)
 
     @caching.cache_decorator
     def extents(self):
@@ -564,7 +557,7 @@ class Scene(Geometry3D):
 
         rotation = transformations.euler_matrix(*angles)
         transform = cameras.look_at(
-            self.bounds_corners,
+            self.bounds,
             fov=fov,
             rotation=rotation,
             distance=distance,

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.15.4'
+__version__ = '3.15.5'
 
 # print version if run directly
 if __name__ == '__main__':

--- a/trimesh/voxel/creation.py
+++ b/trimesh/voxel/creation.py
@@ -152,7 +152,7 @@ def local_voxelize(mesh,
 
     # Fill internal regions
     if fill:
-        regions, n = ndimage.measurements.label(~voxels)
+        regions, n = ndimage.label(~voxels)
         distance = ndimage.distance_transform_cdt(~voxels)
         representatives = [
             np.unravel_index((distance * (regions == i)).argmax(),


### PR DESCRIPTION
Just transform all vertices to calculate exact scene bounds. In tests it actually looked faster than existing approximate-conservative AABB method but I didn't test on large scenes. 

- fix #1706 
- fix #1700 