### PR TITLE
Handle `pathlib` objects in export_scene

### DIFF
--- a/trimesh/exchange/export.py
+++ b/trimesh/exchange/export.py
@@ -223,6 +223,10 @@ def export_scene(scene,
     if len(scene.geometry) == 0:
         raise ValueError("Can't export empty scenes!")
 
+    if util.is_pathlib(file_obj):
+        # handle `pathlib` objects by converting to string
+        file_obj = str(file_obj.absolute())
+
     # if we weren't passed a file type extract from file_obj
     if file_type is None:
         if util.is_string(file_obj):


### PR DESCRIPTION
Hi, this is a quick fix to handle `pathlib` objects when exporting a scene. The lines are simply copied from `export_mesh()`: https://github.com/mikedh/trimesh/blob/d7ffc6a112794a1b896734624fd26cf0d8834ec3/trimesh/exchange/export.py#L47-L49

Before the fix it was falling to no writeable file object, afterward it writes the file properly with the following snippet:
```python
import trimesh
from pathlib import Path

if __name__ == '__main__':
    scene = trimesh.load('input.obj')
    scene.export(Path('output.obj'), file_type='obj')
```