### PR TITLE
Release: Bugbear + ExceptionWrapper

### DIFF
--- a/examples/sinter.py
+++ b/examples/sinter.py
@@ -56,13 +56,17 @@ def collect_meshes(count=None):
 if __name__ == '__main__':
 
     # get some sample data
-    meshes = collect_meshes(count=100)
+    meshes = collect_meshes(count=10)
 
     print('loaded {} meshes'.format(len(meshes)))
 
     # place the meshes into the volume
-    placed, transforms, consume = packing.meshes(
-        meshes, size=[7, 7, 7], spacing=0.05)
+    from pyinstrument import Profiler
+
+    with Profiler() as P:
+        placed, transforms, consume = packing.meshes(
+            meshes, spacing=0.05)
+    P.print()
 
     # none of the placed meshes should have overlapping AABB
     assert not packing.bounds_overlap([i.bounds for i in placed])

--- a/examples/sinter.py
+++ b/examples/sinter.py
@@ -9,6 +9,9 @@ import numpy as np
 
 from trimesh.path import packing
 
+from pyinstrument import Profiler
+
+
 # path with our sample models
 models = os.path.abspath(os.path.join(
     os.path.expanduser(os.path.dirname(__file__)), '..', 'models'))
@@ -56,13 +59,11 @@ def collect_meshes(count=None):
 if __name__ == '__main__':
 
     # get some sample data
-    meshes = collect_meshes(count=10)
+    meshes = collect_meshes(count=100)
 
     print('loaded {} meshes'.format(len(meshes)))
 
     # place the meshes into the volume
-    from pyinstrument import Profiler
-
     with Profiler() as P:
         placed, transforms, consume = packing.meshes(
             meshes, spacing=0.05)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [tool.ruff]
 select = ["E", "F",
-          "T201", # disallow print statements
+          "T201", "B" # disallow print statements
 	  ] # TODO : pass bugbear "B"]
 ignore = ["B905"]
 line-length = 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ requires = [
 ]
 
 [tool.ruff]
-select = ["E", "F",
-          "T201", "B" # disallow print statements
-	  ] # TODO : pass bugbear "B"]
-ignore = ["B905"]
+select = ["E", "F", # the default rules
+          "T201",   # disallow print statements
+	  "B"]      # pass bugbear
+ignore = ["B905"] # `zip()` without an explicit `strict=`
 line-length = 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires = [
 ]
 
 [tool.ruff]
-select = ["E", "F"] # TODO : pass bugbear "B"]
+select = ["E", "F",
+          "T201", # disallow print statements
+	  ] # TODO : pass bugbear "B"]
 ignore = ["B905"]
 line-length = 90

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -86,7 +86,7 @@ except ImportError as E:
 try:
     import jsonschema
 except BaseException as E:
-    jsonschema = trimesh.exceptions.ExceptionModule(E)
+    jsonschema = trimesh.exceptions.ExceptionWrapper(E)
 
 # make sure functions know they should run additional
 # potentially slow validation checks and raise exceptions

--- a/tests/test_except.py
+++ b/tests/test_except.py
@@ -7,11 +7,11 @@ except BaseException:
 class ExceptionsTest(g.unittest.TestCase):
 
     def test_module(self):
-        # create an ExceptionModule
+        # create an ExceptionWrapper
         try:
             raise ValueError('nah')
         except BaseException as E:
-            em = g.trimesh.exceptions.ExceptionModule(E)
+            em = g.trimesh.exceptions.ExceptionWrapper(E)
 
         # checking isinstance should always return false
         # and NOT raise the error

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -21,6 +21,9 @@ _mwd = os.path.abspath(
 
 
 def get_mesh(file_name, **kwargs):
+    """
+    Load a mesh from our models directory.
+    """
     return trimesh.load(os.path.join(_mwd, file_name),
                         **kwargs)
 
@@ -90,6 +93,27 @@ class MinimalTest(unittest.TestCase):
         assert len(scene.geometry) == 1
         glb = scene.export(file_type='glb')
         assert len(glb) > 0
+
+    def test_load_wrap(self):
+        # check to see if we give a useful message
+        # when we *do not* have `lxml` installed
+        try:
+            import lxml  # noqa
+            return
+        except BaseException:
+            pass
+
+        # we have no 3DXML
+        exc = None
+        try:
+            get_mesh('cycloidal.3dxml')
+        except BaseException as E:
+            exc = str(E)
+
+        # should have raised
+        assert exc is not None
+        # error message should have been useful
+        assert 'lxml' in exc
 
 
 if __name__ == '__main__':

--- a/trimesh/__init__.py
+++ b/trimesh/__init__.py
@@ -44,8 +44,8 @@ try:
     from . import path
 except BaseException as E:
     # raise a useful error if path hasn't loaded
-    from .exceptions import ExceptionModule
-    path = ExceptionModule(E)
+    from .exceptions import ExceptionWrapper
+    path = ExceptionWrapper(E)
 
 # explicitly list imports in __all__
 # as otherwise flake8 gets mad

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -16,8 +16,8 @@ try:
 except BaseException as E:
     # raise the exception when someone tries to use it
     from . import exceptions
-    spatial = exceptions.ExceptionModule(E)
-    optimize = exceptions.ExceptionModule(E)
+    spatial = exceptions.ExceptionWrapper(E)
+    optimize = exceptions.ExceptionWrapper(E)
 
 
 # a 90 degree rotation

--- a/trimesh/convex.py
+++ b/trimesh/convex.py
@@ -20,8 +20,8 @@ from . import triangles
 try:
     from scipy import spatial
 except ImportError as E:
-    from .exceptions import ExceptionModule
-    spatial = ExceptionModule(E)
+    from .exceptions import ExceptionWrapper
+    spatial = ExceptionWrapper(E)
 
 
 def convex_hull(obj, qhull_options='QbB Pp Qt'):

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -27,13 +27,13 @@ try:
 except BaseException as E:
     # re-raise the exception when someone tries
     # to use the module that they don't have
-    Polygon = exceptions.closure(E)
-    load_wkb = exceptions.closure(E)
+    Polygon = exceptions.ExceptionWrapper(E)
+    load_wkb = exceptions.ExceptionWrapper(E)
 
 try:
     from mapbox_earcut import triangulate_float64 as _tri_earcut
 except BaseException as E:
-    _tri_earcut = exceptions.closure(E)
+    _tri_earcut = exceptions.ExceptionWrapper(E)
 
 
 def revolve(linestring,

--- a/trimesh/curvature.py
+++ b/trimesh/curvature.py
@@ -12,7 +12,7 @@ try:
     from scipy.sparse import coo_matrix
 except ImportError as E:
     from . import exceptions
-    coo_matrix = exceptions.closure(E)
+    coo_matrix = exceptions.ExceptionWrapper(E)
 
 
 def face_angles_sparse(mesh):

--- a/trimesh/exceptions.py
+++ b/trimesh/exceptions.py
@@ -2,48 +2,33 @@
 exceptions.py
 ----------------
 
-Handle things related to exceptions.
+Wrap exceptions.
 """
 
 
-class ExceptionModule(object):
+class ExceptionWrapper(object):
     """
-    Create a dummy module which will raise an exception when attributes
-    are accessed.
+    Create a dummy object which will raise an exception when attributes
+    are accessed (i.e. when used as a module) or when called (i.e.
+    when used like a function)
 
     For soft dependencies we want to survive failing to import but
     we would like to raise an appropriate error when the functionality is
     actually requested so the user gets an easily debuggable message.
     """
 
-    def __init__(self, exc):
-        self.exc = exc
+    def __init__(self, exception):
+        self.exception = exception
 
     def __getattribute__(self, *args, **kwargs):
+        # will raise when this object is accessed like an object
         # if it's asking for our class type return None
         # this allows isinstance() checks to not re-raise
         if args[0] == '__class__':
             return None.__class__
         # otherwise raise our original exception
-        raise super(ExceptionModule, self).__getattribute__('exc')
+        raise super(ExceptionWrapper, self).__getattribute__('exception')
 
-
-def closure(exc):
-    """
-    Return a function which will accept any arguments
-    but raise the exception when called.
-
-    Parameters
-    ------------
-    exc : Exception
-      Will be raised later
-
-    Returns
-    -------------
-    failed : function
-      When called will raise `exc`
-    """
-    # scoping will save exception
-    def failed(*args, **kwargs):
-        raise exc
-    return failed
+    def __call__(self, *args, **kwargs):
+        # will raise when this object is called like a function
+        raise super(ExceptionWrapper, self).__getattribute__('exception')

--- a/trimesh/exchange/binvox.py
+++ b/trimesh/exchange/binvox.py
@@ -528,7 +528,7 @@ class Binvoxer(object):
         verbosity = subprocess.check_output(self._args)
         # if requested print ourselves
         if self.verbose:
-            print(verbosity)
+            util.log.debug(verbosity)
 
         return out_path
 

--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -425,6 +425,14 @@ def load_zae(file_obj, resolver=None, **kwargs):
 _collada_loaders = {}
 _collada_exporters = {}
 if util.has_module('collada'):
+
     _collada_loaders['dae'] = load_collada
     _collada_loaders['zae'] = load_zae
     _collada_exporters['dae'] = export_collada
+else:
+    # store an exception to raise later
+    from ..exceptions import ExceptionWrapper
+    _exc = ExceptionWrapper(
+        ImportError('missing `pip install pycollada`'))
+    _collada_loaders.update({'dae': exc, 'zae': exc})
+    _collada_exporters['dae'] = exc

--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -434,5 +434,5 @@ else:
     from ..exceptions import ExceptionWrapper
     _exc = ExceptionWrapper(
         ImportError('missing `pip install pycollada`'))
-    _collada_loaders.update({'dae': exc, 'zae': exc})
-    _collada_exporters['dae'] = exc
+    _collada_loaders.update({'dae': _exc, 'zae': _exc})
+    _collada_exporters['dae'] = _exc

--- a/trimesh/exchange/export.py
+++ b/trimesh/exchange/export.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 import numpy as np
 

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1644,7 +1644,7 @@ def _read_buffers(header,
                 # append root node
                 graph.append(kwargs.copy())
                 # put primitives as children
-                for i, geom_name in enumerate(geometries):
+                for geom_name in geometries:
                     # save the name of the geometry
                     kwargs["geometry"] = geom_name
                     # no transformations

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -10,6 +10,7 @@ from ..parent import Geometry
 from ..points import PointCloud
 from ..scene.scene import Scene, append_scenes
 from ..util import log, now
+from ..exceptions import ExceptionWrapper
 
 from . import misc
 from .xyz import _xyz_loaders
@@ -31,8 +32,7 @@ try:
     from ..path.exchange.load import load_path, path_formats
 except BaseException as E:
     # save a traceback to see why path didn't import
-    from ..exceptions import closure
-    load_path = closure(E)
+    load_path = ExceptionWrapper(E)
     # no path formats available
 
     def path_formats():
@@ -49,7 +49,9 @@ def mesh_formats():
       Extensions of available mesh loaders,
       i.e. 'stl', 'ply', etc.
     """
-    return set(mesh_loaders.keys())
+    # filter out exceptionmodule loaders
+    return set(k for k, v in mesh_loaders.items()
+               if not isinstance(v, ExceptionWrapper))
 
 
 def available_formats():
@@ -66,6 +68,7 @@ def available_formats():
     loaders = mesh_formats()
     loaders.update(path_formats())
     loaders.update(compressed_loaders.keys())
+
     return loaders
 
 

--- a/trimesh/exchange/misc.py
+++ b/trimesh/exchange/misc.py
@@ -3,33 +3,6 @@ import json
 from .. import util
 
 
-def load_msgpack(blob, **kwargs):
-    """
-    Load a dict packed with msgpack into kwargs for
-    a Trimesh constructor
-
-    Parameters
-    ----------
-    blob : bytes
-      msgpack packed dict containing
-      keys 'vertices' and 'faces'
-
-    Returns
-    ----------
-    loaded : dict
-     Keyword args for Trimesh constructor, aka
-     mesh=trimesh.Trimesh(**loaded)
-    """
-
-    import msgpack
-    if hasattr(blob, 'read'):
-        data = msgpack.load(blob)
-    else:
-        data = msgpack.loads(blob)
-    loaded = load_dict(data)
-    return loaded
-
-
 def load_dict(data, **kwargs):
     """
     Load multiple input types into kwargs for a Trimesh constructor.
@@ -41,7 +14,8 @@ def load_dict(data, **kwargs):
 
     Parameters
     ----------
-    data: accepts multiple forms
+    data : dict
+    accepts multiple forms
           -dict: has keys for vertices and faces as (n,3) numpy arrays
           -dict: has keys for vertices/faces (n,3) arrays encoded as dicts/base64
                  with trimesh.util.array_to_encoded/trimesh.util.encoded_to_array
@@ -150,8 +124,7 @@ def load_meshio(file_obj, file_type=None, **kwargs):
 
 _misc_loaders = {'dict': load_dict,
                  'dict64': load_dict,
-                 'json': load_dict,
-                 'msgpack': load_msgpack}
+                 'json': load_dict}
 
 try:
     import meshio
@@ -161,4 +134,4 @@ try:
         meshio.extension_to_filetypes.keys()}
     _misc_loaders.update(_meshio_loaders)
 except BaseException:
-    _meshio_loaders = dict()
+    _meshio_loaders = {}

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -10,8 +10,8 @@ try:
 except BaseException as E:
     # if someone tries to use Image re-raise
     # the import error so they can debug easily
-    from ..exceptions import ExceptionModule
-    Image = ExceptionModule(E)
+    from ..exceptions import ExceptionWrapper
+    Image = ExceptionWrapper(E)
 
 from .. import util
 from ..visual.color import to_float

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -932,7 +932,7 @@ def export_obj(mesh,
         mtl_data = {}
         # now loop through: keys are garbage hash
         # values are (data, name)
-        for data, name in materials.values():
+        for data, _ in materials.values():
             for file_name, file_data in data.items():
                 if file_name.lower().endswith('.mtl'):
                     # collect mtl lines into single file

--- a/trimesh/exchange/openctm.py
+++ b/trimesh/exchange/openctm.py
@@ -46,9 +46,9 @@ try:
     if _ctm_lib_name is None or len(_ctm_lib_name) == 0:
         raise ImportError('libopenctm library not found!')
 except BaseException as E:
-    from ..exceptions import closure
+    from ..exceptions import ExceptionWrapper
     _ctm_lib_name = None
-    _ctm_loader = closure(E)
+    _ctm_loader = ExceptionWrapper(E)
 
 
 def load_ctm(file_obj, file_type=None, **kwargs):

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -966,9 +966,9 @@ def load_draco(file_obj, **kwargs):
 
 _ply_loaders = {'ply': load_ply}
 _ply_exporters = {'ply': export_ply}
+
 draco_encoder = util.which('draco_encoder')
 draco_decoder = util.which('draco_decoder')
-
 if draco_decoder is not None:
     _ply_loaders['drc'] = load_draco
 if draco_encoder is not None:

--- a/trimesh/exchange/stl.py
+++ b/trimesh/exchange/stl.py
@@ -78,10 +78,10 @@ def load_stl_binary(file_obj):
         raise HeaderError('Binary STL shorter than a fixed header!')
 
     try:
-        header = np.frombuffer(header_data,
-                               dtype=_stl_dtype_header)
-    except BaseException:
-        raise HeaderError('Binary header incorrect type')
+        header = np.frombuffer(
+            header_data, dtype=_stl_dtype_header)
+    except BaseException as E:
+        raise HeaderError('Binary header incorrect type') from E
 
     try:
         # save the header block as a string

--- a/trimesh/exchange/threedxml.py
+++ b/trimesh/exchange/threedxml.py
@@ -313,7 +313,6 @@ def print_element(element):
     """
     pretty = etree.tostring(
         element, pretty_print=True).decode('utf-8')
-    print(pretty)
     return pretty
 
 

--- a/trimesh/exchange/threedxml.py
+++ b/trimesh/exchange/threedxml.py
@@ -11,14 +11,6 @@ import collections
 
 from .. import util
 
-try:
-    import networkx as nx
-except BaseException as E:
-    # create a dummy module which will raise the ImportError
-    # or other exception only when someone tries to use networkx
-    from ..exceptions import ExceptionModule
-    nx = ExceptionModule(E)
-
 
 def load_3DXML(file_obj, *args, **kwargs):
     """
@@ -326,7 +318,11 @@ def print_element(element):
 
 
 try:
+    # soft dependencies
     from lxml import etree
+    import networkx as nx
     _threedxml_loaders = {'3dxml': load_3DXML}
-except ImportError:
-    _threedxml_loaders = {}
+except BaseException as E:
+    # set loader to exception wrapper
+    from ..exceptions import ExceptionWrapper
+    _threedxml_loaders = {'3dxml': ExceptionWrapper(E)}

--- a/trimesh/exchange/threemf.py
+++ b/trimesh/exchange/threemf.py
@@ -11,14 +11,6 @@ from .. import graph
 
 from ..constants import log
 
-try:
-    import networkx as nx
-except BaseException as E:
-    # create a dummy module which will raise the ImportError
-    # or other exception only when someone tries to use networkx
-    from ..exceptions import ExceptionModule
-    nx = ExceptionModule(E)
-
 
 def load_3MF(file_obj,
              postprocess=True,
@@ -465,6 +457,10 @@ def _attrib_to_transform(attrib):
 # do import here to keep lxml a soft dependency
 try:
     from lxml import etree
+    import networkx as nx
     _three_loaders = {'3mf': load_3MF}
-except ImportError:
-    _three_loaders = {}
+    _3mf_exporters = {'3mf': export_3MF}
+except BaseException as E:
+    from ..exceptions import ExceptionWrapper
+    _three_loaders = {'3mf': ExceptionWrapper(E)}
+    _3mf_exporters = {'3mf': ExceptionWrapper(E)}

--- a/trimesh/exchange/threemf.py
+++ b/trimesh/exchange/threemf.py
@@ -261,7 +261,9 @@ def export_3MF(mesh,
     }
 
     # model ids
-    def model_id(x, models=[]):
+    models = []
+
+    def model_id(x):
         if x not in models:
             models.append(x)
         return str(models.index(x) + 1)

--- a/trimesh/exchange/urdf.py
+++ b/trimesh/exchange/urdf.py
@@ -10,7 +10,7 @@ from ..version import __version__
 def export_urdf(mesh,
                 directory,
                 scale=1.0,
-                color=[0.75, 0.75, 0.75],
+                color=None,
                 **kwargs):
     """
     Convert a Trimesh object into a URDF package for physics
@@ -110,11 +110,12 @@ def export_urdf(mesh,
                                                           scale,
                                                           scale))
         material = et.SubElement(visual, 'material', name='')
-        et.SubElement(material,
-                      'color',
-                      rgba="{:.2E} {:.2E} {:.2E} 1".format(color[0],
-                                                           color[1],
-                                                           color[2]))
+        if color is not None:
+            et.SubElement(material,
+                          'color',
+                          rgba="{:.2E} {:.2E} {:.2E} 1".format(color[0],
+                                                               color[1],
+                                                               color[2]))
 
         # Collision Information
         collision = et.SubElement(link, 'collision')

--- a/trimesh/exchange/xaml.py
+++ b/trimesh/exchange/xaml.py
@@ -150,7 +150,6 @@ def load_XAML(file_obj, *args, **kwargs):
 
 try:
     from lxml import etree
-    import networkx as nx
     _xaml_loaders = {'xaml': load_XAML}
 except BaseException as E:
     # create a dummy module which will raise the ImportError

--- a/trimesh/exchange/xaml.py
+++ b/trimesh/exchange/xaml.py
@@ -12,14 +12,6 @@ from .. import util
 from .. import visual
 from .. import transformations as tf
 
-try:
-    import networkx as nx
-except BaseException as E:
-    # create a dummy module which will raise the ImportError
-    # or other exception only when someone tries to use networkx
-    from ..exceptions import ExceptionModule
-    nx = ExceptionModule(E)
-
 
 def load_XAML(file_obj, *args, **kwargs):
     """
@@ -158,6 +150,10 @@ def load_XAML(file_obj, *args, **kwargs):
 
 try:
     from lxml import etree
+    import networkx as nx
     _xaml_loaders = {'xaml': load_XAML}
-except ImportError:
-    _xaml_loaders = {}
+except BaseException as E:
+    # create a dummy module which will raise the ImportError
+    # or other exception only when someone tries to use networkx
+    from ..exceptions import ExceptionWrapper
+    _xaml_loaders = {'xaml': ExceptionWrapper(E)}

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -8,7 +8,7 @@ try:
 except BaseException as E:
     from . import exceptions
     # raise E again if anyone tries to use sparse
-    scipy = exceptions.ExceptionModule(E)
+    scipy = exceptions.ExceptionWrapper(E)
 
 
 def plane_transform(origin, normal):

--- a/trimesh/graph.py
+++ b/trimesh/graph.py
@@ -22,15 +22,15 @@ try:
     from scipy.sparse import csgraph, coo_matrix
 except BaseException as E:
     # re-raise exception when used
-    csgraph = exceptions.ExceptionModule(E)
-    coo_matrix = exceptions.closure(E)
+    csgraph = exceptions.ExceptionWrapper(E)
+    coo_matrix = exceptions.ExceptionWrapper(E)
 
 try:
     import networkx as nx
 except BaseException as E:
     # create a dummy module which will raise the ImportError
     # or other exception only when someone tries to use networkx
-    nx = exceptions.ExceptionModule(E)
+    nx = exceptions.ExceptionWrapper(E)
 
 
 def face_adjacency(faces=None,

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -17,7 +17,7 @@ except BaseException as E:
     # wrapping just ImportError fails in some cases
     # will raise the error when someone tries to use KDtree
     from . import exceptions
-    cKDTree = exceptions.closure(E)
+    cKDTree = exceptions.ExceptionWrapper(E)
 
 
 def merge_vertices(mesh,

--- a/trimesh/nsphere.py
+++ b/trimesh/nsphere.py
@@ -19,8 +19,8 @@ try:
 except BaseException as E:
     # raise the exception when someone tries to use it
     from . import exceptions
-    leastsq = exceptions.closure(E)
-    spatial = exceptions.ExceptionModule(E)
+    leastsq = exceptions.ExceptionWrapper(E)
+    spatial = exceptions.ExceptionWrapper(E)
 
 try:
     import psutil

--- a/trimesh/path/__init__.py
+++ b/trimesh/path/__init__.py
@@ -9,8 +9,8 @@ try:
     from .path import Path2D, Path3D
 except BaseException as E:
     from .. import exceptions
-    Path2D = exceptions.closure(E)
-    Path3D = exceptions.closure(E)
+    Path2D = exceptions.ExceptionWrapper(E)
+    Path3D = exceptions.ExceptionWrapper(E)
 
 # explicitly add objects to all as per pep8
 __all__ = ['Path2D', 'Path3D']

--- a/trimesh/path/creation.py
+++ b/trimesh/path/creation.py
@@ -11,7 +11,7 @@ from .. import transformations
 def circle_pattern(pattern_radius,
                    circle_radius,
                    count,
-                   center=[0.0, 0.0],
+                   center=None,
                    angle=None,
                    **kwargs):
     """
@@ -44,6 +44,9 @@ def circle_pattern(pattern_radius,
         angles = np.linspace(0.0, angle, count)
     else:
         raise ValueError('angle must be float or int!')
+
+    if center is None:
+        center = [0.0, 0.0]
 
     # centers of circles
     centers = np.column_stack((

--- a/trimesh/path/entities.py
+++ b/trimesh/path/entities.py
@@ -358,10 +358,6 @@ class Text(Entity):
             # otherwise raise rror
             raise ValueError('align must be (2,) str')
 
-        if any(i not in ['left', 'right', 'center']
-               for i in align):
-            print('nah')
-
         self.align = align
 
         # make sure text is a string

--- a/trimesh/path/exchange/svg_io.py
+++ b/trimesh/path/exchange/svg_io.py
@@ -25,14 +25,14 @@ try:
 except BaseException as E:
     # will re-raise the import exception when
     # someone tries to call `parse_path`
-    parse_path = exceptions.closure(E)
+    parse_path = exceptions.ExceptionWrapper(E)
 
 try:
     from lxml import etree
 except BaseException as E:
     # will re-raise the import exception when
     # someone actually tries to use the module
-    etree = exceptions.ExceptionModule(E)
+    etree = exceptions.ExceptionWrapper(E)
 
 # store any additional properties using a trimesh namespace
 _ns_name = 'trimesh'

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -44,23 +44,23 @@ from .exchange.export import export_path
 try:
     from . import repair
 except BaseException as E:
-    repair = exceptions.ExceptionModule(E)
+    repair = exceptions.ExceptionWrapper(E)
 try:
     from . import polygons
 except BaseException as E:
-    polygons = exceptions.ExceptionModule(E)
+    polygons = exceptions.ExceptionWrapper(E)
 try:
     from scipy.spatial import cKDTree
 except BaseException as E:
-    cKDTree = exceptions.closure(E)
+    cKDTree = exceptions.ExceptionWrapper(E)
 try:
     from shapely.geometry import Polygon
 except BaseException as E:
-    Polygon = exceptions.closure(E)
+    Polygon = exceptions.ExceptionWrapper(E)
 try:
     import networkx as nx
 except BaseException as E:
-    nx = exceptions.ExceptionModule(E)
+    nx = exceptions.ExceptionWrapper(E)
 
 
 class Path(parent.Geometry):

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -20,14 +20,14 @@ try:
 except BaseException as E:
     # create a dummy module which will raise the ImportError
     # or other exception only when someone tries to use networkx
-    from ..exceptions import ExceptionModule
-    nx = ExceptionModule(E)
+    from ..exceptions import ExceptionWrapper
+    nx = ExceptionWrapper(E)
 try:
     from rtree import Rtree
 except BaseException as E:
     # create a dummy module which will raise the ImportError
-    from ..exceptions import closure
-    Rtree = closure(E)
+    from ..exceptions import ExceptionWrapper
+    Rtree = ExceptionWrapper(E)
 
 
 def enclosure_tree(polygons):

--- a/trimesh/path/raster.py
+++ b/trimesh/path/raster.py
@@ -14,7 +14,7 @@ try:
 except BaseException as E:
     from .. import exceptions
     # re-raise the useful exception when called
-    _handle = exceptions.ExceptionModule(E)
+    _handle = exceptions.ExceptionWrapper(E)
     Image = _handle
     ImageDraw = _handle
     ImageChops = _handle

--- a/trimesh/path/traversal.py
+++ b/trimesh/path/traversal.py
@@ -12,8 +12,8 @@ try:
 except BaseException as E:
     # create a dummy module which will raise the ImportError
     # or other exception only when someone tries to use networkx
-    from ..exceptions import ExceptionModule
-    nx = ExceptionModule(E)
+    from ..exceptions import ExceptionWrapper
+    nx = ExceptionWrapper(E)
 
 
 def vertex_graph(entities):

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -22,7 +22,7 @@ from . import transformations
 
 def point_plane_distance(points,
                          plane_normal,
-                         plane_origin=[0.0, 0.0, 0.0]):
+                         plane_origin=None):
     """
     The minimum perpendicular distance of a point to a plane.
 
@@ -41,7 +41,10 @@ def point_plane_distance(points,
       Distance from point to plane
     """
     points = np.asanyarray(points, dtype=np.float64)
-    w = points - plane_origin
+    if plane_origin is None:
+        w = points
+    else:
+        w = points - plane_origin
     distances = np.dot(plane_normal, w.T) / np.linalg.norm(plane_normal)
     return distances
 
@@ -155,8 +158,8 @@ def radial_sort(points,
 
 
 def project_to_plane(points,
-                     plane_normal=[0, 0, 1],
-                     plane_origin=[0, 0, 0],
+                     plane_normal,
+                     plane_origin,
                      transform=None,
                      return_transform=False,
                      return_planar=True):

--- a/trimesh/poses.py
+++ b/trimesh/poses.py
@@ -13,8 +13,8 @@ try:
 except BaseException as E:
     # create a dummy module which will raise the ImportError
     # or other exception only when someone tries to use networkx
-    from .exceptions import ExceptionModule
-    nx = ExceptionModule(E)
+    from .exceptions import ExceptionWrapper
+    nx = ExceptionWrapper(E)
 
 
 def compute_stable_poses(mesh,

--- a/trimesh/proximity.py
+++ b/trimesh/proximity.py
@@ -16,8 +16,8 @@ from .triangles import points_to_barycentric
 try:
     from scipy.spatial import cKDTree
 except BaseException as E:
-    from .exceptions import closure
-    cKDTree = closure(E)
+    from .exceptions import ExceptionWrapper
+    cKDTree = ExceptionWrapper(E)
 
 
 def nearby_faces(mesh, points):

--- a/trimesh/ray/__init__.py
+++ b/trimesh/ray/__init__.py
@@ -6,7 +6,7 @@ try:
     has_embree = True
 except BaseException as E:
     from .. import exceptions
-    ray_pyembree = exceptions.ExceptionModule(E)
+    ray_pyembree = exceptions.ExceptionWrapper(E)
     has_embree = False
 
 # add to __all__ as per pep8

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -24,8 +24,8 @@ except BaseException as E:
     # wrapping just ImportError fails in some cases
     # will raise the error when someone tries to use KDtree
     from . import exceptions
-    cKDTree = exceptions.closure(E)
-    sparse = exceptions.closure(E)
+    cKDTree = exceptions.ExceptionWrapper(E)
+    sparse = exceptions.ExceptionWrapper(E)
 
 
 def mesh_other(mesh,

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -303,7 +303,7 @@ def procrustes(a,
 
 def icp(a,
         b,
-        initial=np.identity(4),
+        initial=None,
         threshold=1e-5,
         max_iterations=20,
         **kwargs):
@@ -342,6 +342,9 @@ def icp(a,
     a = np.asanyarray(a, dtype=np.float64)
     if not util.is_shape(a, (-1, 3)):
         raise ValueError('points must be (n,3)!')
+
+    if initial is None:
+        initial = np.eye(4)
 
     is_mesh = util.is_instance_named(b, 'Trimesh')
     if not is_mesh:

--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -20,14 +20,14 @@ try:
 except BaseException as E:
     # create a dummy module which will raise the ImportError
     # or other exception only when someone tries to use networkx
-    from .exceptions import ExceptionModule
-    nx = ExceptionModule(E)
+    from .exceptions import ExceptionWrapper
+    nx = ExceptionWrapper(E)
 
 try:
     from .path.exchange.misc import faces_to_path
 except BaseException as E:
-    from .exceptions import closure
-    faces_to_path = closure(E)
+    from .exceptions import ExceptionWrapper
+    faces_to_path = ExceptionWrapper(E)
 
 
 def fix_winding(mesh):

--- a/trimesh/resources/javascript/compile.py
+++ b/trimesh/resources/javascript/compile.py
@@ -26,13 +26,12 @@ def minify(path):
     if path.startswith('http'):
         data = requests.get(path).content.decode(
             'ascii', errors='ignore')
-        print('downloaded', path, len(data))
+        print('downloaded', path, len(data))  # noqa
     else:
         with open(path, 'rb') as f:
-            # some of these assholes use unicode spaces -_-
-            data = f.read().decode('ascii',
-                                   errors='ignore')
-    # don't re- minify
+            # some upstream JS uses unicode spaces -_-
+            data = f.read().decode('ascii', errors='ignore')
+    # don't re-minify
     if '.min.' in path:
         return data
 
@@ -43,26 +42,25 @@ def minify(path):
 
 
 if __name__ == '__main__':
-    # we're going to embed every non- CDN'd file
+    # we're going to embed every non-CDN'd file
     h = html.parse('viewer.html')
     collection = []
 
     # find all scripts in the document
     for s in h.findall('//script'):
         if 'src' in s.attrib:
-
             if 'http' in s.attrib['src']:
                 # pass # download CDN files and embed
                 continue  # leave any remote files alone
 
             # get a blob of file
             path = s.attrib['src'].strip()
-            print('minifying:', path)
+            print('minifying:', path)  # noqa
             mini = minify(path)
 
             # replace test data in our file
             if path == 'load_base64.js':
-                print('replacing test data with "$B64GLTF"')
+                print('replacing test data with "$B64GLTF"')  # noqa
                 start = mini.find('base64_data')
                 end = mini.find(';', start)
                 # replace test data with a string we can replace

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -31,7 +31,7 @@ class Scene(Geometry3D):
     def __init__(self,
                  geometry=None,
                  base_frame='world',
-                 metadata={},
+                 metadata=None,
                  graph=None,
                  camera=None,
                  lights=None,
@@ -70,7 +70,8 @@ class Scene(Geometry3D):
 
         # hold metadata about the scene
         self.metadata = {}
-        self.metadata.update(metadata)
+        if isinstance(metadata, dict):
+            self.metadata.update(metadata)
 
         if graph is not None:
             # if we've been passed a graph override the default
@@ -1314,7 +1315,7 @@ def split_scene(geometry, **kwargs):
     return scene
 
 
-def append_scenes(iterable, common=['world'], base_frame='world'):
+def append_scenes(iterable, common=None, base_frame='world'):
     """
     Concatenate multiple scene objects into one scene.
 
@@ -1334,6 +1335,9 @@ def append_scenes(iterable, common=['world'], base_frame='world'):
     """
     if isinstance(iterable, Scene):
         return iterable
+
+    if common is None:
+        common = [base_frame]
 
     # save geometry in dict
     geometry = {}

--- a/trimesh/smoothing.py
+++ b/trimesh/smoothing.py
@@ -259,7 +259,7 @@ def filter_mut_dif_laplacian(mesh,
     return mesh
 
 
-def laplacian_calculation(mesh, equal_weight=True, pinned_vertices=[]):
+def laplacian_calculation(mesh, equal_weight=True, pinned_vertices=None):
     """
     Calculate a sparse matrix for laplacian operations.
     Parameters
@@ -279,8 +279,9 @@ def laplacian_calculation(mesh, equal_weight=True, pinned_vertices=[]):
 
     # if a node is pinned, it will average his coordinates by himself
     # in practice it will not move
-    for i in pinned_vertices:
-        neighbors[i] = [i]
+    if pinned_vertices is not None:
+        for i in pinned_vertices:
+            neighbors[i] = [i]
 
     # avoid hitting crc checks in loops
     vertices = mesh.vertices.view(np.ndarray)

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -2,4 +2,4 @@ __version__ = '3.19.4'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script
-    print(__version__)
+    print(__version__)  # noqa

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.19.4'
+__version__ = '3.19.5'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script

--- a/trimesh/viewer/__init__.py
+++ b/trimesh/viewer/__init__.py
@@ -20,14 +20,14 @@ try:
 except BaseException as E:
     # if windowed failed to import only raise
     # the exception if someone tries to use them
-    SceneViewer = exceptions.closure(E)
-    render_scene = exceptions.closure(E)
+    SceneViewer = exceptions.ExceptionWrapper(E)
+    render_scene = exceptions.ExceptionWrapper(E)
 
 
 try:
     from .widget import SceneWidget
 except BaseException as E:
-    SceneWidget = exceptions.closure(E)
+    SceneWidget = exceptions.ExceptionWrapper(E)
 
 
 # this is only standard library imports

--- a/trimesh/viewer/trackball.py
+++ b/trimesh/viewer/trackball.py
@@ -38,8 +38,7 @@ class Trackball(object):
     STATE_ROLL = 2
     STATE_ZOOM = 3
 
-    def __init__(self, pose, size, scale,
-                 target=np.array([0.0, 0.0, 0.0])):
+    def __init__(self, pose, size, scale, target=None):
         """Initialize a trackball with an initial camera-to-world pose
         and the given parameters.
 
@@ -66,8 +65,12 @@ class Trackball(object):
         self._pose = pose
         self._n_pose = pose
 
-        self._target = target
-        self._n_target = target
+        if target is None:
+            self._target = np.array([0.0, 0.0, 0.0])
+            self._n_target = np.array([0.0, 0.0, 0.0])
+        else:
+            self._target = target
+            self._n_target = target
 
         self._state = Trackball.STATE_ROTATE
 

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -813,7 +813,7 @@ class SceneViewer(pyglet.window.Window):
 
         if self._profile:
             profiler.stop()
-            print(profiler.output_text(unicode=True, color=True))
+            util.log.debug(profiler.output_text(unicode=True, color=True))
 
     def flip(self):
         super(SceneViewer, self).flip()

--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -620,7 +620,7 @@ def empty_material(color=None):
     try:
         from PIL import Image
     except BaseException as E:
-        return exceptions.ExceptionModule(E)
+        return exceptions.ExceptionWrapper(E)
 
     if color is None or np.shape(color) not in ((3,), (4,)):
         color = np.array([255, 255, 255], dtype=np.uint8)

--- a/trimesh/voxel/creation.py
+++ b/trimesh/voxel/creation.py
@@ -174,7 +174,7 @@ def local_voxelize(mesh,
 @log_time
 def voxelize_ray(mesh,
                  pitch,
-                 per_cell=[2, 2]):
+                 per_cell=None):
     """
     Voxelize a mesh using ray queries.
 
@@ -191,8 +191,12 @@ def voxelize_ray(mesh,
     -------------
     VoxelGrid instance representing the voxelized mesh.
     """
-    # how many rays per cell
-    per_cell = np.array(per_cell).astype(np.int64).reshape(2)
+    if per_cell is None:
+        # how many rays per cell
+        per_cell = np.array([2, 2], dtype=np.int64)
+    else:
+        per_cell = np.array(per_cell, dtype=np.int64).reshape(2)
+
     # edge length of cube voxels
     pitch = float(pitch)
 

--- a/trimesh/voxel/encoding.py
+++ b/trimesh/voxel/encoding.py
@@ -10,8 +10,8 @@ from .. import caching
 try:
     from scipy import sparse as sp
 except BaseException as E:
-    from ..exceptions import ExceptionModule
-    sp = ExceptionModule(E)
+    from ..exceptions import ExceptionWrapper
+    sp = ExceptionWrapper(E)
 
 
 def _empty_stripped(shape):

--- a/trimesh/voxel/morphology.py
+++ b/trimesh/voxel/morphology.py
@@ -9,11 +9,11 @@ from .. import util
 
 
 try:
-    from scipy import ndimage as _m
+    from scipy import ndimage
 except BaseException as E:
     # scipy is a soft dependency
-    from ..exceptions import ExceptionModule
-    _m = ExceptionModule(E)
+    from ..exceptions import ExceptionWrapper
+    ndimage = ExceptionWrapper(E)
 
 
 def _dense(encoding, rank=None):
@@ -113,7 +113,7 @@ def fill_holes(encoding, **kwargs):
     A new filled in encoding object.
     """
     return enc.DenseEncoding(
-        _m.binary_fill_holes(_dense(encoding, rank=3), **kwargs))
+        ndimage.binary_fill_holes(_dense(encoding, rank=3), **kwargs))
 
 
 fillers = util.FunctionRegistry(
@@ -153,7 +153,7 @@ def binary_dilation(encoding, **kwargs):
     https://docs.scipy.org/doc/scipy-0.15.1/reference/generated/scipy.ndimage.morphology.binary_dilation.html#scipy.ndimage.morphology.binary_dilation
     """
     return enc.DenseEncoding(
-        _m.binary_dilation(_dense(encoding, rank=3), **kwargs))
+        ndimage.binary_dilation(_dense(encoding, rank=3), **kwargs))
 
 
 def binary_closing(encoding, **kwargs):
@@ -163,7 +163,7 @@ def binary_closing(encoding, **kwargs):
     https://docs.scipy.org/doc/scipy-0.15.1/reference/generated/scipy.ndimage.morphology.binary_closing.html#scipy.ndimage.morphology.binary_closing
     """
     return enc.DenseEncoding(
-        _m.binary_closing(_dense(encoding, rank=3), **kwargs))
+        ndimage.binary_closing(_dense(encoding, rank=3), **kwargs))
 
 
 def surface(encoding, structure=None):
@@ -186,6 +186,6 @@ def surface(encoding, structure=None):
     # padding/unpadding resolves issues with occupied voxels on the boundary
     dense = np.pad(dense, np.ones((3, 2), dtype=int), mode='constant')
     empty = np.logical_not(dense)
-    dilated = _m.binary_dilation(empty, structure=structure)
+    dilated = ndimage.binary_dilation(empty, structure=structure)
     surface = np.logical_and(dense, dilated)[1:-1, 1:-1, 1:-1]
     return enc.DenseEncoding(surface)

--- a/trimesh/voxel/runlength.py
+++ b/trimesh/voxel/runlength.py
@@ -387,10 +387,10 @@ def sorted_rle_gather_1d(rle_data, ordered_indices):
             try:
                 value = next(data_iter)
                 start += next(data_iter)
-            except StopIteration:
+            except StopIteration as E:
                 raise IndexError(
                     'Index %d out of range of raw_values length %d'
-                    % (index, start))
+                    % (index, start)) from E
         try:
             while index < start:
                 yield value
@@ -530,10 +530,10 @@ def sorted_brle_gather_1d(brle_data, ordered_indices):
             try:
                 value = not value
                 start += next(data_iter)
-            except StopIteration:
+            except StopIteration as E:
                 raise IndexError(
                     'Index %d out of range of raw_values length %d'
-                    % (index, start))
+                    % (index, start)) from E
         try:
             while index < start:
                 yield value
@@ -654,18 +654,19 @@ def rle_strip(rle_data):
     """
     rle_data = np.reshape(rle_data, (-1, 2))
     start = 0
-    for i, (val, count) in enumerate(rle_data):
+    for val, count in rle_data:
         if val and count > 0:
             break
         else:
             start += count
-
     end = 0
-    for j, (val, count) in enumerate(rle_data[::-1]):
+    for val, count in rle_data[::-1]:
         if val and count > 0:
             break
         else:
             end += count
+
+    i, j = len(rle_data), len(rle_data[::-1])
     rle_data = rle_data[i:None if j == 0 else -j].reshape((-1,))
     return rle_data, (start, end)
 
@@ -686,7 +687,7 @@ def brle_strip(brle_data):
     """
     start = 0
     val = True
-    for i, count in enumerate(brle_data):
+    for count in brle_data:
         val = not val
         if val and count > 0:
             break
@@ -694,12 +695,13 @@ def brle_strip(brle_data):
             start += count
     end = 0
     val = bool(len(brle_data) % 2)
-    for j, count in enumerate(brle_data[::-1]):
+    for count in brle_data[::-1]:
         val = not val
         if val and count > 0:
             break
         else:
             end += count
+    i, j = len(brle_data), len(brle_data[::-1])
     brle_data = brle_data[i:None if j == 0 else -j]
     brle_data = np.concatenate([[0], brle_data])
     return brle_data, (start, end)


### PR DESCRIPTION
- unify `exceptions.ExceptionModule` and `exceptions.closure` into `ExceptionWrapper` by adding a `__call__` method.
- change fail-on-import loaders to an `ExceptionWrapper` so that a useful error message is raised when you try to load (fix #1838)
- enable the `ruff` bugbear rule
- enable the `ruff` no-print-statement rule
- add a speedup for oriented bounding boxes