### PR TITLE
Second moment

### DIFF
--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -154,7 +154,7 @@ class PolygonTests(g.unittest.TestCase):
         def poly_doublecorner(bh):
             # returns two equal sized rectangles as one polygon
             # Same as poly_corner(), but the rectangle gets
-            # mirrored by 180° at the origin
+            # mirrored by 180 deg at the origin
             # This puts the centroid in the origin with Ixy != 0
             shell_1 = rectangle(bh)
             shell_1 += shell_1.min(axis=0)
@@ -189,6 +189,7 @@ class PolygonTests(g.unittest.TestCase):
 
         from trimesh.path.polygons import second_moments
         from trimesh.path.polygons import transform_polygon
+
         from shapely.geometry import Polygon
 
         heights = g.np.array([[0.01, 0.01],
@@ -197,22 +198,22 @@ class PolygonTests(g.unittest.TestCase):
                               [3, 21]])
         for bh in heights:
             # check the second moment of a rectangle
-            # as polygon is already centered, centered doesn't change anything
+            # as polygon is already centered, centered doesn't have any effect
             O_moments, O_principal_moments, O_alpha, O_transform = second_moments(poly(bh), centered=True)
             # check against wikipedia
             t = truth(bh)
             # for a centered rectangle, the principal axis are alread aligned with the frame axis
             assert g.np.allclose(O_moments, t)
             assert g.np.any(g.np.isclose(O_moments, O_principal_moments[0]))
-            assert g.np.isclose(O_moments[2],0)
+            assert g.np.isclose(O_moments[2],0) # Ixy = 0
             assert g.np.isclose(O_alpha,0)
             assert g.np.allclose(O_transform, g.np.eye(3))
 
 
-            # now check a rectangle with the corner
+            # now check a rectangle with the corner, so Ixy != 0
             
             # First we test with centering. The results should be same as
-            # with the centered rectangles
+            # with the initally centered rectangles
             C_moments, C_principal_moments, C_alpha, C_transform = second_moments(poly_corner(bh), centered=True)
             assert g.np.allclose(O_moments, C_moments)
             assert g.np.allclose(O_principal_moments, C_principal_moments)
@@ -225,18 +226,18 @@ class PolygonTests(g.unittest.TestCase):
             assert g.np.allclose(moments, t)
 
             # Now we will get the transform for a double rectangle. Then we will apply
-            # the transform and test if Ixy == 0
+            # the transform and test if Ixy == 0, alpha == 0 etc.
             C_moments, C_principal_moments, C_alpha, C_transform = second_moments(poly_doublecorner(bh), centered=True)
             # apply the outputted transform to the polygon
             T_polygon = transform_polygon(poly_doublecorner(bh), C_transform)
-            # call the function again
+            # call the function on the transformed polygon
             T_moments, T_principal_moments, T_alpha, T_transform = second_moments(T_polygon, centered=True)
             assert g.np.any(g.np.isclose(T_moments, C_principal_moments[0]))
             assert g.np.allclose(C_principal_moments,T_principal_moments)
-            assert g.np.isclose(T_alpha,0)
+            assert g.np.isclose(T_alpha,0, atol=1e-7)
             assert g.np.allclose(T_transform, g.np.eye(3))
 
-            
+            # check polygons with interior
             for bhi in heights:
                 # only check if interior is smaller than exterior
                 if not (bhi < bh).all():

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -159,11 +159,11 @@ class PolygonTests(g.unittest.TestCase):
             shell_1 = rectangle(bh)
             shell_1 += shell_1.min(axis=0)
             shell_2 = - shell_1
-            shell = g.np.concatenate((shell_1[2:,:], 
-                                        shell_1[:2,:],
-                                        shell_2[2:,:],
-                                        shell_2[:2,:]
-                                        ),axis=0)
+            shell = g.np.concatenate((shell_1[2:, :],
+                                      shell_1[:2, :],
+                                      shell_2[2:, :],
+                                      shell_2[:2, :]
+                                      ), axis=0)
             return Polygon(shell=shell)
 
         def truth(bh, bhi=None):
