### PR TITLE
Release: Test Determinism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![trimesh](https://trimsh.org/images/logotype-a.svg)](http://trimsh.org)
 
 -----------
-[![Github Actions](https://github.com/mikedh/trimesh/workflows/Release%20Trimesh/badge.svg)](https://github.com/mikedh/trimesh/actions)  [![PyPI version](https://badge.fury.io/py/trimesh.svg)](https://badge.fury.io/py/trimesh) [![codecov](https://codecov.io/gh/mikedh/trimesh/branch/main/graph/badge.svg?token=4PVRQXyl2h)](https://codecov.io/gh/mikedh/trimesh)
+[![Github Actions](https://github.com/mikedh/trimesh/workflows/Release%20Trimesh/badge.svg)](https://github.com/mikedh/trimesh/actions)  [![PyPI version](https://badge.fury.io/py/trimesh.svg)](https://badge.fury.io/py/trimesh) [![codecov](https://codecov.io/gh/mikedh/trimesh/branch/main/graph/badge.svg?token=4PVRQXyl2h)](https://codecov.io/gh/mikedh/trimesh)  [![Docker Image Version (latest by date)](https://img.shields.io/docker/v/trimesh/trimesh?label=docker)](https://hub.docker.com/repository/docker/trimesh/trimesh/)
 
 
 Trimesh is a pure Python (2.7-3.5+) library for loading and using [triangular meshes](https://en.wikipedia.org/wiki/Triangle_mesh) with an emphasis on watertight surfaces. The goal of the library is to provide a full featured and well tested Trimesh object which allows for easy manipulation and analysis, in the style of the Polygon object in the [Shapely library](https://github.com/Toblerity/Shapely).

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -172,9 +172,11 @@ io_wrap = trimesh.util.wrap_as_stream
 
 def random(*args, **kwargs):
     """
-    A random function always seeded from the same value.
+    A random function always seeded from the same value so tests
+    can use random data but they execute mostly deterministically
+    in a large test matrix.
 
-    Replaces: np.random.random(*args, **kwargs)
+    Drop-in replacement for `np.random.random(*args, **kwargs)`
     """
     state = np.random.RandomState(seed=1)
     return state.random_sample(*args, **kwargs)
@@ -184,6 +186,18 @@ def random_transforms(count, translate=1000):
     """
     Deterministic generation of random transforms so unit
     tests have limited levels of flake.
+
+    Parameters
+    -------------
+    count : int
+      Number of repeatable but random-ish transforms to generate
+    translate : float
+      The scale of translation to apply.
+
+    Yields
+    ------------
+    transform : (4, 4) float
+      Homogenous transformation matrix
     """
     quaternion = random((count, 3))
     translate = (random((count, 3)) - 0.5) * float(translate)
@@ -193,10 +207,12 @@ def random_transforms(count, translate=1000):
         matrix[:3, 3] = trans
         yield matrix
 
+
 # random should be deterministic
 assert np.allclose(random(10), random(10))
 assert np.allclose(list(random_transforms(10)),
                    list(random_transforms(10)))
+
 
 def _load_data():
     """

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -180,6 +180,24 @@ def random(*args, **kwargs):
     return state.random_sample(*args, **kwargs)
 
 
+def random_transforms(count, translate=1000):
+    """
+    Deterministic generation of random transforms so unit
+    tests have limited levels of flake.
+    """
+    quaternion = random((count, 3))
+    translate = (random((count, 3)) - 0.5) * float(translate)
+
+    for quat, trans in zip(quaternion, translate):
+        matrix = tf.random_rotation_matrix(rand=quat)
+        matrix[:3, 3] = trans
+        yield matrix
+
+# random should be deterministic
+assert np.allclose(random(10), random(10))
+assert np.allclose(list(random_transforms(10)),
+                   list(random_transforms(10)))
+
 def _load_data():
     """
     Load the JSON files from our truth directory.

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -20,8 +20,8 @@ class AlignTests(g.unittest.TestCase):
         # start with some edge cases and make sure the transform works
         target = g.np.array([0, 0, -1], dtype=g.np.float64)
         vectors = g.np.vstack((
-            g.trimesh.unitize(g.np.random.random((1000, 3)) - .5),
-            g.np.random.random((1000, 3)) - .5,
+            g.trimesh.unitize(g.random((1000, 3)) - .5),
+            g.random((1000, 3)) - .5,
             [-target, target],
             g.trimesh.util.generate_basis(target),
             [[7.12106798e-07, -7.43194705e-08, 1.00000000e+00],

--- a/tests/test_arc.py
+++ b/tests/test_arc.py
@@ -34,11 +34,11 @@ class ArcTests(g.unittest.TestCase):
         min_angle = g.np.radians(2)
         count = 1000
 
-        center_3D = (g.np.random.random((count, 3)) - .5) * 50
+        center_3D = (g.random((count, 3)) - .5) * 50
         center_2D = center_3D[:, 0:2]
-        radii = g.np.clip(g.np.random.random(count) * 100, min_angle, g.np.inf)
+        radii = g.np.clip(g.random(count) * 100, min_angle, g.np.inf)
 
-        angles = g.np.random.random((count, 2)) * \
+        angles = g.random((count, 2)) * \
             (g.np.pi - min_angle) + min_angle
         angles = g.np.column_stack((g.np.zeros(count),
                                     g.np.cumsum(angles, axis=1)))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -35,7 +35,7 @@ class MeshTests(g.unittest.TestCase):
         assert g.np.isclose(m.volume, pre_vol)
 
         # add some unreferenced vertices
-        m.vertices = g.np.vstack((m.vertices, g.np.random.random((100, 3))))
+        m.vertices = g.np.vstack((m.vertices, g.random((100, 3))))
         assert len(m.vertices) == pre_len + 100
         assert g.np.isclose(m.volume, pre_vol)
 

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -69,7 +69,7 @@ class BoundsTest(g.unittest.TestCase):
         """
         for dimension in [3, 2]:
             for i in range(25):
-                points = g.np.random.random((10, dimension))
+                points = g.random((10, dimension))
                 to_origin, extents = g.trimesh.bounds.oriented_bounds(points)
 
                 assert g.trimesh.util.is_shape(to_origin,
@@ -93,7 +93,7 @@ class BoundsTest(g.unittest.TestCase):
     def test_2D(self):
         for theta in g.np.linspace(0, g.np.pi * 2, 2000):
             # create some random rectangular-ish 2D points
-            points = g.np.random.random((10, 2)) * [5, 1]
+            points = g.random((10, 2)) * [5, 1]
 
             # save the basic AABB of the points before rotation
             rectangle_pre = points.ptp(axis=0)
@@ -207,7 +207,7 @@ class BoundsTest(g.unittest.TestCase):
             # transform box randomly in rotation and translation
             mat = g.trimesh.transformations.random_rotation_matrix()
             # translate in box -100 : +100
-            mat[:3, 3] = (g.np.random.random(3) - .5) * 200
+            mat[:3, 3] = (g.random(3) - .5) * 200
 
             # source mesh to check
             b = g.trimesh.creation.box(extents=extents,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -26,7 +26,7 @@ class CacheTest(g.unittest.TestCase):
 
             # generate test data and perform numpy operations
             a = g.trimesh.caching.tracked_array(
-                g.np.random.random(TEST_DIM))
+                g.random(TEST_DIM))
             modified = [hash(a)]
             a[0][0] = 10
             modified.append(hash(a))
@@ -95,7 +95,7 @@ class CacheTest(g.unittest.TestCase):
         g.trimesh.caching.hash_fast = original
 
     def test_contiguous(self):
-        a = g.np.random.random((100, 3))
+        a = g.random((100, 3))
         t = g.trimesh.caching.tracked_array(a)
 
         original = g.trimesh.caching.hash_fast
@@ -120,7 +120,7 @@ class CacheTest(g.unittest.TestCase):
         """
         d = g.trimesh.caching.DataStore()
 
-        d['hi'] = g.np.random.random(100)
+        d['hi'] = g.random(100)
         hash_initial = hash(d)
         # mutate internal data
         d['hi'][0] += 1

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -93,31 +93,31 @@ class VisualTest(g.unittest.TestCase):
         m.visual.vertex_colors[1] = test_color_transparent
         assert m.visual.transparency
 
-        test = (g.np.random.random((len(m.faces), 4)) * 255).astype(g.np.uint8)
+        test = (g.random((len(m.faces), 4)) * 255).astype(g.np.uint8)
         m.visual.face_colors = test
         assert bool((m.visual.face_colors == test).all())
         assert m.visual.kind == 'face'
 
-        test = (g.np.random.random((len(m.vertices), 4))
+        test = (g.random((len(m.vertices), 4))
                 * 255).astype(g.np.uint8)
         m.visual.vertex_colors = test
         assert bool((m.visual.vertex_colors == test).all())
         assert m.visual.kind == 'vertex'
 
-        test = (g.np.random.random(4) * 255).astype(g.np.uint8)
+        test = (g.random(4) * 255).astype(g.np.uint8)
         m.visual.face_colors = test
         assert bool((m.visual.vertex_colors == test).all())
         assert m.visual.kind == 'face'
         m.visual.vertex_colors[0] = (
-            g.np.random.random(4) * 255).astype(g.np.uint8)
+            g.random(4) * 255).astype(g.np.uint8)
         assert m.visual.kind == 'vertex'
 
-        test = (g.np.random.random(4) * 255).astype(g.np.uint8)
+        test = (g.random(4) * 255).astype(g.np.uint8)
         m.visual.vertex_colors = test
         assert bool((m.visual.face_colors == test).all())
         assert m.visual.kind == 'vertex'
         m.visual.face_colors[0] = (
-            g.np.random.random(4) * 255).astype(g.np.uint8)
+            g.random(4) * 255).astype(g.np.uint8)
         assert m.visual.kind == 'face'
 
     def test_smooth(self):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -264,7 +264,7 @@ class ExportTest(g.unittest.TestCase):
         RET_COUNT = 5
 
         # a path that doesn't exist
-        nonexists = '/banana{}'.format(g.np.random.random())
+        nonexists = '/banana{}'.format(g.random())
         assert not g.os.path.exists(nonexists)
 
         # loadable OBJ model

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -12,8 +12,8 @@ class GeomTests(g.unittest.TestCase):
     def test_triangulate(self):
         from trimesh.geometry import triangulate_quads as tq
         # create some triangles and quads
-        tri = (g.np.random.random((100, 3)) * 100).astype(g.np.int64)
-        quad = (g.np.random.random((100, 4)) * 100).astype(g.np.int64)
+        tri = (g.random((100, 3)) * 100).astype(g.np.int64)
+        quad = (g.random((100, 4)) * 100).astype(g.np.int64)
 
         # should just exit early for triangles
         assert g.np.allclose(tri, tq(tri.tolist()))

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -695,7 +695,7 @@ class GLTFTest(g.unittest.TestCase):
         # test concatenation with texture
         m = g.get_mesh('fuze.obj')
 
-        colors = (g.np.random.random(
+        colors = (g.random(
             (len(m.vertices), 4)) * 255).astype(g.np.uint8)
 
         # set the color vertex attribute

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -195,7 +195,7 @@ class GroupTests(g.unittest.TestCase):
     def test_cluster(self):
         # create some random points stacked with some zeros to cluster
         points = g.np.vstack(((
-            g.np.random.random((10000, 3)) * 5).astype(g.np.int64),
+            g.random((10000, 3)) * 5).astype(g.np.int64),
             g.np.zeros((100, 3))))
         # should be at least one cluster
         assert len(g.trimesh.grouping.clusters(points, .01)) > 0
@@ -304,7 +304,7 @@ class GroupTests(g.unittest.TestCase):
 
     def test_unique_ordered_rows(self):
         # check the ordering of unique_rows
-        v = g.np.random.random((100000, 3))
+        v = g.random((100000, 3))
         v = g.np.vstack((v, v, v, v))
 
         # index, inverse

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -7,7 +7,6 @@ except BaseException:
 class IdentifierTest(g.unittest.TestCase):
 
     def test_identifier(self, count=25):
-
         meshes = g.np.append(list(g.get_meshes(
             only_watertight=True, split=True, min_volume=0.001)),
             g.get_mesh('fixed_top.ply'))
@@ -20,8 +19,8 @@ class IdentifierTest(g.unittest.TestCase):
             g.log.info('Trying hash at %d random transforms', count)
             hashed = []
             identifier = []
-            for _ in range(count):
-                permutated = mesh.permutate.transform()
+            for transform in g.random_transforms(count):
+                permutated = mesh.copy().apply_transform(transform)
                 hashed.append(permutated.identifier_hash)
                 identifier.append(permutated.identifier)
 
@@ -37,10 +36,13 @@ class IdentifierTest(g.unittest.TestCase):
                             str(g.np.array(debug, dtype=g.np.int64)))
                 raise ValueError('values differ after transform!')
 
-            if hashed[-1] == permutated.permutate.noise(
-                    mesh.scale / 100.0).identifier_hash:
-                raise ValueError('Hashes on %s didn\'t change after noise!',
-                                 mesh.metadata['file_name'])
+            # stretch the mesh by a small amount
+            stretched = mesh.copy().apply_scale(
+                [0.99974507, 0.9995662, 1.0029832])
+            if hashed[-1] == stretched.identifier_hash:
+                raise ValueError(
+                    'Hashes on %s didn\'t change after stretching',
+                    mesh.metadata['file_name'])
 
     def test_scene_id(self):
         """

--- a/tests/test_inertia.py
+++ b/tests/test_inertia.py
@@ -112,7 +112,7 @@ class InertiaTest(g.unittest.TestCase):
                     matrix = g.trimesh.transformations.random_rotation_matrix()
                     p.primitive.transform = matrix
                 elif hasattr(p.primitive, 'center'):
-                    p.primitive.center = g.np.random.random(3)
+                    p.primitive.center = g.random(3)
 
     def test_tetrahedron(self):
         # Based on the 'numerical example' of the paper:

--- a/tests/test_integralmeancurvature.py
+++ b/tests/test_integralmeancurvature.py
@@ -32,7 +32,7 @@ class IntegralMeanCurvatureTest(g.unittest.TestCase):
         # how close do we need to be - relative tolerance
         tol = 1e-3
         n_tests = 4
-        extents = 1 - g.np.random.random((n_tests, 3))
+        extents = 1 - g.random((n_tests, 3))
         for extent in extents:
             m = g.trimesh.creation.box(extents=extent)
             IMC = m.integral_mean_curvature

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -19,7 +19,7 @@ class MargeTest(g.unittest.TestCase):
 
         # stack a bunch of unreferenced vertices
         m.vertices = g.np.vstack((
-            m.vertices, g.np.random.random((10000, 3))))
+            m.vertices, g.random((10000, 3))))
         assert m.euler_number == 2
         assert m.vertices.shape == (10008, 3)
         assert m.referenced_vertices.sum() == 8

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -143,21 +143,21 @@ class MutateTests(g.unittest.TestCase):
 
         # ray.intersects_id
         centre = mesh.vertices.mean(axis=0)
-        origins = g.np.random.random((100, 3)) * 1000
+        origins = g.random((100, 3)) * 1000
         directions = g.np.copy(origins)
         directions[:50, :] -= centre
         directions[50:, :] += centre
         mesh.ray.intersects_id(origins, directions)
 
         # nearest.vertex
-        points = g.np.random.random((500, 3)) * 100
+        points = g.random((500, 3)) * 100
         mesh.nearest.vertex(points)
 
         # section
         section_count = 20
-        origins = g.np.random.random((section_count, 3)) * 100
-        normals = g.np.random.random((section_count, 3)) * 100
-        heights = g.np.random.random((10,)) * 100
+        origins = g.random((section_count, 3)) * 100
+        normals = g.random((section_count, 3)) * 100
+        heights = g.random((10,)) * 100
         for o, n in zip(origins, normals):
             # try slicing at random origin and at center mass
             mesh.slice_plane(o, n)

--- a/tests/test_nsphere.py
+++ b/tests/test_nsphere.py
@@ -27,7 +27,7 @@ class NSphereTest(g.unittest.TestCase):
         # check minimum n-sphere for points in 2, 3, 4 dimensions
         for d in [2, 3, 4]:
             for i in range(5):
-                points = g.np.random.random((100, d))
+                points = g.random((100, d))
                 C, R = g.trimesh.nsphere.minimum_nsphere(points)
                 R_check = ((points - C)**2).sum(axis=1).max() ** .5
                 assert len(C) == d
@@ -38,7 +38,7 @@ class NSphereTest(g.unittest.TestCase):
         # make sure created spheres are uv sphere
         m = g.trimesh.creation.uv_sphere()
         # move the mesh around for funsies
-        m.apply_translation(g.np.random.random(3))
+        m.apply_translation(g.random(3))
         m.apply_transform(
             g.trimesh.transformations.random_rotation_matrix())
         # all vertices should be on nsphere

--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -179,8 +179,8 @@ class PackingTest(g.unittest.TestCase):
                 extents = []
                 for i in ori:
                     extents.append(
-                        g.np.roll(i, int(g.np.random.random() * 10)) +
-                        g.np.random.random(3))
+                        g.np.roll(i, int(g.random() * 10)) +
+                        g.random(3))
                 extents = g.np.array(extents)
 
                 bounds, consume = packing.rectangles(extents)
@@ -242,7 +242,7 @@ class PackingTest(g.unittest.TestCase):
         from trimesh.path import packing
         # create some random rotation boxes
         meshes = [g.trimesh.creation.box(
-            extents=g.np.random.random(3),
+            extents=g.random(3),
             transform=g.tf.random_rotation_matrix())
             for _ in range(20)]
         packed, transforms, consume = packing.meshes(

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -12,7 +12,7 @@ class PointsTest(g.unittest.TestCase):
         """
         shape = (100, 3)
         # random points
-        points = g.np.random.random(shape)
+        points = g.random(shape)
         # make sure randomness never gives duplicates by offsetting
         points += g.np.arange(shape[0]).reshape((-1, 1))
 
@@ -35,7 +35,7 @@ class PointsTest(g.unittest.TestCase):
         assert hash(cloud) == initial_hash
 
         # set some random colors
-        cloud.colors = g.np.random.random((shape[0], 4))
+        cloud.colors = g.random((shape[0], 4))
         # remove the duplicates we created
         cloud.merge_vertices()
 
@@ -80,8 +80,8 @@ class PointsTest(g.unittest.TestCase):
         vertices and no faces for some unknowable reason
         """
 
-        v = g.np.random.random((1000, 3))
-        v[g.np.floor(g.np.random.random(90) * len(v)).astype(int)] = v[0]
+        v = g.random((1000, 3))
+        v[g.np.floor(g.random(90) * len(v)).astype(int)] = v[0]
 
         mesh = g.trimesh.Trimesh(v)
 
@@ -94,7 +94,7 @@ class PointsTest(g.unittest.TestCase):
             # create a random rotation
             matrix = g.trimesh.transformations.random_rotation_matrix()
             # create some random points in spacd
-            p = g.np.random.random((1000, 3))
+            p = g.random((1000, 3))
             # make them all lie on the XY plane so we know
             # the correct normal to check against
             p[:, 2] = 0
@@ -116,7 +116,7 @@ class PointsTest(g.unittest.TestCase):
             matrices = [g.trimesh.transformations.random_rotation_matrix()
                         for _ in range(nb_points_sets)]
             # create some random points in spacd
-            p = g.np.random.random((nb_points_sets, 1000, 3))
+            p = g.random((nb_points_sets, 1000, 3))
             # make them all lie on the XY plane so we know
             # the correct normal to check against
             p[..., 2] = 0
@@ -171,7 +171,7 @@ class PointsTest(g.unittest.TestCase):
         for dimension in [2, 3]:
             for count in [2, 10, 100]:
                 for i in range(10):
-                    points = g.np.random.random((count, dimension))
+                    points = g.random((count, dimension))
 
                     # find a path that visits every point quickly
                     idx, dist = g.trimesh.points.tsp(points, start=0)
@@ -225,7 +225,7 @@ class PointsTest(g.unittest.TestCase):
         # initial color CRC
         initial = hash(p.visual)
         # set to random colors
-        p.colors = g.np.random.random(
+        p.colors = g.random(
             (len(p.vertices), 4))
         # visual CRC should have changed
         assert hash(p.visual) != initial
@@ -255,8 +255,8 @@ class PointsTest(g.unittest.TestCase):
         assert mask.shape == (200,)
 
     def test_add_operator(self):
-        points_1 = g.np.random.random((10, 3))
-        points_2 = g.np.random.random((20, 3))
+        points_1 = g.random((10, 3))
+        points_2 = g.random((20, 3))
         colors_1 = [[123, 123, 123, 255]] * len(points_1)
         colors_2 = [[255, 0, 123, 255]] * len(points_2)
 

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -90,7 +90,7 @@ class PolygonTests(g.unittest.TestCase):
         m = g.trimesh.creation.icosphere(subdivisions=4)
 
         p = [g.trimesh.path.polygons.projected(m, normal=n)
-             for n in g.np.random.random((100, 3))]
+             for n in g.random((100, 3))]
 
         # sphere projection should never have interiors
         assert all(len(i.interiors) == 0 for i in p)

--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -36,7 +36,7 @@ class NearestTest(g.unittest.TestCase):
     def test_helper(self):
         # just make sure the plumbing returns something
         for mesh in g.get_meshes(2):
-            points = (g.np.random.random((100, 3)) - .5) * 100
+            points = (g.random((100, 3)) - .5) * 100
 
             a = mesh.nearest.on_surface(points)
             assert a is not None
@@ -210,7 +210,7 @@ class NearestTest(g.unittest.TestCase):
 
     def test_candidates(self):
         mesh = g.trimesh.creation.random_soup(2000)
-        points = g.np.random.random((2000, 3))
+        points = g.random((2000, 3))
         g.trimesh.proximity.nearby_faces(
             mesh=mesh, points=points)
 

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -33,7 +33,7 @@ class RayTests(g.unittest.TestCase):
             sphere = g.get_mesh('unit_sphere.STL',
                                 use_embree=use_embree)
 
-            ray_origins = g.np.random.random(dimension)
+            ray_origins = g.random(dimension)
             ray_directions = g.np.tile([0, 0, 1], (dimension[0], 1))
             ray_origins[:, 2] = -5
 
@@ -66,7 +66,7 @@ class RayTests(g.unittest.TestCase):
             sphere = g.get_mesh('unit_sphere.STL',
                                 use_embree=use_embree)
             # should never hit the sphere
-            ray_origins = g.np.random.random(dimension)
+            ray_origins = g.random(dimension)
             ray_directions = g.np.tile([0, 1, 0], (dimension[0], 1))
             ray_origins[:, 2] = -5
 
@@ -94,7 +94,7 @@ class RayTests(g.unittest.TestCase):
             assert not test_out.any()
 
             points_way_out = (
-                g.np.random.random(
+                g.random(
                     (30, 3)) * 100) + 1.0 + mesh.bounds[1]
             test_way_out = mesh.ray.contains_points(points_way_out)
             assert not test_way_out.any()

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -13,11 +13,11 @@ class RegistrationTest(g.unittest.TestCase):
         opt = g.itertools.combinations([True, False] * 6, 6)
         for reflection, translation, scale, a_flip, a_scale, weight in opt:
             # create random points in space
-            points_a = (g.np.random.random((1000, 3)) - .5) * 1000
+            points_a = (g.random((1000, 3)) - .5) * 1000
             # create a random transform
             matrix = g.trimesh.transformations.random_rotation_matrix()
             # add a translation component to transform
-            matrix[:3, 3] = g.np.random.random(3) * 100
+            matrix[:3, 3] = g.random(3) * 100
             # apply a flip (reflection) to test data
             if a_flip:
                 matrix = g.np.dot(
@@ -34,7 +34,7 @@ class RegistrationTest(g.unittest.TestCase):
 
             # weight points or not
             if weight:
-                weights = (g.np.random.random(len(points_a)) + 9) / 10
+                weights = (g.random(len(points_a)) + 9) / 10
             else:
                 weights = None
 
@@ -114,7 +114,7 @@ class RegistrationTest(g.unittest.TestCase):
     def test_icp_points(self):
         # see if ICP alignment works with point clouds
         # create random points in space
-        points_a = (g.np.random.random((1000, 3)) - .5) * 1000
+        points_a = (g.random((1000, 3)) - .5) * 1000
         # create a random transform
         # matrix = g.trimesh.transformations.random_rotation_matrix()
         # create a small transform
@@ -150,7 +150,7 @@ class RegistrationTest(g.unittest.TestCase):
         mesh = mesh.permutate.noise(noise)
         # randomly rotation with translation
         transform = g.trimesh.transformations.random_rotation_matrix()
-        transform[:3, 3] = (g.np.random.random(3) - .5) * 1000
+        transform[:3, 3] = (g.random(3) - .5) * 1000
 
         mesh.apply_transform(transform)
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -50,13 +50,13 @@ class RenderTest(g.unittest.TestCase):
         assert len(args) == 6
         assert len(args_auto) == len(args)
 
-        P22 = g.np.random.random((100, 2))
+        P22 = g.random((100, 2))
         args = rendering.points_to_vertexlist(P22)
         args_auto = rendering.convert_to_vertexlist(P22)
         assert len(args) == 6
         assert len(args_auto) == len(args)
 
-        P31 = g.np.random.random((100, 3))
+        P31 = g.random((100, 3))
         args = rendering.points_to_vertexlist(P31)
         args_auto = rendering.convert_to_vertexlist(P31)
         assert len(args) == 6

--- a/tests/test_scenegraph.py
+++ b/tests/test_scenegraph.py
@@ -7,7 +7,7 @@ from trimesh.scene.transforms import EnforcedForest
 
 
 def random_chr():
-    return chr(ord('a') + int(round(g.np.random.random() * 25)))
+    return chr(ord('a') + int(round(g.random() * 25)))
 
 
 class GraphTests(g.unittest.TestCase):
@@ -82,7 +82,7 @@ class GraphTests(g.unittest.TestCase):
         assert g.np.allclose(f(), g.np.eye(4))
 
         # a passed matrix should return immediately
-        fix = g.np.random.random((4, 4))
+        fix = g.random((4, 4))
         assert g.np.allclose(f(matrix=fix), fix)
 
         quat = g.trimesh.unitize([1, 2, 3, 1])
@@ -205,13 +205,13 @@ class GraphTests(g.unittest.TestCase):
             n=1000, seed=0, create_using=g.nx.DiGraph)
         for e in tree.edges:
             data = {}
-            if g.np.random.random() > .5:
+            if g.random() > .5:
                 # if a matrix is omitted but an edge exists it is
                 # the same as passing an identity matrix
                 data['matrix'] = tf.random_rotation_matrix()
-            if g.np.random.random() > .4:
+            if g.random() > .4:
                 # a geometry is not required for a node
-                data['geometry'] = str(int(g.np.random.random() * 1e8))
+                data['geometry'] = str(int(g.random() * 1e8))
             edgelist[e] = data
 
         # now apply the random data to an EnforcedForest

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -136,11 +136,11 @@ class PlaneLine(g.unittest.TestCase):
         z = g.np.linspace(-1, 1, count)
 
         plane_origins = g.np.column_stack((
-            g.np.random.random((count, 2)), z))
+            g.random((count, 2)), z))
         plane_normals = g.np.tile([0, 0, -1], (count, 1))
 
         line_origins = g.np.tile([0, 0, 0], (count, 1))
-        line_directions = g.np.random.random((count, 3))
+        line_directions = g.random((count, 3))
 
         i, valid = g.trimesh.intersections.planes_lines(
             plane_origins=plane_origins,

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -12,7 +12,7 @@ class SegmentsTest(g.unittest.TestCase):
         # check 2D and 3D
         for dimension in [2, 3]:
             # a bunch of random line segments
-            s = g.np.random.random((100, 2, dimension))
+            s = g.random((100, 2, dimension))
             # convert segment to point on line closest to origin
             # as well as a vector and two distances along vector
             param = segments.segments_to_parameters(s)

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -36,7 +36,7 @@ class STLTests(g.unittest.TestCase):
 
         len_vertices = len(m.vertices)
         # assign some random vertex attributes
-        random = g.np.random.random(len(m.vertices))
+        random = g.random(len(m.vertices))
         m.vertex_attributes['random'] = random
         m.vertex_attributes['nah'] = 20
 

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -65,11 +65,11 @@ class TransformTest(g.unittest.TestCase):
 
     def test_around(self):
         # check transform_around on 2D points
-        points = g.np.random.random((100, 2))
+        points = g.random((100, 2))
         for i, p in enumerate(points):
-            offset = g.np.random.random(2)
+            offset = g.random(2)
             matrix = g.trimesh.transformations.planar_matrix(
-                theta=g.np.random.random() + .1,
+                theta=g.random() + .1,
                 offset=offset,
                 point=p)
 
@@ -82,7 +82,7 @@ class TransformTest(g.unittest.TestCase):
             assert compare.all(axis=1).sum() == 1
 
         # check transform_around on 3D points
-        points = g.np.random.random((100, 3))
+        points = g.random((100, 3))
         for i, p in enumerate(points):
             matrix = g.trimesh.transformations.random_rotation_matrix()
             matrix = g.trimesh.transformations.transform_around(matrix, p)
@@ -106,9 +106,9 @@ class TransformTest(g.unittest.TestCase):
                                       [0, 0, 0, 1]),
                              [1, -1, 0, 1])
 
-        angle = (g.np.random.random() - 0.5) * (2 * g.np.pi)
-        direc = g.np.random.random(3) - 0.5
-        point = g.np.random.random(3) - 0.5
+        angle = (g.random() - 0.5) * (2 * g.np.pi)
+        direc = g.random(3) - 0.5
+        point = g.random(3) - 0.5
         R0 = rotation_matrix(angle, direc, point)
         R1 = rotation_matrix(angle - 2 * g.np.pi, direc, point)
         assert g.trimesh.transformations.is_same_transform(R0, R1)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -48,7 +48,7 @@ class UtilTests(unittest.TestCase):
     def test_bounds_tree(self):
         for attempt in range(3):
             for dimension in [2, 3]:
-                t = g.np.random.random((1000, 3, dimension))
+                t = g.random((1000, 3, dimension))
                 bounds = g.np.column_stack((t.min(axis=1), t.max(axis=1)))
                 tree = g.trimesh.util.bounds_tree(bounds)
                 self.assertTrue(0 in tree.intersection(bounds[0]))
@@ -57,7 +57,7 @@ class UtilTests(unittest.TestCase):
         # shortcut to the function
         f = g.trimesh.util.stack_3D
         # start with some random points
-        p = g.np.random.random((100, 2))
+        p = g.random((100, 2))
         stack = f(p)
         # shape should be 3D
         assert stack.shape == (100, 3)
@@ -234,7 +234,7 @@ class IOWrapTests(unittest.TestCase):
         util = g.trimesh.util
 
         # check wrap_as_stream
-        test_b = g.np.random.random(1).tobytes()
+        test_b = g.random(1).tobytes()
         test_s = 'this is a test yo'
         res_b = util.wrap_as_stream(test_b).read()
         res_s = util.wrap_as_stream(test_s).read()

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -11,7 +11,7 @@ class SphericalTests(g.unittest.TestCase):
         Convert vectors to spherical coordinates
         """
         # random unit vectors
-        v = g.trimesh.unitize(g.np.random.random((1000, 3)) - .5)
+        v = g.trimesh.unitize(g.random((1000, 3)) - .5)
         # (n, 2) angles in radians
         spherical = g.trimesh.util.vector_to_spherical(v)
         # back to unit vectors
@@ -26,7 +26,7 @@ class HemisphereTests(g.unittest.TestCase):
         for dimension in [2, 3]:
             # random unit vectors
             v = g.trimesh.unitize(
-                g.np.random.random((10000, dimension)) - .5)
+                g.random((10000, dimension)) - .5)
 
             # add some on- axis points
             v[:dimension] = g.np.eye(dimension)

--- a/trimesh/comparison.py
+++ b/trimesh/comparison.py
@@ -15,7 +15,7 @@ from .constants import tol
 # how many significant figures to use for each
 # field of the identifier based on hand-tuning
 id_sigfig = np.array(
-    [4,  # area
+    [4,   # area
      10,  # euler number
      5,  # area/volume ratio
      2,  # convex/mesh area ratio


### PR DESCRIPTION
- In unit tests seed `np.random.random` with the same number to limit non-determinism in the large test matrix.
  - fixes #1843 
- release #1833 