### PR TITLE
Release: Voxel Tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye AS base
+FROM python:3.11-slim-bullseye AS base
 LABEL maintainer="mikedh@kerfed.com"
 
 # Install the llvmpipe software renderer

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -11,14 +11,14 @@ Typically when writing Dockerfiles it is a good idea to use a first-party base i
 
 It should generally work fine to just use a first party base image and install trimesh via `pip` which always has the latest version:
 ```
-FROM python:3.10-slim-bullseye
+FROM python:3.11-slim-bullseye
 RUN pip install trimesh[easy]
 ```
 
 
 ### Using Prebuilt Images
 
-The `trimesh/trimesh` docker images are based on the offical Python base image, currently `python:3.10-slim-bullseye`. They are built and pushed to Docker Hub automatically in Github Actions for every release. 
+The `trimesh/trimesh` docker images are based on the offical Python base image, currently `python:3.11-slim-bullseye`. They are built and pushed to Docker Hub automatically in Github Actions for every release. 
 
 If you need some of the more demanding dependencies they can be a good option. The `trimesh/trimesh` images are pushed with three tags: `latest` (for latest :), semantic version (i.e. `3.15.5`), or git short hash (i.e. `1c6178d`). These images include `embree` and `trimesh[all]` which is run in a multi-stage build to avoid including intermediate files in the final image.
 
@@ -41,7 +41,7 @@ docker run -t example
 
 ### Building Trimesh Images
 