@@ -199,26 +199,28 @@ class PolygonTests(g.unittest.TestCase):
         for bh in heights:
             # check the second moment of a rectangle
             # as polygon is already centered, centered doesn't have any effect
-            O_moments, O_principal_moments, O_alpha, O_transform = second_moments(poly(bh), centered=True)
+            O_moments, O_principal_moments, O_alpha, O_transform = second_moments(
+                poly(bh), centered=True)
             # check against wikipedia
             t = truth(bh)
-            # for a centered rectangle, the principal axis are alread aligned with the frame axis
+            # for a centered rectangle, the principal axis are alread aligned
+            # with the frame axis
             assert g.np.allclose(O_moments, t)
             assert g.np.any(g.np.isclose(O_moments, O_principal_moments[0]))
-            assert g.np.isclose(O_moments[2],0) # Ixy = 0
-            assert g.np.isclose(O_alpha,0)
+            assert g.np.isclose(O_moments[2], 0)  # Ixy = 0
+            assert g.np.isclose(O_alpha, 0)
             assert g.np.allclose(O_transform, g.np.eye(3))
 
-
             # now check a rectangle with the corner, so Ixy != 0
-            
+
             # First we test with centering. The results should be same as
             # with the initally centered rectangles
-            C_moments, C_principal_moments, C_alpha, C_transform = second_moments(poly_corner(bh), centered=True)
+            C_moments, C_principal_moments, C_alpha, C_transform = second_moments(
+                poly_corner(bh), centered=True)
             assert g.np.allclose(O_moments, C_moments)
             assert g.np.allclose(O_principal_moments, C_principal_moments)
             assert g.np.isclose(O_alpha, C_alpha)
-            assert g.np.allclose(O_transform[:,:2], C_transform[:,:2])
+            assert g.np.allclose(O_transform[:, :2], C_transform[:, :2])
 
             # Now without centering
             moments = second_moments(poly_corner(bh), centered=False)
@@ -227,14 +229,16 @@ class PolygonTests(g.unittest.TestCase):
 
             # Now we will get the transform for a double rectangle. Then we will apply
             # the transform and test if Ixy == 0, alpha == 0 etc.
-            C_moments, C_principal_moments, C_alpha, C_transform = second_moments(poly_doublecorner(bh), centered=True)
+            C_moments, C_principal_moments, C_alpha, C_transform = second_moments(
+                poly_doublecorner(bh), centered=True)
             # apply the outputted transform to the polygon
             T_polygon = transform_polygon(poly_doublecorner(bh), C_transform)
             # call the function on the transformed polygon
-            T_moments, T_principal_moments, T_alpha, T_transform = second_moments(T_polygon, centered=True)
+            T_moments, T_principal_moments, T_alpha, T_transform = second_moments(
+                T_polygon, centered=True)
             assert g.np.any(g.np.isclose(T_moments, C_principal_moments[0]))
-            assert g.np.allclose(C_principal_moments,T_principal_moments)
-            assert g.np.isclose(T_alpha,0, atol=1e-7)
+            assert g.np.allclose(C_principal_moments, T_principal_moments)
+            assert g.np.isclose(T_alpha, 0, atol=1e-7)
             assert g.np.allclose(T_transform, g.np.eye(3))
 
             # check polygons with interior

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -144,6 +144,28 @@ class PolygonTests(g.unittest.TestCase):
                 holes = []
             return Polygon(shell=shell, holes=holes)
 
