### PR TITLE
fix dummy Profiler class to be a proper context manager

### DIFF
--- a/tests/generic.py
+++ b/tests/generic.py
@@ -49,8 +49,8 @@ try:
 except BaseException:
     # make a dummy profiler which does nothing
     class Profiler(object):
-        def __enter__(*args, **kwargs):
-            pass
+        def __enter__(self, *args, **kwargs):
+            return self
 
         def __exit__(*args, **kwargs):
             pass


### PR DESCRIPTION
The dummy `Profiler` class that is used whenever `pyinstrument` is not available did not return a object in its `__enter__` method, effectively breaking statements like:

    with g.Profiler() as P:
        pass
    print(P.output_text())

Make it return itself to fix that.  This fixes 4 test failures for us.