### PR TITLE
added lxml import error message print

### DIFF
--- a/trimesh/exchange/threedxml.py
+++ b/trimesh/exchange/threedxml.py
@@ -328,5 +328,6 @@ def print_element(element):
 try:
     from lxml import etree
     _threedxml_loaders = {'3dxml': load_3DXML}
-except ImportError:
+except ImportError as error:
+    print(error)
     _threedxml_loaders = {}

--- a/trimesh/exchange/threemf.py
+++ b/trimesh/exchange/threemf.py
@@ -466,5 +466,6 @@ def _attrib_to_transform(attrib):
 try:
     from lxml import etree
     _three_loaders = {'3mf': load_3MF}
-except ImportError:
+except ImportError as error:
+    print(error)
     _three_loaders = {}

--- a/trimesh/exchange/xaml.py
+++ b/trimesh/exchange/xaml.py
@@ -159,5 +159,6 @@ def load_XAML(file_obj, *args, **kwargs):
 try:
     from lxml import etree
     _xaml_loaders = {'xaml': load_XAML}
-except ImportError:
+except ImportError as error:
+    print(error)
     _xaml_loaders = {}


### PR DESCRIPTION
If the lxml package for loading 3DXML/XAML/3MF is not installed, the `ImportError` is not displayed but only `ValueError: File type: 3dxml not supported`. This is not too helpful because it does not say that you just need to install lxml to make it work.