+        def poly_corner(bh):
+            # return a rectangle with one corner
+            # at the origin and the rest in positive space
+            shell = rectangle(bh)
+            shell += shell.min(axis=0)
+            return Polygon(shell=shell)
+
+        def poly_doublecorner(bh):
+            # returns two equal sized rectangles as one polygon
+            # Same as poly_corner(), but the rectangle gets
+            # mirrored by 180° at the origin
+            # This puts the centroid in the origin with Ixy != 0
+            shell_1 = rectangle(bh)
+            shell_1 += shell_1.min(axis=0)
+            shell_2 = - shell_1
+            shell = g.np.concatenate((shell_1[2:,:], 
+                                        shell_1[:2,:],
+                                        shell_2[2:,:],
+                                        shell_2[:2,:]
+                                        ),axis=0)
+            return Polygon(shell=shell)
+
         def truth(bh, bhi=None):
             # return the analytical second moment of area
             # for a rectangle with centroid at the origin
@@ -161,46 +183,69 @@ class PolygonTests(g.unittest.TestCase):
             # check a rectangle with one corner
             # at the origin and the rest in positive space
             b, h = bh
-            return g.np.array([b * h**3,
-                               h * b**3], dtype=g.np.float64) / 3.0
+            return g.np.array([b * h**3 / 3.0,
+                               h * b**3 / 3.0,
+                               0.5 * b**2 * 0.5 * h**2], dtype=g.np.float64)
 
-        from trimesh.path.polygons import second_moment
+        from trimesh.path.polygons import second_moments
+        from trimesh.path.polygons import transform_polygon
         from shapely.geometry import Polygon
+
         heights = g.np.array([[0.01, 0.01],
                               [1, 1],
                               [10, 2],
                               [3, 21]])
         for bh in heights:
             # check the second moment of a rectangle
-            # as both a numpy array and as a Polygon
-            a = second_moment(rectangle(bh))
-            b = second_moment(poly(bh))
+            # as polygon is already centered, centered doesn't change anything
+            O_moments, O_principal_moments, O_alpha, O_transform = second_moments(poly(bh), centered=True)
             # check against wikipedia
             t = truth(bh)
-            assert g.np.allclose(a, b)
-            assert g.np.allclose(a, t)
+            # for a centered rectangle, the principal axis are alread aligned with the frame axis
+            assert g.np.allclose(O_moments, t)
+            assert g.np.any(g.np.isclose(O_moments, O_principal_moments[0]))
+            assert g.np.isclose(O_moments[2],0)
+            assert g.np.isclose(O_alpha,0)
+            assert g.np.allclose(O_transform, g.np.eye(3))
 
-            # now add some interiors
+
+            # now check a rectangle with the corner
+            
+            # First we test with centering. The results should be same as
+            # with the centered rectangles
+            C_moments, C_principal_moments, C_alpha, C_transform = second_moments(poly_corner(bh), centered=True)
+            assert g.np.allclose(O_moments, C_moments)
+            assert g.np.allclose(O_principal_moments, C_principal_moments)
+            assert g.np.isclose(O_alpha, C_alpha)
+            assert g.np.allclose(O_transform[:,:2], C_transform[:,:2])
+
+            # Now without centering
+            moments = second_moments(poly_corner(bh), centered=False)
+            t = truth_corner(bh)
+            assert g.np.allclose(moments, t)
+
+            # Now we will get the transform for a double rectangle. Then we will apply
+            # the transform and test if Ixy == 0
+            C_moments, C_principal_moments, C_alpha, C_transform = second_moments(poly_doublecorner(bh), centered=True)
+            # apply the outputted transform to the polygon
+            T_polygon = transform_polygon(poly_doublecorner(bh), C_transform)
+            # call the function again
+            T_moments, T_principal_moments, T_alpha, T_transform = second_moments(T_polygon, centered=True)
+            assert g.np.any(g.np.isclose(T_moments, C_principal_moments[0]))
+            assert g.np.allclose(C_principal_moments,T_principal_moments)
+            assert g.np.isclose(T_alpha,0)
+            assert g.np.allclose(T_transform, g.np.eye(3))
+
+            
             for bhi in heights:
                 # only check if interior is smaller than exterior
                 if not (bhi < bh).all():
                     continue
 
                 # check a rectangle with interiors
