### PR TITLE
Release: Fixes O3D

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Formatting
       run: |
         python -m pip install --upgrade pip
-        pip install autopep8 flake8 flake8-no-implicit-concat
+        pip install `python setup.py --list-test`
     - name: Check Formatting
       run: |
         flake8 tests
@@ -69,7 +69,7 @@ jobs:
         pip install .
         python tests/test_minimal.py
     - name: Install Trimesh
-      run: pip install .[easy,test]
+      run: pip install .[easy, test]
     - name: Run Pytest
       run: pytest tests/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: "3.10"
     - name: Install Formatting
       run: |
-        pip install autopep8 flake8 flake8-no-implicit-concat
+        pip install `python setup.py --list-test`
     - name: Check Formatting
       run: |
         flake8 tests

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,9 +16,9 @@ python -m venv ~/myenv
 echo "source ~/myenv/bin/activate" >> ~/.bashrc
 ```
 
-With a virtual environment so pip doesn't dump files everywhere you can install some stuff. The `flake8-no-implicit-concat` adds a rule which disallows strings on different lines with no comma being concatenated as this is pretty much always a bug.
+With a virtual environment so pip doesn't dump files everywhere you can install some stuff. I usually start with:
 ```
-pip install autopep8 flake8 flake8-no-implicit-concat codespell pyinstrument ipython
+pip install codespell ipython
 ```
 
 If you're planning on editing trimesh you might want to fork it via the Github interface, then install it via an editable pip install:
@@ -28,7 +28,7 @@ git clone git@github.com:mikedh/trimesh.git
 
 # do an editable install so you can experiment
 cd trimesh
-pip install -e .
+pip install -e .[easy, test]
 ```
 
 

--- a/examples/nricp.py
+++ b/examples/nricp.py
@@ -128,9 +128,16 @@ if __name__ == '__main__':
                 t = value - t1
 
                 pv_mesh.points = (1 - t) * records[t1] + t * records[t2]
-                for i, pos in enumerate(pv_mesh.points[landmarks_vertex_indices[:, 0]]):
-                    p.add_mesh(pv.Sphere(target.scale / 200, pos), name=str(i), color='r')
-                pv_mesh['scalars'] = (1 - t) * distances[t1] + t * distances[t2]
+                for i, pos in enumerate(
+                        pv_mesh.points[landmarks_vertex_indices[:, 0]]):
+                    p.add_mesh(
+                        pv.Sphere(
+                            target.scale / 200,
+                            pos),
+                        name=str(i),
+                        color='r')
+                pv_mesh['scalars'] = (
+                    1 - t) * distances[t1] + t * distances[t2]
             p.add_slider_widget(cb, rng=(0, len(records)), value=0,
                                 color='black', event_type='always')
 

--- a/examples/outlined.py
+++ b/examples/outlined.py
@@ -13,7 +13,8 @@ if __name__ == '__main__':
 
     # get edges we want to highlight by finding edges
     # that have sharp angles between adjacent faces
-    edges = mesh.face_adjacency_edges[mesh.face_adjacency_angles > np.radians(30)]
+    edges = mesh.face_adjacency_edges[mesh.face_adjacency_angles > np.radians(
+        30)]
     # get a Path3D object for the edges we want to highlight
     path = trimesh.path.Path3D(**trimesh.path.exchange.misc.edges_to_path(
         edges, mesh.vertices.copy()))

--- a/examples/voxel.py
+++ b/examples/voxel.py
@@ -37,15 +37,21 @@ if __name__ == '__main__':
     binvox_path = os.path.join(dir_models, '%s.binvox' % base_name)
     chair_voxels = trimesh.load(binvox_path)
 
-    chair_voxels = v.VoxelGrid(chair_voxels.encoding.dense, chair_voxels.transform)
+    chair_voxels = v.VoxelGrid(
+        chair_voxels.encoding.dense,
+        chair_voxels.transform)
 
     print('white: voxelized chair (binvox, exact)')
-    show(chair_mesh, voxelize_mesh(chair_mesh, exact=True), colors=(1, 1, 1, 0.3))
+    show(
+        chair_mesh, voxelize_mesh(
+            chair_mesh, exact=True), colors=(
+            1, 1, 1, 0.3))
 
     print('red: binvox-loaded chair')
     show(chair_mesh, chair_voxels, colors=(1, 0, 0, 0.3))
 
-    voxelized_chair_mesh = chair_mesh.voxelized(np.max(chair_mesh.extents) / 32)
+    voxelized_chair_mesh = chair_mesh.voxelized(
+        np.max(chair_mesh.extents) / 32)
     print('green: voxelized chair (default).')
     show(chair_mesh, voxelized_chair_mesh, colors=(0, 1, 0, 0.3))
 
@@ -84,7 +90,8 @@ if __name__ == '__main__':
     print('red: binvox (default). Poor performance on thin structures')
     show(chair_mesh, voxelized, colors=(1, 0, 0, 0.3))
 
-    voxelized = chair_mesh.voxelized(pitch=0.02, method='binvox', wireframe=True)
+    voxelized = chair_mesh.voxelized(
+        pitch=0.02, method='binvox', wireframe=True)
     print('green: binvox (wireframe). Still doesn\'t capture all thin structures')
     show(chair_mesh, voxelized, colors=(0, 1, 0, 0.3))
 
@@ -101,7 +108,8 @@ if __name__ == '__main__':
     print('red: binvox (exact downsampled) surface')
     show(chair_mesh, voxelized, colors=(1, 0, 0, 0.3))
 
-    chair_voxels = chair_mesh.voxelized(pitch=0.02, method='binvox', exact=True)
+    chair_voxels = chair_mesh.voxelized(
+        pitch=0.02, method='binvox', exact=True)
 
     voxelized = chair_voxels.copy().fill(method='base')
     print('blue: binvox (exact) filled (base). Gets a bit overly excited')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ requires = [
     "setuptools >= 40.8",
     "wheel",
 ]
+
+[tool.flake8]
+max_line_length = "90"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,4 @@ requires = [
 ]
 
 [tool.flake8]
-max_line_length = "90"
+max_line_length = 90

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max_line_length=90

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ lock = [((3, 4), 'lxml', '4.3.5'),
         ((3, 4), 'pyglet', '1.4.10'),
         ((3, 5), 'sympy', None),
         ((3, 0), 'pyglet<2', None),
+        ((3, 0), 'autopep8', None),
         ((3, 0), 'flake8-pyproject', None),
         ((3, 0), 'flake8-no-implicit-concat', None),
         ((3, 6), 'svg.path', '4.1')]

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,12 @@ requirements_test = set(['pytest',       # run all unit tests
                          'pytest-cov',   # coverage plugin
                          'pyinstrument',  # profile code
                          'coveralls',    # report coverage stats
+                         'autopep8',     # check and autoformat
+                         'flake8',           # static code analysis
+                         'flake8-pyproject', # use new config format
+                         'flake8-no-implicit-concat', # concat rules
                          'ezdxf'])       # use as a validator for exports
