### PR TITLE
Ensure that packed UV output order matches original order for multiple materials with duplicates.

### DIFF
--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -737,6 +737,6 @@ def pack(materials, uvs, deduplicate=True):
         [new_uv.append(transform_uvs(uvs[i], scale, xy_off)) for i in idxs]
 
     # stack UV coordinates into single (n, 2) array
-    stacked = np.vstack(new_uv)
+    stacked = np.vstack([new_uv[n] for n in np.argsort([x for i in mat_idx for x in i])])
 
     return SimpleMaterial(image=final), stacked


### PR DESCRIPTION
This is intended to fix a specific corner case I ran into where the returned array of UVs of a mesh using multiple textures (of which two or more are identical) does not match the order of the original array of UVs after the deduplication of the textures is applied in this pack function.  As a result of this issue, downstream processes end up with a scrambled texture applied.  I am relatively new both to Python and to the Trimesh library, so I apologize if my proposed solution introduces new complications.