### PR TITLE
feature: Support adding animations to GLTF export as a postprocessing step

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -157,7 +157,8 @@ def export_glb(
         scene,
         include_normals=None,
         unitize_normals=False,
-        tree_postprocessor=None):
+        tree_postprocessor=None,
+        buffer_postprocessor=None):
     """
     Export a scene as a binary GLTF (GLB) file.
 
@@ -187,7 +188,7 @@ def export_glb(
     tree, buffer_items = _create_gltf_structure(
         scene=scene,
         unitize_normals=unitize_normals,
-        include_normals=include_normals)
+        include_normals=include_normals, buffer_postprocessor=buffer_postprocessor)
 
     # allow custom postprocessing
     if tree_postprocessor is not None:
@@ -589,7 +590,8 @@ def _jsonify(blob):
 def _create_gltf_structure(scene,
                            include_normals=None,
                            include_metadata=True,
-                           unitize_normals=None,):
+                           unitize_normals=None,
+                           buffer_postprocessor=None):
     """
     Generate a GLTF header.
 
@@ -682,6 +684,9 @@ def _create_gltf_structure(scene,
     nodes = scene.graph.to_gltf(
         scene=scene, mesh_index=mesh_index)
     tree.update(nodes)
+
+    if buffer_postprocessor is not None:
+        buffer_postprocessor(buffer_items, tree)
 
     # convert accessors back to a flat list
     tree['accessors'] = list(tree['accessors'].values())


### PR DESCRIPTION
Hey, based on https://github.com/mikedh/trimesh/issues/1714 I finally got some time to take another look. And now I managed to find the appropriate entrypoint within the GLTF export for adding animations. 

![gltf_animation](https://user-images.githubusercontent.com/9642232/204144153-0d083e8d-f5d1-4884-a9d2-cd1bbc3df37c.gif)

If you want me to create a test for this let me know where you want it? (I will then also add the remaining test discussed in https://github.com/mikedh/trimesh/pull/1734)

Here's a minimum working example

```python
import trimesh
from trimesh.visual.material import PBRMaterial
import numpy as np
import os


def polygon_mesh():
    vertices = np.asarray([(0, 0, 0), (0, 1, 0), (1, 1, 0)], dtype="float32")
    faces = np.asarray([(0, 1, 2)], dtype="uint8")
    vertex_color = np.asarray([(245, 40, 145), (128, 50, 0), (200, 50, 0)], dtype="uint8")
    new_mesh = trimesh.Trimesh(vertices=vertices, faces=faces, vertex_colors=vertex_color)
    new_mesh.visual.material = PBRMaterial(doubleSided=True)
    return new_mesh


scene = trimesh.Scene()

scene.add_geometry(polygon_mesh(), node_name="test", geom_name="test")

def add_animation_to_buffer(buffer_items, tree, node_no=1):
    from trimesh.exchange.gltf import _data_append, uint32

    deform = np.array(
        [[0.07455, 0.13965, -0.02597], [0.03956, -0.02361, 0.03978], [-0.14752, -0.10503, -0.04253]],
        dtype="float32",
    )

    pos = _data_append(
        acc=tree["accessors"],
        buff=buffer_items,
        blob={"componentType": 5126, "type": "VEC3"},
        data=deform,
    )

    val1 = np.array(
        [0.00000, 0.04167, 0.08333, 0.12500, 0.16667, 0.20833, 0.25000, 0.29167, 0.33333, 0.37500, 0.41667],
        dtype="float32",
    )
    input_val = _data_append(
        acc=tree["accessors"],
        buff=buffer_items,
        blob={"componentType": 5126, "type": "SCALAR"},
        data=val1,
    )
    val2 = np.array(
        [0.00000, 0.02800, 0.10400, 0.21600, 0.35200, 0.50000, 0.64800, 0.78400, 0.89600, 0.97200, 1.00000],
        dtype="float32",
    )
    output_val = _data_append(
        acc=tree["accessors"],
        buff=buffer_items,
        blob={"componentType": 5126, "type": "SCALAR"},
        data=val2,
    )

    # Update tree with data added to buffer
    tree["animations"] = [
        {
            "name": "animation1",
            "samplers": [{"input": input_val, "interpolation": "LINEAR", "output": output_val}],
            "channels": [{"sampler": 0, "target": {"node": node_no, "path": "weights"}}],
        }
    ]
    mesh_no = tree["nodes"][node_no]["mesh"]
    mesh = tree["meshes"][mesh_no]

    mesh["extras"]["targetNames"] = ["Deformed"]
    mesh["weights"] = [mesh_no]

    primitive = mesh["primitives"][0]
    primitive.pop("mode")
    primitive["targets"] = [{"POSITION": pos}]

    print()


os.makedirs("temp", exist_ok=True)

scene.export(
    file_obj="temp/polygon_animation.glb",
    file_type=".glb",
    buffer_postprocessor=add_animation_to_buffer,
)
```

- closes #1714