+
 
 # Python 2.7 and 3.4 support has been dropped from packages
 # version lock those packages here so install succeeds

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,8 @@ requirements_test = set(['pytest',       # run all unit tests
                          'coveralls',    # report coverage stats
                          'autopep8',     # check and autoformat
                          'flake8',           # static code analysis
-                         'flake8-pyproject', # use new config format
-                         'flake8-no-implicit-concat', # concat rules
+                         'flake8-pyproject',  # use new config format
+                         'flake8-no-implicit-concat',  # concat rules
                          'ezdxf'])       # use as a validator for exports
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ requirements_easy = set([
     'scipy',     # provide convex hulls, fast graph ops, etc
     'networkx',  # provide slow graph ops with a nice API
     'lxml',      # handle XML better and faster than built- in XML
-    'pyglet<2',  # render preview windows nicely : note pyglet 2.0 is basically a re-write
     'shapely',   # handle 2D polygons robustly
     'rtree',     # create N-dimension trees for broad-phase queries
     'svg.path',  # handle SVG format path strings
@@ -62,6 +61,7 @@ requirements_all = requirements_easy.union([
     'meshio',        # load a number of additional mesh formats; Python 3.5+
     'scikit-image',  # marching cubes and other nice stuff
     'xatlas',        # texture unwrapping
+    'pyglet<2',  # render preview windows nicely : note pyglet 2.0 is basically a re-write
 ])
 # requirements for running unit tests
 requirements_test = set(['pytest',       # run all unit tests
@@ -79,18 +79,19 @@ requirements_test = set(['pytest',       # run all unit tests
 # version lock those packages here so install succeeds
 current = (sys.version_info.major, sys.version_info.minor)
 # packages that no longer support old Python
-# setuptools-scm is required by sympy-mpmath chain
-# and will hopefully be removed in future versions
 lock = [((3, 4), 'lxml', '4.3.5'),
         ((3, 4), 'shapely', '1.6.4'),
         ((3, 4), 'pyglet', '1.4.10'),
         ((3, 5), 'sympy', None),
         ((3, 0), 'pyglet<2', None),
+        ((3, 0), 'flake8-no-implicit-concat', None),
         ((3, 6), 'svg.path', '4.1')]
 for max_python, name, version in lock:
     if current <= max_python:
         # remove version-free requirements
         requirements_easy.discard(name)
+        requirements_test.discard(name)
+
         # if version is None drop that package
         if version is not None:
             # add working version locked requirements

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ lock = [((3, 4), 'lxml', '4.3.5'),
         ((3, 4), 'pyglet', '1.4.10'),
         ((3, 5), 'sympy', None),
         ((3, 0), 'pyglet<2', None),
+        ((3, 0), 'flake8-pyproject', None),
         ((3, 0), 'flake8-no-implicit-concat', None),
         ((3, 6), 'svg.path', '4.1')]
 for max_python, name, version in lock:

--- a/tests/corpus.py
+++ b/tests/corpus.py
@@ -69,8 +69,10 @@ def on_repo(repo, commit):
                 resolver=resolver)
             report[saveas] = str(m)
 
-            # if our source was a GLTF we should be able to roundtrip without dropping
-            if name.lower().split('.')[-1] in ('gltf', 'glb') and len(m.geometry) > 0:
+            # if our source was a GLTF we should be able to roundtrip without
+            # dropping
+            if name.lower().split('.')[-1] in ('gltf',
+                                               'glb') and len(m.geometry) > 0:
                 # try round-tripping the file
                 e = trimesh.load(file_obj=wrap_as_stream(m.export(file_type='glb')),
                                  file_type='glb', process=False)
@@ -89,7 +91,8 @@ def on_repo(repo, commit):
                         # try our fancy equal
                         assert equal(a.baseColorFactor, b.baseColorFactor)
                         try:
-                            assert equal(a.baseColorTexture, b.baseColorTexture)
+                            assert equal(
+                                a.baseColorTexture, b.baseColorTexture)
                         except BaseException:
                             from IPython import embed
                             embed()

--- a/tests/notebooks.py
+++ b/tests/notebooks.py
@@ -184,7 +184,9 @@ def main():
         try:
             exec(script, globals())
         except BaseException as E:
-            print('failed {}!\n\nscript was:\n{}\n\n'.format(file_name, script))
+            print(
+                'failed {}!\n\nscript was:\n{}\n\n'.format(
+                    file_name, script))
             raise E
 
 

--- a/tests/test_3mf.py
+++ b/tests/test_3mf.py
@@ -41,7 +41,8 @@ class MFTest(g.unittest.TestCase):
         assert all(len(v.vertices) == 5 for v in s.geometry.values())
 
     def test_names(self):
-        # check if two different objects with the same name are correctly processed
+        # check if two different objects with the same name are correctly
+        # processed
         s = g.get_mesh('cube_and_sphere_same_name.3mf')
         assert len(s.geometry) == 2
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -96,7 +96,8 @@ class AlignTests(g.unittest.TestCase):
         T = align([0, 0, -1], [-1e-4, 1e-4, 1])
         assert g.np.isclose(g.np.linalg.det(T), 1.0)
 
-        vector_1 = g.np.array([7.12106798e-07, -7.43194705e-08, 1.00000000e+00])
+        vector_1 = g.np.array(
+            [7.12106798e-07, -7.43194705e-08, 1.00000000e+00])
         vector_2 = g.np.array([0, 0, -1])
         T, angle = align(vector_1, vector_2, return_angle=True)
         assert g.np.isclose(g.np.linalg.det(T), 1.0)

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -253,7 +253,8 @@ class BoundsTest(g.unittest.TestCase):
             for i, b in enumerate(bounds):
                 assert i in set(tree.intersection(b.ravel()))
             # construct tree with per-row bounds
-            tree = g.trimesh.util.bounds_tree(bounds.reshape((-1, dimension * 2)))
+            tree = g.trimesh.util.bounds_tree(
+                bounds.reshape((-1, dimension * 2)))
             for i, b in enumerate(bounds):
                 assert i in set(tree.intersection(b.ravel()))
 

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -194,7 +194,8 @@ class CollisionTest(g.unittest.TestCase):
         n = g.trimesh.collision.CollisionManager()
         n.add_object('cube4', cube, tf2)
 
-        dist, names, data = m.min_distance_other(n, return_names=True, return_data=True)
+        dist, names, data = m.min_distance_other(
+            n, return_names=True, return_data=True)
         assert g.np.isclose(dist, 4.0)
         assert names == ('cube0', 'cube4')
         assert g.np.isclose(
@@ -204,7 +205,8 @@ class CollisionTest(g.unittest.TestCase):
 
         n.add_object('cube5', cube, tf4)
 
-        dist, names, data = m.min_distance_other(n, return_names=True, return_data=True)
+        dist, names, data = m.min_distance_other(
+            n, return_names=True, return_data=True)
         assert g.np.isclose(dist, 1.0)
         assert names == ('cube0', 'cube5')
         assert g.np.isclose(

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -178,7 +178,8 @@ class GLTFTest(g.unittest.TestCase):
 
         # make sure export keeps alpha modes
         # should be the same
-        assert len([geom for geom in rs.geometry if geom.startswith('Test')]) == 5
+        assert len(
+            [geom for geom in rs.geometry if geom.startswith('Test')]) == 5
         assert rs.geometry['TestCutoffDefaultMesh'].visual.material.alphaMode == 'MASK'
         assert rs.geometry['TestCutoff25Mesh'].visual.material.alphaMode == 'MASK'
         assert rs.geometry['TestCutoff25Mesh'].visual.material.alphaCutoff == 0.25
@@ -353,11 +354,13 @@ class GLTFTest(g.unittest.TestCase):
     def test_optional_camera(self):
         gltf_cameras_key = 'cameras'
 
-        # if there's no camera in the scene, then it shouldn't be added to the gltf
+        # if there's no camera in the scene, then it shouldn't be added to the
+        # gltf
         box = g.trimesh.creation.box([1, 1, 1])
         scene = g.trimesh.Scene(box)
         export = scene.export(file_type='gltf')
-        assert gltf_cameras_key not in g.json.loads(export['model.gltf'].decode('utf8'))
+        assert gltf_cameras_key not in g.json.loads(
+            export['model.gltf'].decode('utf8'))
 
         # `scene.camera` creates a camera if it does not exist.
         # once in the scene, it should be added to the gltf.
@@ -365,7 +368,8 @@ class GLTFTest(g.unittest.TestCase):
         scene = g.trimesh.Scene(box)
         scene.set_camera()
         export = scene.export(file_type='gltf')
-        assert gltf_cameras_key in g.json.loads(export['model.gltf'].decode('utf8'))
+        assert gltf_cameras_key in g.json.loads(
+            export['model.gltf'].decode('utf8'))
 
     def test_gltf_pole(self):
         scene = g.get_mesh('simple_pole.glb')
@@ -710,7 +714,8 @@ class GLTFTest(g.unittest.TestCase):
     def test_export_postprocess(self):
         scene = g.trimesh.Scene()
         sphere = g.trimesh.primitives.Sphere()
-        sphere.visual.material = g.trimesh.visual.material.PBRMaterial(name='unlit_test')
+        sphere.visual.material = g.trimesh.visual.material.PBRMaterial(
+            name='unlit_test')
         scene.add_geometry(sphere)
 
         def add_unlit(gltf_tree):
@@ -722,10 +727,12 @@ class GLTFTest(g.unittest.TestCase):
             gltf_tree["extensionsUsed"] = ["KHR_materials_unlit"]
 
         gltf_1 = g.trimesh.exchange.gltf.export_gltf(scene)
-        gltf_2 = g.trimesh.exchange.gltf.export_gltf(scene, tree_postprocessor=add_unlit)
+        gltf_2 = g.trimesh.exchange.gltf.export_gltf(
+            scene, tree_postprocessor=add_unlit)
 
         def extract_materials(gltf_files):
-            return g.json.loads(gltf_files['model.gltf'].decode('utf8'))['materials']
+            return g.json.loads(gltf_files['model.gltf'].decode('utf8'))[
+                'materials']
 
         assert "extensions" not in extract_materials(gltf_1)[-1]
         assert "extensions" in extract_materials(gltf_2)[-1]
@@ -812,7 +819,8 @@ class GLTFTest(g.unittest.TestCase):
                 # and crash on reload if we've done anything screwey
                 # unitize normals will unitize any normals to comply with
                 # the validator although there are probably reasons you'd
-                # want to roundtrip non-unit normals for things, stuff, and activities
+                # want to roundtrip non-unit normals for things, stuff, and
+                # activities
                 export = geom.export(file_type='glb', unitize_normals=True)
                 validate_glb(export, name=fn)
 

--- a/tests/test_integralmeancurvature.py
+++ b/tests/test_integralmeancurvature.py
@@ -22,7 +22,8 @@ class IntegralMeanCurvatureTest(g.unittest.TestCase):
         radius = 1.2
         for aspect_ratio in [0.0, 0.5, 1.0, 4.0, 100]:
             L = aspect_ratio * radius
-            m = g.trimesh.creation.capsule(height=L, radius=radius, count=[64, 64])
+            m = g.trimesh.creation.capsule(
+                height=L, radius=radius, count=[64, 64])
             IMC = m.integral_mean_curvature
             ref = g.np.pi * (L + 4 * radius)
             assert g.np.isclose(IMC, ref, rtol=tol)

--- a/tests/test_loaded.py
+++ b/tests/test_loaded.py
@@ -22,13 +22,6 @@ class LoaderTest(g.unittest.TestCase):
         model = g.get_mesh('empty.stl')
         assert model.is_empty
 
-    def test_ply_dtype(self):
-        # make sure all ply dtype strings are valid dtypes
-        dtypes = g.trimesh.exchange.ply.dtypes
-        for d in dtypes.values():
-            # will raise if dtype string not valid
-            g.np.dtype(d)
-
     def test_meshio(self):
         try:
             import meshio  # NOQA

--- a/tests/test_off.py
+++ b/tests/test_off.py
@@ -18,7 +18,8 @@ class OFFTests(g.unittest.TestCase):
         assert m.faces.shape == (12, 3)
 
         with open(g.os.path.join(g.dir_models, file_name)) as f:
-            lines = [line.split('#', 1)[0].strip() for line in str.splitlines(f.read())]
+            lines = [line.split('#', 1)[0].strip()
+                     for line in str.splitlines(f.read())]
         lines = [line.split() for line in lines if
                  'OFF' not in line and len(line) > 0]
         vertices = g.np.array(lines[1:9], dtype=g.np.float64)
@@ -32,7 +33,8 @@ class OFFTests(g.unittest.TestCase):
         assert m.faces.shape == (12, 3)
 
         with open(g.os.path.join(g.dir_models, file_name)) as f:
-            lines = [line.split('#', 1)[0].strip() for line in str.splitlines(f.read())]
+            lines = [line.split('#', 1)[0].strip()
+                     for line in str.splitlines(f.read())]
         lines = [line.split() for line in lines if
                  'OFF' not in line and len(line) > 0]
 

--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -8,7 +8,7 @@ class PlyTest(g.unittest.TestCase):
 
     def test_ply_dtype(self):
         # make sure all ply dtype strings are valid dtypes
-        dtypes = g.trimesh.exchange.ply.dtypes
+        dtypes = g.trimesh.exchange.ply._dtypes
         for d in dtypes.values():
             # will raise if dtype string not valid
             g.np.dtype(d)
@@ -183,13 +183,16 @@ class PlyTest(g.unittest.TestCase):
         # test texture coordinate loading for Blender exported ply files
         mesh_names = []
 
-        # test texture coordinate loading for simple triangulated Blender-export
+        # test texture coordinate loading for simple triangulated
+        # Blender-export
         mesh_names.append('cube_blender_uv.ply')
 
-        # same mesh but re-exported from meshlab as binary ply (and with changed header)
+        # same mesh but re-exported from meshlab as binary ply (and with
+        # changed header)
         mesh_names.append('cube_blender_uv_meshlab.ply')
 
-        # test texture coordinate loading for mesh with mixed quads and triangles
+        # test texture coordinate loading for mesh with mixed quads and
+        # triangles
         mesh_names.append('suzanne.ply')
 
         for mesh_name in mesh_names:

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -249,7 +249,8 @@ class PointsTest(g.unittest.TestCase):
         # create 100 unique points
         p = g.np.arange(300).reshape((100, 3))
         # should return the original 100 points
-        culled, mask = g.trimesh.points.remove_close(g.np.vstack((p, p)), radius=0.1)
+        culled, mask = g.trimesh.points.remove_close(
+            g.np.vstack((p, p)), radius=0.1)
         assert culled.shape == (100, 3)
         assert mask.shape == (200,)
 
@@ -273,14 +274,16 @@ class PointsTest(g.unittest.TestCase):
         cloud_2 = g.trimesh.points.PointCloud(points_2, colors=colors_2)
 
         cloud_sum = cloud_1 + cloud_2
-        assert g.np.allclose(cloud_sum.colors[len(cloud_1.vertices):], cloud_2.colors)
+        assert g.np.allclose(
+            cloud_sum.colors[len(cloud_1.vertices):], cloud_2.colors)
 
         # Next test: Only first cloud has colors
         cloud_1 = g.trimesh.points.PointCloud(points_1, colors=colors_1)
         cloud_2 = g.trimesh.points.PointCloud(points_2)
 
         cloud_sum = cloud_1 + cloud_2
-        assert g.np.allclose(cloud_sum.colors[:len(cloud_1.vertices)], cloud_1.colors)
+        assert g.np.allclose(
+            cloud_sum.colors[:len(cloud_1.vertices)], cloud_1.colors)
 
     def test_radial_sort(self):
         theta = g.np.linspace(0.0, g.np.pi * 2.0, 1000)

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -110,7 +110,7 @@ class PrimitiveTest(g.unittest.TestCase):
             perm[2].apply_transform(
                 g.tf.rotation_matrix(g.np.pi / 4, [0, 0, 1]))
             # try with a gnarly rotation
-            perm[2].primitive.transform = g.tf.random_rotation_matrix(
+            perm[3].primitive.transform = g.tf.random_rotation_matrix(
                 translate=1000)
 
             fields = set(dir(original.primitive))

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -149,7 +149,8 @@ class PrimitiveTest(g.unittest.TestCase):
                                             ori_height * scale)
 
                     # should be the same size
-                    assert g.np.allclose(p.extents, m.extents, atol=1e-3 * scale)
+                    assert g.np.allclose(
+                        p.extents, m.extents, atol=1e-3 * scale)
                     # should be in the same place
                     assert g.np.allclose(p.bounds, m.bounds, atol=1e-3 * scale)
 
@@ -285,7 +286,8 @@ class PrimitiveTest(g.unittest.TestCase):
                                      primitive.transform[:3, 3])
 
     def test_sphere_center(self):
-        s = g.trimesh.primitives.Sphere(center=[0, 0, 100], radius=10.0, subdivisions=5)
+        s = g.trimesh.primitives.Sphere(
+            center=[0, 0, 100], radius=10.0, subdivisions=5)
         assert g.np.allclose(s.center, [0, 0, 100])
 
         s.center = [1, 1, 1]

--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -176,7 +176,8 @@ class NearestTest(g.unittest.TestCase):
 
         # should be well outside the box and not coplanar with a face
         # so the signed distance should be negative
-        distance = mesh.nearest.signed_distance([mesh.bounds[0] + [100, 100, 100]])
+        distance = mesh.nearest.signed_distance(
+            [mesh.bounds[0] + [100, 100, 100]])
 
         assert distance[0] < 0.0
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -212,14 +212,16 @@ class RegistrationTest(g.unittest.TestCase):
 
         T = g.trimesh.registration.procrustes(source_markers_vertices,
                                               target_markers_vertices)[0]
-        source.vertices = g.trimesh.transformations.transform_points(source.vertices, T)
+        source.vertices = g.trimesh.transformations.transform_points(
+            source.vertices, T)
 
         # Just for the sake of using barycentric coordinates...
         use_barycentric_coordinates = True
         if use_barycentric_coordinates:
             source_markers_vertices = source.vertices[landmarks_vertex_indices[:, 0]]
             source_markers_tids = \
-                g.trimesh.proximity.closest_point(source, source_markers_vertices)[2]
+                g.trimesh.proximity.closest_point(
+                    source, source_markers_vertices)[2]
             source_markers_barys = \
                 g.trimesh.triangles.points_to_barycentric(
                     source.triangles[source_markers_tids], source_markers_vertices)
@@ -276,13 +278,17 @@ class RegistrationTest(g.unittest.TestCase):
             return_records=True, distance_threshold=0.05)
 
         d_amberg_no_ldm = \
-            g.trimesh.proximity.closest_point(target, records_amberg_no_ldm[-1])[1]
+            g.trimesh.proximity.closest_point(
+                target, records_amberg_no_ldm[-1])[1]
         d_amberg_ldm = \
-            g.trimesh.proximity.closest_point(target, records_amberg_ldm[-1])[1]
+            g.trimesh.proximity.closest_point(
+                target, records_amberg_ldm[-1])[1]
         d_sumner_no_ldm = \
-            g.trimesh.proximity.closest_point(target, records_sumner_no_ldm[-1])[1]
+            g.trimesh.proximity.closest_point(
+                target, records_sumner_no_ldm[-1])[1]
         d_sumner_ldm = \
-            g.trimesh.proximity.closest_point(target, records_sumner_ldm[-1])[1]
+            g.trimesh.proximity.closest_point(
+                target, records_sumner_ldm[-1])[1]
 
         # Meshes should remain untouched
         assert g.np.allclose(source.vertices, source_copy.vertices)

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -165,7 +165,8 @@ class SubDivideTest(g.unittest.TestCase):
         def _get_boundary_vertices(mesh):
             boundary_groups = g.trimesh.grouping.group_rows(
                 mesh.edges_sorted, require_count=1)
-            return mesh.vertices[g.np.unique(mesh.edges_sorted[boundary_groups])]
+            return mesh.vertices[g.np.unique(
+                mesh.edges_sorted[boundary_groups])]
 
         box = g.trimesh.creation.box()
         bottom_mask = g.np.zeros(len(box.faces), dtype=bool)

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -157,7 +157,8 @@ class SliceTest(g.unittest.TestCase):
         mesh = g.trimesh.creation.box()
 
         # Cut corner off of box and make sure the bounds and number of faces is correct
-        # Tests new triangles, but not new quads or triangles contained entirely
+        # Tests new triangles, but not new quads or triangles contained
+        # entirely
         plane_origin = mesh.bounds[1] - 0.05
         plane_normal = mesh.bounds[1]
 
@@ -361,7 +362,8 @@ class SliceTest(g.unittest.TestCase):
         mesh = g.trimesh.creation.box()
 
         # Cut corner off of box and make sure the bounds and number of faces is correct
-        # Tests new triangles, but not new quads or triangles contained entirely
+        # Tests new triangles, but not new quads or triangles contained
+        # entirely
         plane_origin = mesh.bounds[1] - 0.05
         plane_normal = mesh.bounds[1]
 
@@ -371,7 +373,9 @@ class SliceTest(g.unittest.TestCase):
                                          cap=True)
 
         assert len(sliced_capped.faces) == 8
-        assert g.np.isclose(sliced_capped.bounds[0], mesh.bounds[1] - 0.15).all()
+        assert g.np.isclose(
+            sliced_capped.bounds[0],
+            mesh.bounds[1] - 0.15).all()
         assert g.np.isclose(sliced_capped.bounds[1], mesh.bounds[1]).all()
         assert sliced_capped.is_watertight
 

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -34,7 +34,8 @@ class TextureTest(g.unittest.TestCase):
             # get the location of the model file
             file_path = g.get_path(file_name)
             with open(file_path, 'r') as f:
-                # get the raw ordered vertices from the file with basic string ops
+                # get the raw ordered vertices from the file with basic string
+                # ops
                 v_raw = g.np.array(
                     [line[2:].split() for line in f if line.startswith('v ')],
                     dtype=g.np.float64)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -437,7 +437,8 @@ class StructuredArrayToString(unittest.TestCase):
             g.trimesh.util.structured_array_to_string(
                 np.array(
                     [([1, 2], 1.1), ([3, 4], 2.2)],
-                    dtype=[('some_int', np.int64, 2), ('some_float', np.float64)]
+                    dtype=[('some_int', np.int64, 2),
+                           ('some_float', np.float64)]
                 )
             ),
             '1 2 1.10000000\n3 4 2.20000000'

--- a/tests/test_vertices.py
+++ b/tests/test_vertices.py
@@ -26,7 +26,8 @@ class VerticesTest(g.unittest.TestCase):
                 low=0, high=len(m.vertices), size=100)
             for v in rand_vertices:
                 v_faces = g.np.where(m.faces == v)[0][::-1]
-                assert (g.np.all(v_faces == m.vertex_faces[v][m.vertex_faces[v] >= 0]))
+                assert (
+                    g.np.all(v_faces == m.vertex_faces[v][m.vertex_faces[v] >= 0]))
 
             # make mesh degenerate
             m.faces[0] = [0, 0, 0]

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -24,7 +24,8 @@ class VisualTest(g.unittest.TestCase):
         m = g.get_mesh('torus.STL')
 
         vertex_colors = g.np.random.randint(0, 255, size=(len(m.vertices), 3))
-        m.visual = trimesh.visual.ColorVisuals(mesh=m, vertex_colors=vertex_colors)
+        m.visual = trimesh.visual.ColorVisuals(
+            mesh=m, vertex_colors=vertex_colors)
 
         face_index = g.np.random.choice(len(m.faces), len(m.triangles) // 2)
         idx = m.faces[g.np.unique(face_index)].flatten()

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2474,8 +2474,10 @@ class Trimesh(Geometry3D):
         import open3d
         # create from numpy arrays
         return open3d.geometry.TriangleMesh(
-            vertices=open3d.utility.Vector3dVector(self.vertices),
-            triangles=open3d.utility.Vector3iVector(self.faces))
+            vertices=open3d.utility.Vector3dVector(
+                self.vertices.copy()),
+            triangles=open3d.utility.Vector3iVector(
+                self.faces.copy()))
 
     def simplify_quadratic_decimation(self, *args, **kwargs):
         """

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -412,7 +412,8 @@ class Trimesh(Geometry3D):
         vertices : (n, 3) float
           Points in cartesian space referenced by self.faces
         """
-        return self._data.get('vertices', np.empty(shape=(0, 3), dtype=np.float64))
+        return self._data.get('vertices', np.empty(
+            shape=(0, 3), dtype=np.float64))
 
     @vertices.setter
     def vertices(self, values):

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -471,7 +471,8 @@ class Cache(object):
         # dumpy cache if ID function has changed
         self.verify()
         # make numpy arrays read-only if asked to
-        if self.force_immutable and hasattr(value, 'flags') and len(value.shape) > 0:
+        if self.force_immutable and hasattr(
+                value, 'flags') and len(value.shape) > 0:
             value.flags.writeable = False
         # assign data to dict
         self.cache[key] = value

--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -171,7 +171,8 @@ class CollisionManager(object):
         Initialize a mesh-mesh collision manager.
         """
         if fcl is None:
-            raise ValueError('No FCL Available! Please install the python-fcl library')
+            raise ValueError(
+                'No FCL Available! Please install the python-fcl library')
         # {name: {geom:, obj}}
         self._objs = {}
         # {id(bvh) : str, name}
@@ -507,7 +508,9 @@ class CollisionManager(object):
         o = fcl.CollisionObject(geom, t)
 
         # Collide with manager's objects
-        ddata = fcl.DistanceData(fcl.DistanceRequest(enable_signed_distance=True))
+        ddata = fcl.DistanceData(
+            fcl.DistanceRequest(
+                enable_signed_distance=True))
         if return_data:
             ddata = fcl.DistanceData(
                 fcl.DistanceRequest(
@@ -565,7 +568,9 @@ class CollisionManager(object):
         data : DistanceData
           Extra data about the distance query
         """
-        ddata = fcl.DistanceData(fcl.DistanceRequest(enable_signed_distance=True))
+        ddata = fcl.DistanceData(
+            fcl.DistanceRequest(
+                enable_signed_distance=True))
         if return_data:
             ddata = fcl.DistanceData(
                 fcl.DistanceRequest(
@@ -623,7 +628,9 @@ class CollisionManager(object):
         data : DistanceData
           Extra data about the distance query
         """
-        ddata = fcl.DistanceData(fcl.DistanceRequest(enable_signed_distance=True))
+        ddata = fcl.DistanceData(
+            fcl.DistanceRequest(
+                enable_signed_distance=True))
         if return_data:
             ddata = fcl.DistanceData(
                 fcl.DistanceRequest(

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -145,7 +145,9 @@ def revolve(linestring,
 
     if tol.strict:
         # make sure we didn't screw up stacking operation
-        assert np.allclose(stacked.reshape((-1, single.shape[0], 3)) - single, 0)
+        assert np.allclose(
+            stacked.reshape(
+                (-1, single.shape[0], 3)) - single, 0)
 
     # offset stacked and wrap vertices
     faces = (stacked + offset) % len(vertices)
@@ -1248,7 +1250,8 @@ def truncated_prisms(tris, origin=None, normal=None):
     vs = np.column_stack((transformed, transformed)).reshape((-1, 3, 3))
     # set the Z value of the second triangle to zero
     vs[1::2, :, 2] = 0
-    # reshape triangles to a flat array of points and transform back to original frame
+    # reshape triangles to a flat array of points and transform back to
+    # original frame
     vertices = tf.transform_points(
         vs.reshape((-1, 3)), matrix=np.linalg.inv(transform))
 
@@ -1262,13 +1265,15 @@ def truncated_prisms(tris, origin=None, normal=None):
                   [5, 4, 1],
                   [3, 5, 2]])
     # find the projection of each triangle with the normal vector
-    cross = np.dot([0, 0, 1], triangles.cross(transformed.reshape((-1, 3, 3))).T)
+    cross = np.dot([0, 0, 1], triangles.cross(
+        transformed.reshape((-1, 3, 3))).T)
     # stack faces into one prism per triangle
     f_seq = np.tile(f, (len(transformed), 1)).reshape((-1, len(f), 3))
     # if the normal of the triangle was positive flip the winding
     f_seq[cross > 0] = np.fliplr(f)
     # offset stacked faces to create correct indices
-    faces = (f_seq + (np.arange(len(f_seq)) * 6).reshape((-1, 1, 1))).reshape((-1, 3))
+    faces = (f_seq + (np.arange(len(f_seq)) *
+             6).reshape((-1, 1, 1))).reshape((-1, 3))
 
     # create a mesh from the data
     mesh = Trimesh(vertices=vertices, faces=faces, process=False)

--- a/trimesh/exchange/export.py
+++ b/trimesh/exchange/export.py
@@ -223,6 +223,10 @@ def export_scene(scene,
     if len(scene.geometry) == 0:
         raise ValueError("Can't export empty scenes!")
 
+    if util.is_pathlib(file_obj):
+        # handle `pathlib` objects by converting to string
+        file_obj = str(file_obj.absolute())
+
     # if we weren't passed a file type extract from file_obj
     if file_type is None:
         if util.is_string(file_obj):

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -920,7 +920,8 @@ def _build_accessor(array):
     if len(shape) == 2:
         vec_length = shape[1]
         if vec_length > 4:
-            raise ValueError("The GLTF spec does not support vectors larger than 4")
+            raise ValueError(
+                "The GLTF spec does not support vectors larger than 4")
         if vec_length > 1:
             data_type = "VEC%d" % vec_length
         else:
@@ -1408,9 +1409,11 @@ def _read_buffers(header,
                         if mode == _GL_STRIP:
                             # this is triangle strips
                             flat = access[p['indices']].reshape(-1)
-                            kwargs['faces'] = util.triangle_strips_to_faces([flat])
+                            kwargs['faces'] = util.triangle_strips_to_faces([
+                                                                            flat])
                         else:
-                            kwargs["faces"] = access[p["indices"]].reshape((-1, 3))
+                            kwargs["faces"] = access[p["indices"]
+                                                     ].reshape((-1, 3))
                     else:
                         # indices are apparently optional and we are supposed to
                         # do the same thing as webGL drawArrays?
@@ -1446,7 +1449,8 @@ def _read_buffers(header,
                                     # just pass to mesh as vertex color
                                     kwargs['vertex_colors'] = colors
                                 else:
-                                    # we ALSO have texture so save as vertex attribute
+                                    # we ALSO have texture so save as vertex
+                                    # attribute
                                     visuals.vertex_attributes['color'] = colors
                         except BaseException:
                             # survive failed colors

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -62,7 +62,8 @@ def load_obj(file_obj,
     # same logic even if they jump directly in to data lines
     text = '\n{}\n'.format(text.strip().replace('\r\n', '\n'))
 
-    # remove backslash continuation characters and merge them into the same line
+    # remove backslash continuation characters and merge them into the same
+    # line
     text = text.replace('\\\n', '')
 
     # Load Materials
@@ -848,7 +849,8 @@ def export_obj(mesh,
                 row_delim='\nv ',
                 digits=digits)])
         # only include vertex normals if they're already stored
-        if include_normals and current._cache.cache.get('vertex_normals') is not None:
+        if include_normals and current._cache.cache.get(
+                'vertex_normals') is not None:
 
             try:
                 converted = util.array_to_string(

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -147,9 +147,11 @@ def add_attributes_to_dtype(dtype, attributes):
         if data.ndim == 1:
             dtype.append((name, data.dtype))
         else:
-            attribute_dtype = data.dtype if len(data.dtype) == 0 else data.dtype[0]
+            attribute_dtype = data.dtype if len(
+                data.dtype) == 0 else data.dtype[0]
             dtype.append(('{}_count'.format(name), 'u1'))
-            dtype.append((name, numpy_type_to_ply_type(attribute_dtype), data.shape[1]))
+            dtype.append(
+                (name, numpy_type_to_ply_type(attribute_dtype), data.shape[1]))
     return dtype
 
 
@@ -199,7 +201,8 @@ def add_attributes_to_data_array(data_array, attributes):
     """
     for name, data in attributes.items():
         if data.ndim > 1:
-            data_array['{}_count'.format(name)] = data.shape[1] * np.ones(data.shape[0])
+            data_array['{}_count'.format(
+                name)] = data.shape[1] * np.ones(data.shape[0])
         data_array[name] = data
     return data_array
 
@@ -662,7 +665,8 @@ def load_element_different(properties, data):
             length = 1
             if '$LIST' in dt:
                 dt = dt.split('($LIST,)')[-1]
-                # the first entry in a list-property is the number of elements in the list
+                # the first entry in a list-property is the number of elements
+                # in the list
                 length = int(row[start])
                 # skip the first entry (the length), when reading the data
                 start += 1
@@ -762,7 +766,8 @@ def ply_ascii(elements, file_obj):
             col_count_equal = False
 
         # number of list properties in this element
-        list_count = sum(1 for dt in values['properties'].values() if '$LIST' in dt)
+        list_count = sum(
+            1 for dt in values['properties'].values() if '$LIST' in dt)
         if col_count_equal and list_count <= 1:
             # all rows have the same length and we only have at most one list
             # property where all entries have the same length. this means we can

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -15,7 +15,7 @@ from ..geometry import triangulate_quads
 from ..constants import log
 
 # from ply specification, and additional dtypes found in the wild
-dtypes = {
+_dtypes = {
     'char': 'i1',
     'uchar': 'u1',
     'short': 'i2',
@@ -37,7 +37,7 @@ dtypes = {
     'double': 'f8'}
 
 # Inverse of the above dict, collisions on numpy type were removed
-inverse_dtypes = {
+_inverse_dtypes = {
     'i1': 'char',
     'u1': 'uchar',
     'i2': 'short',
@@ -51,19 +51,19 @@ inverse_dtypes = {
     'f8': 'double'}
 
 
-def numpy_type_to_ply_type(numpy_type):
+def _numpy_type_to_ply_type(_numpy_type):
     """
     Returns the closest ply equivalent of a numpy type
 
     Parameters
     ---------
-    numpy_type : a numpy datatype
+    _numpy_type : a numpy datatype
 
     Returns
     ---------
     ply_type : string
     """
-    return inverse_dtypes[numpy_type.str[1:]]
+    return _inverse_dtypes[_numpy_type.str[1:]]
 
 
 def load_ply(file_obj,
@@ -96,13 +96,13 @@ def load_ply(file_obj,
     """
 
     # OrderedDict which is populated from the header
-    elements, is_ascii, image_name = parse_header(file_obj)
+    elements, is_ascii, image_name = _parse_header(file_obj)
 
     # functions will fill in elements from file_obj
     if is_ascii:
-        ply_ascii(elements, file_obj)
+        _ply_ascii(elements, file_obj)
     else:
-        ply_binary(elements, file_obj)
+        _ply_binary(elements, file_obj)
 
     # try to load the referenced image
     image = None
@@ -119,7 +119,7 @@ def load_ply(file_obj,
         log.warning('unable to load image!', exc_info=True)
 
     # translate loaded PLY elements to kwargs
-    kwargs = elements_to_kwargs(
+    kwargs = _elements_to_kwargs(
         image=image,
         elements=elements,
         fix_texture=fix_texture,
@@ -128,7 +128,7 @@ def load_ply(file_obj,
     return kwargs
 
 
-def add_attributes_to_dtype(dtype, attributes):
+def _add_attributes_to_dtype(dtype, attributes):
     """
     Parses attribute datatype to populate a numpy dtype list
 
@@ -151,11 +151,11 @@ def add_attributes_to_dtype(dtype, attributes):
                 data.dtype) == 0 else data.dtype[0]
             dtype.append(('{}_count'.format(name), 'u1'))
             dtype.append(
-                (name, numpy_type_to_ply_type(attribute_dtype), data.shape[1]))
+                (name, _numpy_type_to_ply_type(attribute_dtype), data.shape[1]))
     return dtype
 
 
-def add_attributes_to_header(header, attributes):
+def _add_attributes_to_header(header, attributes):
     """
     Parses attributes in to ply header entries
 
@@ -175,15 +175,15 @@ def add_attributes_to_header(header, attributes):
         if data.ndim == 1:
             header.append(
                 'property {} {}\n'.format(
-                    numpy_type_to_ply_type(data.dtype), name))
+                    _numpy_type_to_ply_type(data.dtype), name))
         else:
             header.append(
                 'property list uchar {} {}\n'.format(
-                    numpy_type_to_ply_type(data.dtype), name))
+                    _numpy_type_to_ply_type(data.dtype), name))
     return header
 
 
-def add_attributes_to_data_array(data_array, attributes):
+def _add_attributes_to_data_array(data_array, attributes):
     """
     Parses attribute data in to a custom array, assumes datatype has been defined
     appropriately
@@ -207,7 +207,7 @@ def add_attributes_to_data_array(data_array, attributes):
     return data_array
 
 
-def assert_attributes_valid(attributes):
+def _assert_attributes_valid(attributes):
     """
     Asserts that a set of attributes is valid for PLY export.
 
@@ -263,9 +263,9 @@ def export_ply(mesh,
     # if we want to include mesh attributes in the export
     if include_attributes:
         if hasattr(mesh, 'vertex_attributes'):
-            assert_attributes_valid(mesh.vertex_attributes)
+            _assert_attributes_valid(mesh.vertex_attributes)
         if hasattr(mesh, 'face_attributes'):
-            assert_attributes_valid(mesh.face_attributes)
+            _assert_attributes_valid(mesh.face_attributes)
 
     # custom numpy dtypes for exporting
     dtype_face = [('count', '<u1'),
@@ -298,8 +298,8 @@ def export_ply(mesh,
             dtype_vertex.append(dtype_color)
 
         if include_attributes and hasattr(mesh, 'vertex_attributes'):
-            add_attributes_to_header(header, mesh.vertex_attributes)
-            add_attributes_to_dtype(dtype_vertex, mesh.vertex_attributes)
+            _add_attributes_to_header(header, mesh.vertex_attributes)
+            _add_attributes_to_dtype(dtype_vertex, mesh.vertex_attributes)
 
         # create and populate the custom dtype for vertices
         vertex = np.zeros(num_vertices,
@@ -311,7 +311,7 @@ def export_ply(mesh,
             vertex['rgba'] = mesh.visual.vertex_colors
 
         if include_attributes and hasattr(mesh, 'vertex_attributes'):
-            add_attributes_to_data_array(vertex, mesh.vertex_attributes)
+            _add_attributes_to_data_array(vertex, mesh.vertex_attributes)
     else:
         num_vertices = 0
 
@@ -325,8 +325,8 @@ def export_ply(mesh,
             dtype_face.append(dtype_color)
 
         if include_attributes and hasattr(mesh, 'face_attributes'):
-            add_attributes_to_header(header, mesh.face_attributes)
-            add_attributes_to_dtype(dtype_face, mesh.face_attributes)
+            _add_attributes_to_header(header, mesh.face_attributes)
+            _add_attributes_to_dtype(dtype_face, mesh.face_attributes)
 
         # put mesh face data into custom dtype to export
         faces = np.zeros(len(mesh.faces), dtype=dtype_face)
@@ -337,7 +337,7 @@ def export_ply(mesh,
         header_params['face_count'] = len(mesh.faces)
 
         if include_attributes and hasattr(mesh, 'face_attributes'):
-            add_attributes_to_data_array(faces, mesh.face_attributes)
+            _add_attributes_to_data_array(faces, mesh.face_attributes)
 
     header.append(templates['outro'])
     export = Template(''.join(header)).substitute(
@@ -362,7 +362,7 @@ def export_ply(mesh,
     return export
 
 
-def parse_header(file_obj):
+def _parse_header(file_obj):
     """
     Read the ASCII header of a PLY file, and leave the file object
     at the position of the start of data but past the header.
@@ -421,7 +421,7 @@ def parse_header(file_obj):
             if len(line) == 3:
                 dtype, field = line[1:]
                 elements[name]['properties'][
-                    str(field)] = endian + dtypes[dtype]
+                    str(field)] = endian + _dtypes[dtype]
             # is the property a painful list, like:
             # `property list uchar int vertex_indices`
             elif 'list' in line[1]:
@@ -429,10 +429,10 @@ def parse_header(file_obj):
                 elements[name]['properties'][
                     str(field)] = (
                     endian +
-                    dtypes[dtype_count] +
+                    _dtypes[dtype_count] +
                     ', ($LIST,)' +
                     endian +
-                    dtypes[dtype])
+                    _dtypes[dtype])
         # referenced as a file name
         elif 'texturefile' in raw.lower():
             # textures come listed like:
@@ -444,10 +444,10 @@ def parse_header(file_obj):
     return elements, is_ascii, image_name
 
 
-def elements_to_kwargs(elements,
-                       fix_texture,
-                       image,
-                       prefer_color=None):
+def _elements_to_kwargs(elements,
+                        fix_texture,
+                        image,
+                        prefer_color=None):
     """
     Given an elements data structure, extract the keyword
     arguments that a Trimesh object constructor will expect.
@@ -727,7 +727,7 @@ def load_element_single(properties, data):
     return columns
 
 
-def ply_ascii(elements, file_obj):
+def _ply_ascii(elements, file_obj):
     """
     Load data from an ASCII PLY file into an existing elements data structure.
 
@@ -784,7 +784,7 @@ def ply_ascii(elements, file_obj):
         elements[key]['data'] = element_data
 
 
-def ply_binary(elements, file_obj):
+def _ply_binary(elements, file_obj):
     """
     Load the data from a binary PLY file into the elements data structure.
 
@@ -868,7 +868,7 @@ def ply_binary(elements, file_obj):
                 elements[key]['data'] = None
         return elements
 
-    def elements_size(elements):
+    def _elements_size(elements):
         """
         Given an elements data structure populated from the header,
         calculate how long the file should be if it is intact.
@@ -889,7 +889,7 @@ def ply_binary(elements, file_obj):
     size_file = util.distance_to_end(file_obj)
     # how many bytes should the data structure described by
     # the header take up
-    size_elements = elements_size(elements)
+    size_elements = _elements_size(elements)
 
     # if the number of bytes is not the same the file is probably corrupt
     if size_file != size_elements:

--- a/trimesh/exchange/threedxml.py
+++ b/trimesh/exchange/threedxml.py
@@ -79,7 +79,8 @@ def load_3DXML(file_obj, *args, **kwargs):
                 '{*}MaterialDomainInstance'):
             instance = MaterialDomainInstance.find('{*}IsInstanceOf')
             # colors[b.attrib['id']] = colors[instance.text]
-            for aggregate in MaterialDomainInstance.findall('{*}IsAggregatedBy'):
+            for aggregate in MaterialDomainInstance.findall(
+                    '{*}IsAggregatedBy'):
                 colors[aggregate.text] = colors[instance.text]
 
     # references which hold the 3DXML scene structure as a dict

--- a/trimesh/exchange/threemf.py
+++ b/trimesh/exchange/threemf.py
@@ -43,7 +43,8 @@ def load_3MF(file_obj,
                       if '3d/3dmodel.model' in k.lower()))
 
     # read root attributes only from XML first
-    event, root = next(etree.iterparse(model, tag=('{*}model'), events=('start',)))
+    event, root = next(etree.iterparse(
+        model, tag=('{*}model'), events=('start',)))
     # collect unit information from the tree
     if 'unit' in root.attrib:
         metadata = {'units': root.attrib['unit']}
@@ -308,7 +309,8 @@ def export_3MF(mesh,
                                     # vertex nodes are writed directly to the file
                                     # so make sure lxml's buffer is flushed
                                     xf.flush()
-                                    for i in range(0, len(m.vertices), batch_size):
+                                    for i in range(
+                                            0, len(m.vertices), batch_size):
                                         batch = m.vertices[i: i + batch_size]
                                         fragment = (
                                             '<vertex x="{}" y="{}" z="{}" />'
@@ -321,7 +323,8 @@ def export_3MF(mesh,
                                         )
                                 with xf.element("triangles"):
                                     xf.flush()
-                                    for i in range(0, len(m.faces), batch_size):
+                                    for i in range(
+                                            0, len(m.faces), batch_size):
                                         batch = m.faces[i: i + batch_size]
                                         fragment = (
                                             '<triangle v1="{}" v2="{}" v3="{}" />'
@@ -427,7 +430,11 @@ def export_3MF(mesh,
             ]
             with xf.element("Types", nsmap=nsmap):
                 for ext, ctype in types:
-                    xf.write(etree.Element("Default", Extension=ext, ContentType=ctype))
+                    xf.write(
+                        etree.Element(
+                            "Default",
+                            Extension=ext,
+                            ContentType=ctype))
 
     return file_obj.getvalue()
 

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -266,7 +266,8 @@ def vertex_face_indices(vertex_count,
         flat = faces.flatten()
         for v in range(vertex_count):
             # assign the data in order
-            sort[starts[v]:starts[v] + counts[v]] = (np.where(flat == v)[0] // 3)[::-1]
+            sort[starts[v]:starts[v] + counts[v]
+                 ] = (np.where(flat == v)[0] // 3)[::-1]
         padded[padded == 0] = sort
     return padded
 

--- a/trimesh/path/entities.py
+++ b/trimesh/path/entities.py
@@ -699,7 +699,10 @@ class Arc(Entity):
             # if we have a closed arc (a circle), we can return the actual bounds
             # this only works in two dimensions, otherwise this would return the
             # AABB of an sphere
-            info = self.center(vertices, return_normal=False, return_angle=False)
+            info = self.center(
+                vertices,
+                return_normal=False,
+                return_angle=False)
             bounds = np.array([info['center'] - info['radius'],
                                info['center'] + info['radius']],
                               dtype=np.float64)

--- a/trimesh/path/exchange/dxf.py
+++ b/trimesh/path/exchange/dxf.py
@@ -156,11 +156,15 @@ def load_dxf(file_obj, **kwargs):
 
             blob_block = blob[block_start:block_end]
             blob_block_raw = blob_raw[block_start:block_end]
-            block_infl = np.nonzero((blob_block == ['0', 'BLOCK']).all(axis=1))[0]
+            block_infl = np.nonzero(
+                (blob_block == [
+                    '0', 'BLOCK']).all(
+                    axis=1))[0]
 
             # collect blocks by name
             blocks = {}
-            for index in np.array_split(np.arange(len(blob_block)), block_infl):
+            for index in np.array_split(
+                    np.arange(len(blob_block)), block_infl):
                 try:
                     v, e, name = convert_entities(
                         blob_block[index],

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -697,7 +697,8 @@ class PointCloud(Geometry3D):
             Result of the query.
         """
         from .proximity import query_from_points
-        return query_from_points(self.vertices, input_points, self.kdtree, **kwargs)
+        return query_from_points(
+            self.vertices, input_points, self.kdtree, **kwargs)
 
     def __add__(self, other):
         if len(other.colors) == len(self.colors) == 0:

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -309,7 +309,8 @@ class _PrimitiveAttributes(object):
 
 class Cylinder(_Primitive):
 
-    def __init__(self, radius=1.0, height=1.0, transform=None, sections=32, **kwargs):
+    def __init__(self, radius=1.0, height=1.0,
+                 transform=None, sections=32, **kwargs):
         """
         Create a Cylinder Primitive, a subclass of Trimesh.
 
@@ -568,7 +569,8 @@ class Sphere(_Primitive):
         # since a sphere is rotationally symmetric
         if center is not None:
             if transform is not None:
-                raise ValueError('only one of `center` and `transform` may be passed!')
+                raise ValueError(
+                    'only one of `center` and `transform` may be passed!')
             translate = np.eye(4)
             translate[:3, 3] = center
             constructor['transform'] = translate

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -242,7 +242,6 @@ class _PrimitiveAttributes(object):
             if value is not None:
                 # convert passed data into type of defaults
                 self._data[key] = util.convert_like(value, default)
-
         # make sure stored values are immutable after setting
         if not self._mutable:
             self._data.mutable = False
@@ -310,7 +309,7 @@ class _PrimitiveAttributes(object):
 
 class Cylinder(_Primitive):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, radius=1.0, height=1.0, transform=None, sections=32, **kwargs):
         """
         Create a Cylinder Primitive, a subclass of Trimesh.
 
@@ -325,15 +324,19 @@ class Cylinder(_Primitive):
         sections : int
           Number of facets in circle
         """
-        super(Cylinder, self).__init__(*args, **kwargs)
+        super(Cylinder, self).__init__(**kwargs)
 
         defaults = {'height': 10.0,
                     'radius': 1.0,
                     'transform': np.eye(4),
                     'sections': 32}
-        self.primitive = _PrimitiveAttributes(self,
-                                              defaults,
-                                              kwargs)
+        self.primitive = _PrimitiveAttributes(
+            self,
+            defaults,
+            {'height': height,
+             'radius': radius,
+             'transform': transform,
+             'sections': sections})
 
     @caching.cache_decorator
     def volume(self):
@@ -452,7 +455,12 @@ class Cylinder(_Primitive):
 
 class Capsule(_Primitive):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self,
+                 radius=1.0,
+                 height=10.0,
+                 transform=None,
+                 sections=32,
+                 **kwargs):
         """
         Create a Capsule Primitive, a subclass of Trimesh.
 
@@ -467,15 +475,19 @@ class Capsule(_Primitive):
         sections : int
           Number of facets in circle
         """
-        super(Capsule, self).__init__(*args, **kwargs)
+        super(Capsule, self).__init__(**kwargs)
 
         defaults = {'height': 1.0,
                     'radius': 1.0,
                     'transform': np.eye(4),
                     'sections': 32}
-        self.primitive = _PrimitiveAttributes(self,
-                                              defaults,
-                                              kwargs)
+        self.primitive = _PrimitiveAttributes(
+            self,
+            defaults,
+            {'height': height,
+             'radius': radius,
+             'transform': transform,
+             'sections': sections})
 
     @property
     def transform(self):
@@ -525,7 +537,12 @@ class Capsule(_Primitive):
 
 class Sphere(_Primitive):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self,
+                 radius=1.0,
+                 center=None,
+                 transform=None,
+                 subdivisions=3,
+                 **kwargs):
         """
         Create a Sphere Primitive, a subclass of Trimesh.
 
@@ -533,27 +550,34 @@ class Sphere(_Primitive):
         ----------
         radius : float
           Radius of sphere
-        center : (3,) float
-          Center of sphere
+        center : None or (3,) float
+          Center of sphere.
+        transform : None or (4, 4) float
+          Full homogenous transform. Pass `center` OR `transform.
         subdivisions : int
           Number of subdivisions for icosphere.
         """
-        super(Sphere, self).__init__(*args, **kwargs)
+        super(Sphere, self).__init__(**kwargs)
         defaults = {'radius': 1.0,
                     'transform': np.eye(4),
                     'subdivisions': 3}
 
+        constructor = {'radius': float(radius),
+                       'subdivisions': int(subdivisions)}
         # center is a helper method for "transform"
         # since a sphere is rotationally symmetric
-        center = kwargs.get('center', None)
         if center is not None:
+            if transform is not None:
+                raise ValueError('only one of `center` and `transform` may be passed!')
             translate = np.eye(4)
             translate[:3, 3] = center
-            kwargs['transform'] = translate
+            constructor['transform'] = translate
+        elif transform is not None:
+            constructor['transform'] = transform
 
         # create the attributes object
         self.primitive = _PrimitiveAttributes(
-            self, defaults, kwargs)
+            self, defaults, constructor)
 
     @property
     def center(self):
@@ -648,7 +672,10 @@ class Sphere(_Primitive):
 
 class Box(_Primitive):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self,
+                 extents=None,
+                 transform=None,
+                 **kwargs):
         """
         Create a Box Primitive as a subclass of Trimesh
 
@@ -659,11 +686,14 @@ class Box(_Primitive):
         transform : (4, 4) float
           Homogeneous transformation matrix for box center
         """
-        super(Box, self).__init__(*args, **kwargs)
+        super(Box, self).__init__(**kwargs)
         defaults = {'transform': np.eye(4),
                     'extents': np.ones(3)}
         self.primitive = _PrimitiveAttributes(
-            self, defaults, kwargs)
+            self,
+            defaults,
+            {'extents': extents,
+             'transform': transform})
 
     def to_dict(self):
         """
@@ -793,8 +823,11 @@ class Box(_Primitive):
 
 
 class Extrusion(_Primitive):
-
-    def __init__(self, triangle_args=None, *args, **kwargs):
+    def __init__(self,
+                 polygon=None,
+                 transform=None,
+                 height=1.0,
+                 **kwargs):
         """
         Create an Extrusion primitive, which
         is a subclass of Trimesh.
@@ -807,20 +840,18 @@ class Extrusion(_Primitive):
           Transform to apply after extrusion
         height : float
           Height to extrude polygon by
-        triangle_args : str
-          Arguments to pass to triangle
         """
         # do the import here, fail early if Shapely isn't installed
         from shapely.geometry import Point
-        super(Extrusion, self).__init__(*args, **kwargs)
-        # save arguments for triangulation
-        self.triangle_args = triangle_args
+        super(Extrusion, self).__init__(**kwargs)
         # set default values
         defaults = {'polygon': Point([0, 0]).buffer(1.0),
                     'transform': np.eye(4),
                     'height': 1.0}
         self.primitive = _PrimitiveAttributes(
-            self, defaults, kwargs)
+            self, defaults, {'transform': transform,
+                             'polygon': polygon,
+                             'height': height})
 
     @caching.cache_decorator
     def area(self):
@@ -992,8 +1023,7 @@ class Extrusion(_Primitive):
         mesh = creation.extrude_polygon(
             polygon=self.primitive.polygon,
             height=self.primitive.height,
-            transform=self.primitive.transform,
-            triangle_args=self.triangle_args)
+            transform=self.primitive.transform)
 
         # check volume here in unit tests
         if tol.strict and mesh.volume < 0.0:

--- a/trimesh/proximity.py
+++ b/trimesh/proximity.py
@@ -169,7 +169,8 @@ def closest_point(mesh, points):
 
     # get best two candidate indices by arg-sorting the per-query_distances
     qds = np.array_split(query_distance, query_group)
-    idxs = np.int32([qd.argsort()[:2] if len(qd) > 1 else [0, 0] for qd in qds])
+    idxs = np.int32([qd.argsort()[:2] if len(qd) > 1 else [0, 0]
+                    for qd in qds])
     idxs[1:] += query_group.reshape(-1, 1)
 
     # points, distances and triangle ids for best two candidates

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -393,7 +393,8 @@ def _normalize_by_source(source_mesh, target_geometry, target_positions):
     centroid, scale = source_mesh.centroid, source_mesh.scale
     source_mesh.vertices = (source_mesh.vertices - centroid[None, :]) / scale
     # Dont forget to also transform the target positions
-    target_geometry.vertices = (target_geometry.vertices - centroid[None, :]) / scale
+    target_geometry.vertices = (
+        target_geometry.vertices - centroid[None, :]) / scale
     if target_positions is not None:
         target_positions = (target_positions - centroid[None, :]) / scale
     return target_geometry, target_positions, centroid, scale
@@ -410,7 +411,8 @@ def _denormalize_by_source(
     # [-1, 1]^3 to its original transform
     # and transform target geometry accordingly
     source_mesh.vertices = scale * source_mesh.vertices + centroid[None, :]
-    target_geometry.vertices = scale * target_geometry.vertices + centroid[None, :]
+    target_geometry.vertices = scale * \
+        target_geometry.vertices + centroid[None, :]
     if target_positions is not None:
         target_positions = scale * target_positions + centroid[None, :]
     if isinstance(result, list):
@@ -498,7 +500,8 @@ def nricp_amberg(source_mesh,
         iteration.
     """
 
-    def _solve_system(M_kron_G, D, vertices_weight, nearest, ws, nE, nV, Dl, Ul, wl):
+    def _solve_system(M_kron_G, D, vertices_weight,
+                      nearest, ws, nE, nV, Dl, Ul, wl):
         # Solve for Eq. 12
         U = nearest * vertices_weight[:, None]
         use_landmarks = Dl is not None and Ul is not None
@@ -534,7 +537,9 @@ def nricp_amberg(source_mesh,
         nV = len(vertex_3d_data)
         rows = np.repeat(np.arange(nV), 4)
         cols = np.arange(4 * nV)
-        data = np.concatenate((vertex_3d_data, np.ones((nV, 1))), axis=-1).flatten()
+        data = np.concatenate(
+            (vertex_3d_data, np.ones(
+                (nV, 1))), axis=-1).flatten()
         return sparse.csr_matrix((data, (rows, cols)), shape=(nV, 4 * nV))
 
     def _create_X(nV):
@@ -626,7 +631,8 @@ def nricp_amberg(source_mesh,
         cpt_iter = 0
 
         # Current step iterations loop
-        while last_error - error > eps and (max_iter is None or cpt_iter < max_iter):
+        while last_error - \
+                error > eps and (max_iter is None or cpt_iter < max_iter):
 
             qres = _from_mesh(
                 target_geometry,
@@ -656,7 +662,8 @@ def nricp_amberg(source_mesh,
                               ws, nE, nV, Dl, Ul, wl)
             transformed_vertices = D * X
             last_error = error
-            error_vec = np.linalg.norm(qres['nearest'] - transformed_vertices, axis=-1)
+            error_vec = np.linalg.norm(
+                qres['nearest'] - transformed_vertices, axis=-1)
             error = (error_vec * vertices_weight).mean()
             if return_records:
                 records.append(transformed_vertices)
@@ -720,7 +727,8 @@ def _from_mesh(mesh,
     qres = {}
     from .proximity import closest_point
     from .triangles import points_to_barycentric
-    qres['nearest'], qres['distances'], qres['tids'] = closest_point(mesh, input_points)
+    qres['nearest'], qres['distances'], qres['tids'] = closest_point(
+        mesh, input_points)
 
     if return_normals:
         qres['normals'] = mesh.face_normals[qres['tids']]
@@ -877,7 +885,8 @@ def nricp_sumner(source_mesh,
         minus_inv_sum = -Vinv.sum(axis=1)
         Vinv_flat = Vinv.reshape(nV, 9)
         data = np.concatenate((minus_inv_sum, Vinv_flat), axis=-1).flatten()
-        return sparse.coo_matrix((data, (rows, cols)), shape=(3 * nV, size), dtype=float)
+        return sparse.coo_matrix((data, (rows, cols)),
+                                 shape=(3 * nV, size), dtype=float)
 
     def _build_tetrahedrons(mesh):
         # UUtility function for constructing the frames
@@ -930,7 +939,8 @@ def nricp_sumner(source_mesh,
 
             AEl = sparse.coo_matrix((data, (rows, cols)), shape=(nL, nVT))
             marker_vids = \
-                source_landmarks_vids[source_landmarks_barys > np.finfo(np.float16).eps]
+                source_landmarks_vids[source_landmarks_barys > np.finfo(
+                    np.float16).eps]
             non_markers_mask = np.ones(len(source_mesh.vertices), dtype=bool)
             non_markers_mask[marker_vids] = False
         else:
@@ -946,7 +956,9 @@ def nricp_sumner(source_mesh,
 
     def _construct_correspondence_cost(points, non_markers_mask, size):
         # Utility function for constructing the correspondence cost
-        AEc = sparse.identity(size, dtype=float, format="csc")[:len(non_markers_mask)]
+        AEc = sparse.identity(
+            size, dtype=float, format="csc")[
+            :len(non_markers_mask)]
         AEc = AEc[non_markers_mask]
         Bc = points[non_markers_mask]
         return AEc, Bc

--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -282,8 +282,13 @@ def subdivide_loop(vertices,
         edges.sort(axis=1)
         unique, inverse = grouping.unique_rows(edges)
 
-        # set interior edges if there are two edges and boundary if there is one.
-        edge_inter = np.sort(grouping.group_rows(edges, require_count=2), axis=1)
+        # set interior edges if there are two edges and boundary if there is
+        # one.
+        edge_inter = np.sort(
+            grouping.group_rows(
+                edges,
+                require_count=2),
+            axis=1)
         edge_bound = grouping.group_rows(edges, require_count=1)
         # make sure that one edge is shared by only one or two faces.
         if not len(edge_inter) * 2 + len(edge_bound) == len(edges):
@@ -342,7 +347,8 @@ def subdivide_loop(vertices,
         opposite_face1 = edges_face[unique]
         opposite_face2 = edges_face[edge_pair[unique]]
 
-        # set odd vertices to the middle of each edge (default as boundary case).
+        # set odd vertices to the middle of each edge (default as boundary
+        # case).
         odd = vertices[edges[unique]].mean(axis=1)
         # modify the odd vertices for the interior case
         e = edges[unique[edge_inter_mask]]
@@ -357,14 +363,19 @@ def subdivide_loop(vertices,
 
         # simplified from:
         # # 3 / 8 * (e_v0 + e_v1) + 1 / 8 * (e_v2 + e_v3)
-        odd[edge_inter_mask] = 0.375 * e_v0 + 0.375 * e_v1 + e_v2 / 8.0 + e_v3 / 8.0
+        odd[edge_inter_mask] = 0.375 * e_v0 + \
+            0.375 * e_v1 + e_v2 / 8.0 + e_v3 / 8.0
 
         # find vertex neighbors of each vertex
-        neighbors = graph.neighbors(edges=edges[unique], max_index=len(vertices))
-        # convert list type of array into a fixed-shaped numpy array (set -1 to empties)
+        neighbors = graph.neighbors(
+            edges=edges[unique],
+            max_index=len(vertices))
+        # convert list type of array into a fixed-shaped numpy array (set -1 to
+        # empties)
         neighbors = np.array(list(zip_longest(*neighbors, fillvalue=-1))).T
         # if the neighbor has -1 index, its point is (0, 0, 0), so that
-        # it is not included in the summation of neighbors when calculating the even
+        # it is not included in the summation of neighbors when calculating the
+        # even
         vertices_ = np.vstack([vertices, [0.0, 0.0, 0.0]])
         # number of neighbors
         k = (neighbors + 1).astype(bool).sum(axis=1)
@@ -383,7 +394,8 @@ def subdivide_loop(vertices,
             # boundary vertices from boundary edges
             vrt_bound_mask = np.zeros(len(vertices), dtype=bool)
             vrt_bound_mask[np.unique(edges[unique][~edge_inter_mask])] = True
-            # one boundary vertex has two neighbor boundary vertices (set others as -1)
+            # one boundary vertex has two neighbor boundary vertices (set
+            # others as -1)
             boundary_neighbors = neighbors[vrt_bound_mask]
             boundary_neighbors[~vrt_bound_mask[neighbors[vrt_bound_mask]]] = -1
 

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -600,7 +600,10 @@ class EnforcedForest(object):
         self._hash = None
 
         # delete all children's references and parent reference
-        children = [child for (child, parent) in self.parents.items() if parent == u]
+        children = [
+            child for (
+                child,
+                parent) in self.parents.items() if parent == u]
         for c in children:
             del self.parents[c]
         if u in self.parents:

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1168,7 +1168,8 @@ def structured_array_to_string(array,
 
     # abort for unstructured arrays
     if array.dtype.names is None:
-        raise ValueError('array is not structured, use array_to_string instead')
+        raise ValueError(
+            'array is not structured, use array_to_string instead')
 
     # do not allow a value to be repeated in a value format
     if value_format.count('{') > 1:

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.18.1'
+__version__ = '3.18.2'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -17,7 +17,8 @@ import pyglet
 # new viewer `trimesh.viewer.shaders` and then basically keeping
 # `windowed` around for backwards-compatibility with no changes
 if int(pyglet.version.split('.')[0]) >= 2:
-    raise ImportError('`trimesh.viewer.windowed` requires `pip install "pyglet<2"`')
+    raise ImportError(
+        '`trimesh.viewer.windowed` requires `pip install "pyglet<2"`')
 
 from .trackball import Trackball
 

--- a/trimesh/visual/texture.py
+++ b/trimesh/visual/texture.py
@@ -220,7 +220,8 @@ class TextureVisuals(Visuals):
         concatenated : TextureVisuals
           Concatenated visual objects
         """
-        util.log.warning('concatenating texture: may result in visual artifacts')
+        util.log.warning(
+            'concatenating texture: may result in visual artifacts')
         from .objects import concatenate
         return concatenate(self, others)
 

--- a/trimesh/voxel/runlength.py
+++ b/trimesh/voxel/runlength.py
@@ -349,7 +349,9 @@ def _unsorted_gatherer(indices, sorted_gather_fn):
     ordered_indices = indices[order]
 
     def f(data, dtype=None):
-        result = np.empty(len(order), dtype=dtype or getattr(data, 'dtype', None))
+        result = np.empty(
+            len(order), dtype=dtype or getattr(
+                data, 'dtype', None))
         result[order] = tuple(sorted_gather_fn(data, ordered_indices))
         return result
 


### PR DESCRIPTION
- copy vertices before passing to `open3d` to fix #1807 
- explicitly list args in primitive constructors to fix #1814 
- release #1811 
- prefix internal function names in `trimesh.exchange.ply` with `_` to avoid inclusion in docs and to indicate they don't have a stable API. 
- move `pyglet<2` from `easy` pip extra to `all` until [feat/p2](https://github.com/mikedh/trimesh/tree/feat/p2) is merged hopefully providing short term solution to #1812. 