-                c = second_moment(poly(bh, bhi))
+                c = second_moments(poly(bh, bhi), centered=False)
                 t = truth(bh, bhi)
                 assert g.np.allclose(c, t)
-
-            # now check a rectangle with the corner
-            # at the origin to see if we've done something
-            # silly with regards to offsets
-            r = rectangle(bh)
-            r += r.min(axis=0)
-            a = second_moment(r)
-            t = truth_corner(bh)
-            # not sure what Ixy is analytically because
-            # wikipedia didn't list it for this case
-            assert g.np.allclose(a[:2], t)
 
 
 if __name__ == '__main__':

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -846,39 +846,90 @@ def projected(mesh,
     return polygon
 
 
-def second_moment(coords):
+def second_moments(polygon, centered=True):
     """
-    Calculate the second moment of area of a polygon
+    Calculate the second moments of area of a polygon
     from the boundary.
 
     Parameters
     ------------
     coords : (n, 2) float or Polygon
       Closed polygon.
+    centered: bool
+      If true, get second moments for a frame with origin at the centroid
+      and perform a principal axis transformation
 
     Returns
     ----------
     moments : (3,) float
-      The values of `[Ix, Iy, Ixy]`
+      The values of `[Ixx, Iyy, Ixy]`
+    principal_moments : (2,) float
+      Principal second moments of inertia: `[Imax, Imin]`
+      Only returned if centered=True
+    alpha : float
+      Angle by which the input polygon needs to be rotated, so the 
+      principal axis align with the x- and y-Axis. 
+      Only returned if centered=True
+    transform : (3,3) float
+      Transformation matrix which rotates the polygon by alpha.
+      Only returned if centered=True
     """
-    if hasattr(coords, 'exterior'):
-        # if we have been passed a shapely.geometry.Polygon
-        exterior = second_moment(np.array(coords.exterior.coords))
-        interiors = np.sum([second_moment(np.array(i.coords))
-                            for i in coords.interiors],
-                           axis=0)
-        return exterior - interiors
 
-    coords = np.asanyarray(coords, dtype=np.float64)
+    transform = np.eye(3)
+    if centered == True:
+        # calculate centroid and move polygon
+        transform[:2,2] = - np.array(polygon.centroid.coords)
+        polygon = transform_polygon(polygon, transform)
+
+    # start with the exterior
+    coords = np.array(polygon.exterior.coords)
     # shorthand the coordinates
     x1, y1 = np.vstack((coords[-1], coords[:-1])).T
     x2, y2 = coords.T
     # do vectorized operations
     v = x1 * y2 - x2 * y1
-    Ix = v * (y1 * y1 + y1 * y2 + y2 * y2)
-    Iy = v * (x1 * x1 + x1 * x2 + x2 * x2)
-    Ixy = v * (x1 * y2 + 2 * x1 * y1 + 2 * x2 * y2 + x2 * y1)
-    # divide by constants and return
-    return np.array([Ix.sum() / 12.0,
-                     Iy.sum() / 12.0,
-                     Ixy.sum() / 24.0], dtype=np.float64)
+    Ixx = 0.083333333333 * np.sum( v * (y1 * y1 + y1 * y2 + y2 * y2) )
+    Iyy = 0.083333333333 * np.sum( v * (x1 * x1 + x1 * x2 + x2 * x2) )
+    Ixy = 0.041666666666 * np.sum( v * (x1 * y2 + 2 * x1 * y1 + 2 * x2 * y2 + x2 * y1) )
+
+    for interior in polygon.interiors:
+        coords = np.array(interior.coords)
+        # shorthand the coordinates
+        x1, y1 = np.vstack((coords[-1], coords[:-1])).T
+        x2, y2 = coords.T
+        # do vectorized operations
+        v = x1 * y2 - x2 * y1
+        Ixx -= 0.083333333333 * np.sum( v * (y1 * y1 + y1 * y2 + y2 * y2) )
+        Iyy -= 0.083333333333 * np.sum( v * (x1 * x1 + x1 * x2 + x2 * x2) )
+        Ixy -= 0.041666666666 * np.sum( v * (x1 * y2 + 2 * x1 * y1 + 2 * x2 * y2 + x2 * y1) )
+    
+    moments = [Ixx, Iyy, Ixy]
+
+    if centered is not True:
+        return moments
+    else:
+        # get the principal moments
+        root = np.sqrt(((Iyy-Ixx)/2)**2 + Ixy**2)
+        Imax = (Ixx+Iyy)/2 + root
+        Imin = (Ixx+Iyy)/2 - root
+        principal_moments = [Imax, Imin]
+
+        # do the principal axis transform
+        if np.isclose(Ixy, 0, atol=1e-12): # for small shapes Ixy can get very small, but not 0
+            alpha = 0
+        elif np.isclose(Ixx, Iyy):
+            # prevent division by 0
+            alpha = 0.25 * np.pi
+        else:
+            alpha = 0.5 * np.arctan(2*Ixy/(Ixx - Iyy))
+
+        # construct transformation matrix
+        cos_alpha = np.cos(alpha)
+        sin_alpha = np.sin(alpha)
+
+        transform[0,0] = cos_alpha
+        transform[1,1] = cos_alpha
+        transform[0,1] = - sin_alpha
+        transform[1,0] = sin_alpha
+
+        return moments, principal_moments, alpha, transform

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -846,7 +846,7 @@ def projected(mesh,
     return polygon
 
 
-def second_moments(polygon, centered=True):
+def second_moments(polygon, centered=False):
     """
     Calculate the second moments of area of a polygon
     from the boundary.
@@ -867,7 +867,7 @@ def second_moments(polygon, centered=True):
       Principal second moments of inertia: `[Imax, Imin]`
       Only returned if centered=True
     alpha : float
-      Angle by which the input polygon needs to be rotated, so the 
+      Angle by which the polygon needs to be rotated, so the 
       principal axis align with the x- and y-Axis. 
       Only returned if centered=True
     transform : (3,3) float


### PR DESCRIPTION
Hi,
I added a new feature regarding the second moment of area for polygons. 

I added a `centered` input flag, which can center the polygon before the second moments are calculated. 
If the `centered` flag is set, the function also performs a principal axis transform. This is pretty similar to inertia tensors. Ixy should be 0 after the transformation.

The function outputs the angle by which the polygon needs to be rotated (around the centroid because `centered` must be set True) and a transformation matrix to perform that rotation and a translation to move the origin to the centroid. 
Normally `alpha` is the angle by which the frame needs to be rotated, not the shape. I decided to return `-alpha` which is the angle by which the polygon needs be rotated. I felt this is more intuitive in context of the other polygon functions. 

Before my changes the function also allowed (n,2) numpy arrays as input instead of a polygon. I removed this because the function needs the `Polygon.centroid`. For the numpy array there had to be another function able to do that. 
And for the centroid you need to calculate the area which also would require another function. It wouldn’t be overly complicated to implement this but I thought the use of the shapely Polygon is exactly because to prevent implementing all this simple functions. Also, all the other functions in `polygon.py` only take polygon inputs so it is more consistent now. But if you think otherwise, let me know, I can re-add support for numpy arrays.

I used my university textbook as source, but the content is the same as on this website: https://leancrew.com/all-this/2018/01/transforming-section-properties-and-principal-directions/ I was surprised there is rather little reference on the internet on this as this was quite a big thing in my mechanics class. 

I added a test on a double cornered rectangle: One rectangle is still in the first quadrant of the coordinate system, but there is another rectangle rotated by 180 deg. The idea is to have a polygon that has `Ixy != 0` with the centroid at the origin. This polygon is then rotated by the outputted alpha and the the test checks if after that `Ixy == 0`. 

I hope you like it, I appreciate your Feedback!
