### PR TITLE
Removes g tag from the list of faces when loading an obj

### DIFF
--- a/models/face_in_group_name.obj
+++ b/models/face_in_group_name.obj
@@ -1,0 +1,2 @@
+g An f Three Other Things
+v 388.018188 778.077576 347.121552

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -423,6 +423,13 @@ class OBJTest(g.unittest.TestCase):
         assert len(t.geometry.keys()) == len(c.geometry.keys())
         assert g.np.isclose(t.area, c.area)
 
+    def test_face_parsing_in_group_names(self):
+        # Checks that an obj with a g tag containinig a face like name (an 'f '
+        # followed by three space separated text chunks, ex: f 1 2 3) does load
+        # properly
+        m = g.get_mesh('face_in_group_name.obj')
+        assert len(m.vertices) == 1
+
 
 def simple_load(text):
     # we're going to load faces in a basic text way

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -748,6 +748,9 @@ def _preprocess_faces(text):
         elif chunk.startswith('usemtl'):
             current_mtl, chunk = chunk.split('\n', 1)
             current_mtl = current_mtl[6:].strip()
+        # Discard the g tag line in the list of faces
+        elif chunk.startswith('g '):
+            _, chunk = chunk.split('\n', 1)
         if 'f ' in chunk:
             face_tuples.append((current_mtl, current_obj, chunk))
     return face_tuples


### PR DESCRIPTION
Fixes the issue https://github.com/mikedh/trimesh/issues/1829 where loading an obj could fail if a 'g ' tag contains a face like name.