### PR TITLE
NRICP fix issue #1724 (KeyError: 'has_normals')

### DIFF
--- a/examples/nricp.py
+++ b/examples/nricp.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
         [10000, wi, ws, wl, wn],
     ]
 
-    # Amberg et. al 2007
+    # Amberg et al. 2007
     records_amberg = nricp_amberg(
         source, target, source_landmarks=source_landmarks,
         distance_threshold=0.05,
@@ -105,20 +105,21 @@ if __name__ == '__main__':
         distance_threshold=0.05,
         target_positions=target_markers_vertices,
         steps=steps_sumner, return_records=True)
+
     # Show the result
     try:
         import pyvista as pv
-        for records, name in [(records_amberg, 'Amberg et. al 2007'),
+        for records, name in [(records_amberg, 'Amberg et al. 2007'),
                               (records_sumner, 'Sumner and Popovic 2004')]:
             distances = [closest_point(target, r)[1] for r in records]
             p = pv.Plotter()
             p.background_color = 'w'
             pv_mesh = pv.wrap(source)
-            pv_mesh['scalars'] = distances[0]
+            pv_mesh['distance'] = distances[0]
             p.add_text(name, color=(0, 0, 0))
             p.add_mesh(
                 pv_mesh, color=(0.6, 0.6, 0.9), cmap='rainbow',
-                clim=(0, target.scale / 100), scalars='scalars',
+                clim=(0, target.scale / 100), scalars='distance',
                 scalar_bar_args={'color': (0, 0, 0)})
             p.add_mesh(pv.wrap(target), style='wireframe')
 
@@ -136,10 +137,11 @@ if __name__ == '__main__':
                             pos),
                         name=str(i),
                         color='r')
-                pv_mesh['scalars'] = (
+                pv_mesh['distance'] = (
                     1 - t) * distances[t1] + t * distances[t2]
             p.add_slider_widget(cb, rng=(0, len(records)), value=0,
-                                color='black', event_type='always')
+                                color='black', event_type='always',
+                                title='step')
 
             for pos in target_markers_vertices:
                 p.add_mesh(pv.Sphere(target.scale / 200, pos), color='g')

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -268,6 +268,11 @@ class RegistrationTest(g.unittest.TestCase):
             source, target, source_landmarks=source_landmarks,
             target_positions=target_markers_vertices, steps=steps_amberg,
             return_records=True, distance_threshold=0.05)
+        try:
+            g.trimesh.registration.nricp_amberg(source, target)
+        except KeyError:
+            assert False  # related to #1724
+
         # Sumner and Popovic 2004
         records_sumner_no_ldm = g.trimesh.registration.nricp_sumner(
             source, target, distance_threshold=0.05,
@@ -276,6 +281,10 @@ class RegistrationTest(g.unittest.TestCase):
             source, target, source_landmarks=source_landmarks,
             target_positions=target_markers_vertices, steps=steps_sumner,
             return_records=True, distance_threshold=0.05)
+        try:
+            g.trimesh.registration.nricp_sumner(source, target)
+        except KeyError:
+            assert False  # related to #1724
 
         d_amberg_no_ldm = \
             g.trimesh.proximity.closest_point(

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -648,7 +648,7 @@ def nricp_amberg(source_mesh,
 
             if wn > 0 and 'normals' in qres:
                 target_normals = qres['normals']
-                if use_vertex_normals and qres['interpolated_normals'] is not None:
+                if use_vertex_normals and 'interpolated_normals' in qres:
                     target_normals = qres['interpolated_normals']
                 # Normal weighting = multiplying weights by cosines^wn
                 source_normals = DN * X
@@ -710,9 +710,14 @@ def _from_mesh(mesh,
         Dict to accept other key word arguments (not used)
     Returns
     ----------
-    qres : NearestQueryResult
-        NearestQueryResult object containing the nearest points (m, 3) and their
-        attributes
+    qres : Dict
+      Dictionnary containing :
+       - nearest points (m, 3) with key 'nearest'
+       - distances to nearest point (m,) with key 'distances'
+       - support triangle indices of the nearest points (m,) with key 'tids'
+       - [optional] normals at nearest points (m,3) with key 'normals'
+       - [optional] barycentric coordinates in support triangles (m,3) with key 'barycentric_coordinates'
+       - [optional] interpolated normals (m,3) with key 'interpolated_normals'
     """
     input_points = np.asanyarray(input_points)
     neighbors_count = min(neighbors_count, len(mesh.vertices))
@@ -772,14 +777,18 @@ def _from_points(target_points,
 
     Returns
     ----------
-    qres : NearestQueryResult
-      NearestQueryResult object containing the nearest points (m, 3) and their attributes
+    qres : Dict
+      Dictionnary containing :
+       - nearest points (m, 3) with key 'nearest'
+       - distances to nearest point (m,) with key 'distances'
+       - vertex indices of the nearest points (m,) with key 'vertex_indices'
+       - [optional] normals at nearest points (m,3) with key 'normals'
     """
     # Empty result
     target_points = np.asanyarray(target_points)
     input_points = np.asanyarray(input_points)
     neighbors_count = min(neighbors_count, len(target_points))
-    qres = {'has_normals': return_normals}
+    qres = {}
     if kdtree is None:
         kdtree = cKDTree(target_points)
 
@@ -1047,9 +1056,9 @@ def nricp_sumner(source_mesh,
                 len(source_vtet))
             vertices_weight = np.ones(nV)
             vertices_weight[qres['distances'] > distance_threshold] = 0
-            if wn > 0 or qres['has_normals']:
+            if wn > 0 or 'normals' in qres:
                 target_normals = qres['normals']
-                if use_vertex_normals and qres['interpolated_normals'] is not None:
+                if use_vertex_normals and 'interpolated_normals' in qres:
                     target_normals = qres['interpolated_normals']
                 # Normal weighting : multiplying weights by cosines^wn
                 source_normals = _compute_vertex_normals(transformed_vertices,

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -711,12 +711,13 @@ def _from_mesh(mesh,
     Returns
     ----------
     qres : Dict
-      Dictionnary containing :
+      Dictionary containing :
        - nearest points (m, 3) with key 'nearest'
        - distances to nearest point (m,) with key 'distances'
        - support triangle indices of the nearest points (m,) with key 'tids'
        - [optional] normals at nearest points (m,3) with key 'normals'
-       - [optional] barycentric coordinates in support triangles (m,3) with key 'barycentric_coordinates'
+       - [optional] barycentric coordinates in support triangles (m,3) with key
+         'barycentric_coordinates'
        - [optional] interpolated normals (m,3) with key 'interpolated_normals'
     """
     input_points = np.asanyarray(input_points)
@@ -778,7 +779,7 @@ def _from_points(target_points,
     Returns
     ----------
     qres : Dict
-      Dictionnary containing :
+      Dictionary containing :
        - nearest points (m, 3) with key 'nearest'
        - distances to nearest point (m,) with key 'distances'
        - vertex indices of the nearest points (m,) with key 'vertex_indices'


### PR DESCRIPTION
Related to #1724

The dict returned by `_from_mesh` does never contain the key `'has_normals'`...

This PR : 

- fixes #1724
  - removes `'has_normals'` key from the result of `_from_mesh` and the result of `_from_points`
  - replaces `qres['has_normals']` by `'normals' in qres`
  - replaces `qres['interpolated_normals'] is not None` by `'interpolated_normals' in qres`
- clarifies what returns `_from_mesh` and `_from_points` in the documentation
- add small details to `examples\nricp.py`