-Trimesh is using a multistage build to avoid copying in things like `g++`, so you have to explicitly specify that you want to build the `output` target. You also probably neeed to enable BuildKit:
+Trimesh is using a multistage build to avoid copying in things like `g++`, so you have to explicitly specify that you want to build the `output` target. You also probably need to enable BuildKit:
 
 ```
 DOCKER_BUILDKIT=1 docker build --target output -t trimesh/trimesh:latest .

--- a/tests/corpus.py
+++ b/tests/corpus.py
@@ -179,7 +179,8 @@ if __name__ == '__main__':
             repo='ros-industrial/universal_robot',
             commit='8f01aa1934079e5a2c859ccaa9dd6623d4cfa2fe'))
 
-    P.print()
+    # show all profiler lines
+    P.print(show_all=True)
 
     # print a formatted report of what we loaded
     print('\n'.join(f'# {k}\n{v}\n' for k, v in report.items()))

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -31,6 +31,7 @@ from trimesh.constants import tol, tol_path
 from collections import deque
 from copy import deepcopy
 
+tf = trimesh.transformations
 
 if sys.version_info >= (3, 1):
     # Python 3

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -348,6 +348,22 @@ class OBJTest(g.unittest.TestCase):
         assert g.np.isclose(m.visual.material.glossiness,
                             r.visual.material.glossiness)
 
+    def test_scene_export_material_name(self):
+        s = g.get_mesh('fuze.obj', force='scene')
+        dummy = 'fuxx'
+        s.geometry['fuze.obj'].visual.material.name = dummy
+
+        r = g.trimesh.resolvers.ZipResolver()
+        r['model.obj'] = s.export(
+            file_type='obj',
+            mtl_name='mystuff.mtl',
+            resolver=r)
+
+        mtl = r['mystuff.mtl'].decode('utf-8')
+        assert mtl.count('newmtl') == 1
+        assert 'newmtl {}'.format(dummy) in mtl
+        assert '{}.jpeg'.format(dummy) in r
+
     def test_compound_scene_export(self):
 
         # generate a mesh with multiple textures

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -80,6 +80,14 @@ class PrimitiveTest(g.unittest.TestCase):
         p.apply_scale(5.0)
         assert g.np.allclose(p.bounds, [[0, 0, 0], [5, 5, 5]])
 
+        try:
+            raised = False
+            p.apply_scale([2, 3, 4])
+        except BaseException:
+            raised = True
+        if not raised:
+            raise ValueError('primitives should raise on non-uniform scaling')
+
         # now try with more complicated generated data
         prims = [g.trimesh.primitives.Sphere(radius=1.0),
                  g.trimesh.primitives.Sphere(radius=112.007),

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -75,12 +75,18 @@ class PrimitiveTest(g.unittest.TestCase):
         assert g.np.allclose(m.extents, 1.0)
         assert g.np.allclose(p.extents, m.extents, atol=1e-3)
 
+        p = g.trimesh.primitives.Box()
+        p.apply_translation([0.5, 0.5, 0.5])
+        p.apply_scale(5.0)
+        assert g.np.allclose(p.bounds, [[0, 0, 0], [5, 5, 5]])
+
         # now try with more complicated generated data
         prims = [g.trimesh.primitives.Sphere(radius=1.0),
                  g.trimesh.primitives.Sphere(radius=112.007),
                  g.trimesh.primitives.Cylinder(radius=1.0,
                                                height=10.0),
-
+                 g.trimesh.primitives.Box(),
+                 g.trimesh.primitives.Box(extents=[12, 32, 31]),
                  g.trimesh.primitives.Cylinder(radius=1.1212,
                                                height=0.001),
                  g.trimesh.primitives.Capsule(radius=1.0,

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -62,6 +62,78 @@ class PrimitiveTest(g.unittest.TestCase):
         self.primitives.append(g.trimesh.primitives.Capsule(radius=1.5,
                                                             height=10))
 
+    def test_scaling(self):
+        # try a simple scaling test
+        p = g.trimesh.primitives.Sphere(radius=1.0)
+        m = p.to_mesh()
+        assert g.np.allclose(p.extents, 2.0)
+        assert g.np.allclose(m.extents, 2.0)
+        p.apply_scale(0.5)
+        m.apply_scale(0.5)
+        assert g.np.isclose(p.primitive.radius, 0.5)
+        assert g.np.allclose(p.extents, 1.0)
+        assert g.np.allclose(m.extents, 1.0)
+        assert g.np.allclose(p.extents, m.extents, atol=1e-3)
+
+        # now try with more complicated generated data
+        prims = [g.trimesh.primitives.Sphere(radius=1.0),
+                 g.trimesh.primitives.Sphere(radius=112.007),
+                 g.trimesh.primitives.Cylinder(radius=1.0,
+                                               height=10.0),
+
+                 g.trimesh.primitives.Cylinder(radius=1.1212,
+                                               height=0.001),
+                 g.trimesh.primitives.Capsule(radius=1.0,
+                                              height=7.0)]
+
+        for original in prims:
+            perm = [original, original.copy(), original.copy()]
+            # try with a simple translation
+            perm[1].primitive.transform = g.tf.translation_matrix([0, 0, 7])
+            # try with a gnarly rotation
+            perm[2].primitive.transform = g.tf.random_rotation_matrix(
+                translate=1000)
+
+            fields = set(dir(original.primitive))
+            ori_radius, ori_height = None, None
+            if 'radius' in fields:
+                ori_radius = original.primitive.radius
+            if 'height' in fields:
+                ori_height = original.primitive.height
+
+            for scale in [1e-2, 0.123, 0.5, 100.2]:
+                for po in perm:
+                    # converting to mesh will do all scaling
+                    # and transformations on simple discrete
+                    # copy of primitive and should match with
+                    # only tesselation differences
+                    p = po.copy()
+                    m = p.to_mesh()
+
+                    # make sure we have the types we think we do
+                    assert isinstance(p, g.trimesh.primitives._Primitive)
+                    assert isinstance(m, g.trimesh.Trimesh)
+
+                    assert g.np.allclose(p.extents, m.extents)
+
+                    p.apply_scale(scale)
+                    m.apply_scale(scale)
+
+                    # matrix should never have scale
+                    assert g.tf.is_rigid(p.primitive.transform)
+
+                    if ori_radius is not None:
+                        assert g.np.isclose(p.primitive.radius,
+                                            ori_radius * scale)
+                    if ori_height is not None:
+                        assert g.np.isclose(p.primitive.height,
+                                            ori_height * scale)
+
+                    # should be the same size
+                    assert g.np.allclose(p.extents, m.extents, atol=1e-3 * scale)
+                    # should be in the same place
+                    assert g.np.allclose(p.bounds, m.bounds, atol=1e-3 * scale)
+
     def test_primitives(self):
 
         kind = set([i.__class__.__name__

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -27,6 +27,19 @@ class ResolverTest(g.unittest.TestCase):
         assert set(ns.keys()).issuperset(['tray-easy1.dxf',
                                           'single_arc.dxf'])
 
+    def test_web_namespace(self):
+        base = 'https://example.com'
+        ns = 'stuff'
+        # check with a trailing slash
+        a = g.trimesh.resolvers.WebResolver(base + '/')
+        b = a.namespaced(ns)
+
+        # should have correct slashes
+        truth = base + '/' + ns
+        assert b.base_url == truth
+        # should not have altered original
+        assert a.base_url == base + '/'
+
     def test_items(self):
         # check __getitem__ and __setitem__
         archive = {}

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,0 +1,57 @@
+try:
+    from . import generic as g
+except BaseException:
+    import generic as g
+
+
+class ResolverTest(g.unittest.TestCase):
+
+    def test_filepath_namespace(self):
+        # check the namespaced method
+        models = g.dir_models
+        subdir = '2D'
+
+        # create a resolver for the models diretory
+        resolver = g.trimesh.resolvers.FilePathResolver(models)
+
+        # should be able to get an asset
+        assert len(resolver.get('rabbit.obj')) > 0
+
+        # check a few file path keys
+        check = set(['ballA.off', 'featuretype.STL'])
+        assert set(resolver.keys()).issuperset(check)
+
+        # try a namespaced resolver
+        ns = resolver.namespaced(subdir)
+        assert not set(ns.keys()).issuperset(check)
+        assert set(ns.keys()).issuperset(['tray-easy1.dxf',
+                                          'single_arc.dxf'])
+
+    def test_items(self):
+        # check __getitem__ and __setitem__
+        archive = {}
+        resolver = g.trimesh.resolvers.ZipResolver(archive)
+        assert len(set(resolver.keys())) == 0
+        resolver['hi'] = b'what'
+        # should have one item
+        assert set(resolver.keys()) == set(['hi'])
+        # should have the right value
+        assert resolver['hi'] == b'what'
+        # original archive should have been modified
+        assert set(archive.keys()) == set(['hi'])
+
+        # add a subdirectory key
+        resolver['stuff/nah'] = b'sup'
+        assert set(archive.keys()) == set(['hi', 'stuff/nah'])
+        assert set(resolver.keys()) == set(['hi', 'stuff/nah'])
+
+        # try namespacing
+        ns = resolver.namespaced('stuff')
+        assert ns['nah'] == b'sup'
+        print(ns.keys())
+        assert set(ns.keys()) == set(['nah'])
+
+
+if __name__ == '__main__':
+    g.trimesh.util.attach_to_log()
+    g.unittest.main()

--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -334,7 +334,7 @@ class VoxelGridTest(g.unittest.TestCase):
             g.log.warning('no binvox to test!')
             return
 
-        filled = Sphere().voxelized(
+        filled = g.trimesh.primitives.Sphere().voxelized(
             pitch=0.1,
             method='binvox',
             exact=True)
@@ -355,9 +355,10 @@ class VoxelGridTest(g.unittest.TestCase):
             g.log.warning('no binvox to test!')
             return
 
-        octant = Sphere().voxelized(pitch=0.1,
-                                    method='binvox',
-                                    exact=True)
+        octant = g.trimesh.primitives.Sphere().voxelized(
+            pitch=0.1,
+            method='binvox',
+            exact=True)
         dense = octant.encoding.dense.copy()
         nx, ny, nz = octant.shape
         dense[:nx // 2] = 0
@@ -376,11 +377,12 @@ class VoxelGridTest(g.unittest.TestCase):
             return
 
         dim = 10
-        octant = Sphere().voxelized(pitch=None,
-                                    dimension=dim,
-                                    method='binvox',
-                                    exact=True)
-        self.assertEqual(octant.shape, (dim,) * 3)
+        octant = g.trimesh.primitives.Sphere().voxelized(
+            pitch=None,
+            dimension=dim,
+            method='binvox',
+            exact=True)
+        assert octant.shape == (dim, dim, dim)
 
 
 if __name__ == '__main__':

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2477,7 +2477,7 @@ class Trimesh(Geometry3D):
             vertices=open3d.utility.Vector3dVector(self.vertices),
             triangles=open3d.utility.Vector3iVector(self.faces))
 
-    def simplify_quadratic_decimation(self, face_count):
+    def simplify_quadric_decimation(self, face_count):
         """
         A thin wrapper around the open3d implementation of this:
         `open3d.geometry.TriangleMesh.simplify_quadric_decimation`

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -110,7 +110,7 @@ class Trimesh(Geometry3D):
         # self._cache stores information about the mesh which CAN be
         # regenerated from self._data, but may be slow to calculate.
         # In order to maintain consistency
-        # the cache is cleared when self._data.crc() changes
+        # the cache is cleared when self._data.__hash__() changes
         self._cache = caching.Cache(
             id_function=self._data.__hash__,
             force_immutable=True)
@@ -2477,9 +2477,21 @@ class Trimesh(Geometry3D):
             vertices=open3d.utility.Vector3dVector(self.vertices),
             triangles=open3d.utility.Vector3iVector(self.faces))
 
+    def simplify_quadratic_decimation(self, *args, **kwargs):
+        """
+        DERECATED MARCH 2024 REPLACE WITH:
+        `mesh.simplify_quadric_decimation`
+        """
+        warnings.warn(
+            '`simplify_quadratic_decimation` is deprecated ' +
+            'as it was a typo and will be removed in March 2024: ' +
+            'replace with `simplify_quadric_decimation`',
+            DeprecationWarning)
+        return self.simplify_quadric_decimation(*args, **kwargs)
+
     def simplify_quadric_decimation(self, face_count):
         """
-        A thin wrapper around the open3d implementation of this:
+        A thin wrapper around the `open3d` implementation of this:
         `open3d.geometry.TriangleMesh.simplify_quadric_decimation`
 
         Parameters

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -361,13 +361,13 @@ class Cache(object):
           If set will make all numpy arrays read-only
         """
         self._id_function = id_function
-        # force stored numpy arrays to have flags.writable=False
+        # for stored numpy arrays set `flags.writable = False`
         self.force_immutable = bool(force_immutable)
         # call the id function for initial value
         self.id_current = self._id_function()
         # a counter for locks
         self._lock = 0
-        # actuSal store for data
+        # actual store for data
         self.cache = {}
 
     def delete(self, key):

--- a/trimesh/exchange/threedxml.py
+++ b/trimesh/exchange/threedxml.py
@@ -152,7 +152,7 @@ def load_3DXML(file_obj, *args, **kwargs):
                 strips = [np.fromstring(i, sep=' ', dtype=np.int64)
                           for i in faces.attrib['strips'].split(',')]
 
-                # convert strips to (m,3) int
+                # convert strips to (m, 3) int
                 mesh_faces.append(util.triangle_strips_to_faces(strips))
             if 'triangles' in faces.attrib:
                 # both triangles and strips are allowed to be defined so
@@ -174,7 +174,7 @@ def load_3DXML(file_obj, *args, **kwargs):
                 sep=' ',
                 dtype=np.float64).reshape((-1, 3)))
 
-            # store the material information as (m,3) uint8 FACE COLORS
+            # store the material information as (m, 3) uint8 FACE COLORS
             mesh_colors.append(np.tile(colors[material_id],
                                        (len(mesh_faces[-1]), 1)))
 

--- a/trimesh/interfaces/gmsh.py
+++ b/trimesh/interfaces/gmsh.py
@@ -135,7 +135,7 @@ def to_volume(mesh,
       Maximum length of an element in the volume mesh
     mesher_id : int
       3D unstructured algorithms:
-      1: Delaunay, 4: Frontal, 7: MMG3D, 10: HXT
+      1: Delaunay, 3: Initial mesh only, 4: Frontal, 7: MMG3D, 9: R-tree, 10: HXT
 
     Returns
     ------------
@@ -147,8 +147,8 @@ def to_volume(mesh,
     import gmsh
 
     # checks mesher selection
-    if mesher_id not in [1, 4, 7, 10]:
-        raise ValueError('unavilable mesher selected!')
+    if mesher_id not in [1, 3, 4, 7, 9, 10]:
+        raise ValueError('unavailable mesher selected!')
     else:
         mesher_id = int(mesher_id)
 

--- a/trimesh/permutate.py
+++ b/trimesh/permutate.py
@@ -29,8 +29,8 @@ def transform(mesh, translation_scale=1000.0):
       and rigidly transformed in space.
     """
     # rotate and translate randomly
-    matrix = transformations.random_rotation_matrix()
-    matrix[:3, 3] = (np.random.random(3) - 0.5) * translation_scale
+    matrix = transformations.random_rotation_matrix(
+        translate=translation_scale)
 
     # randomly re-order triangles
     triangles = np.random.permutation(mesh.triangles).reshape((-1, 3))

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -418,7 +418,7 @@ class PointCloud(Geometry3D):
           Metadata about points
         """
         self._data = caching.DataStore()
-        self._cache = caching.Cache(self._data.hash)
+        self._cache = caching.Cache(self._data.__hash__)
         self.metadata = {}
 
         if metadata is not None:

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -165,14 +165,12 @@ class _Primitive(Trimesh):
             if hasattr(prim, 'radius'):
                 prim.radius *= scale
 
-        # get the current transform
-        #current = self.primitive.transform
+        # apply the new transform to the old
         new_transform = np.dot(
             matrix, self.primitive.transform)
-
         assert tf.is_rigid(new_transform)
-
         self.primitive.transform = new_transform
+
         return self
 
     def _create_mesh(self):

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -174,12 +174,14 @@ class _Primitive(Trimesh):
                 prim.height *= scale
             if hasattr(prim, 'radius'):
                 prim.radius *= scale
+            if hasattr(prim, 'extents'):
+                prim.extents *= scale
 
+            current[:3, 3] *= scale
             # apply new matrix, rescale, translate, current
             updated = util.multi_dot([
                 matrix,
                 tf.scale_matrix(1.0 / scale),
-                tf.translation_matrix(current[:3, 3] * -scale),
                 current])
 
         else:
@@ -210,9 +212,7 @@ class _PrimitiveAttributes(object):
         self._data.update(defaults)
         self._mutable = True
         for key, default in defaults.items():
-            if key == 'transform':
-                pass  # continue
-            elif key in kwargs:
+            if key in kwargs:
                 self._data[key] = util.convert_like(
                     kwargs[key], default)
 

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -8,7 +8,6 @@ Useful because you can move boxes and spheres around
 and then use trimesh operations on them at any point.
 """
 import numpy as np
-import copy
 import abc
 
 from . import util
@@ -124,7 +123,7 @@ class _Primitive(Trimesh):
           Copy of current primitive
         """
         # get the constructor arguments
-        kwargs = self.to_dict()
+        kwargs.update(self.to_dict())
         # remove the type indicator, i.e. `Cylinder`
         kwargs.pop('kind')
         # create a new object with kwargs

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -238,6 +238,7 @@ class _PrimitiveAttributes(object):
             if value is not None:
                 # convert passed data into type of defaults
                 self._data[key] = util.convert_like(value, default)
+
         # make sure stored values are immutable after setting
         if not self._mutable:
             self._data.mutable = False
@@ -269,7 +270,6 @@ class _PrimitiveAttributes(object):
         elif key == 'center':
             # this whole __getattr__ is a little hacky
             return self._data['transform'][:3, 3]
-
         elif key in self._defaults:
             return util.convert_like(self._data[key],
                                      self._defaults[key])
@@ -277,7 +277,6 @@ class _PrimitiveAttributes(object):
             "primitive object has no attribute '{}' ".format(key))
 
     def __setattr__(self, key, value):
-
         if key.startswith('_'):
             return super(_PrimitiveAttributes,
                          self).__setattr__(key, value)
@@ -539,10 +538,18 @@ class Sphere(_Primitive):
         defaults = {'radius': 1.0,
                     'transform': np.eye(4),
                     'subdivisions': 3}
+
+        # center is a helper method for "transform"
+        # since a sphere is rotationally symmetric
+        center = kwargs.get('center', None)
+        if center is not None:
+            translate = np.eye(4)
+            translate[:3, 3] = center
+            kwargs['transform'] = translate
+
+        # create the attributes object
         self.primitive = _PrimitiveAttributes(
             self, defaults, kwargs)
-        if 'center' in kwargs:
-            self.primitive.center = kwargs['center']
 
     @property
     def center(self):

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -189,6 +189,14 @@ class ZipResolver(Resolver):
             self.namespace = None
 
     def keys(self):
+        """
+        Get the available keys in the current archive.
+
+        Returns
+        -----------
+        keys : iterable
+          Keys in the current archive.
+        """
         if self.namespace is not None:
             namespace = self.namespace
             length = len(namespace)
@@ -202,6 +210,14 @@ class ZipResolver(Resolver):
 
     def write(self, key, value):
         """
+        Store a value in the current archive.
+
+        Parameters
+        -----------
+        key : hashable
+          Key to store data under.
+        value : str, bytes, file-like
+          Value to store.
         """
         if self.archive is None:
             self.archive = {}

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -400,6 +400,9 @@ class GithubResolver(Resolver):
         """
         return self.zipped.keys()
 
+    def write(self, name, data):
+        raise NotImplementedError('`write` not implemented!')
+
     @property
     def zipped(self):
         """

--- a/trimesh/transformations.py
+++ b/trimesh/transformations.py
@@ -1567,7 +1567,7 @@ def random_quaternion(rand=None, num=1):
                      np.cos(t1) * r1, np.sin(t2) * r2]).T.squeeze()
 
 
-def random_rotation_matrix(rand=None, num=1):
+def random_rotation_matrix(rand=None, num=1, translate=False):
     """Return uniform random rotation matrix.
 
     rand: array like
@@ -1582,7 +1582,12 @@ def random_rotation_matrix(rand=None, num=1):
     True
 
     """
-    return quaternion_matrix(random_quaternion(rand=rand, num=num))
+    matrix = quaternion_matrix(
+        random_quaternion(rand=rand, num=num))
+    if translate:
+        scale = float(translate)
+        matrix[:3, 3] = (np.random.random(3) - 0.5) * scale
+    return matrix
 
 
 class Arcball(object):

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.17.1'
+__version__ = '3.17.2'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.17.2'
+__version__ = '3.18.0'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script

--- a/trimesh/visual/base.py
+++ b/trimesh/visual/base.py
@@ -17,11 +17,11 @@ class Visuals(ABC):
         pass
 
     @abc.abstractmethod
-    def update_vertices(self):
+    def update_vertices(self, mask):
         pass
 
     @abc.abstractmethod
-    def update_faces(self):
+    def update_faces(self, mask):
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
- change imports in voxel tests
- add tests and docstrings for `trimesh.resolvers.namespaced`
  - fix a number of incorrect uses of `str.lstrip` which takes chars not a substring and produces odd results if you're expecting it to trim a prefix. 
- release #1782
- release #1796 
- release #1793 
- fix #1790 
  - for a primitive.apply_scale(value) will now alter the radius/height/extents
  - I didn't implement it for Extrusion but the simple kinds all work pretty well
  - I added tests that the scaling of radius/height/transform produced the same result as simple "transform the vertices" 
- fix new releases of numpy raising on `np.array(ragged sequence)` in `geometry.triangulate_quads`
- print full profiler on "load everything we can get our hands on test" in `corpus.py`
- update docker base image to python 3.11 