### PR TITLE
Change face_count data type from signed to unsigned int in binary stl header

### DIFF
--- a/trimesh/exchange/stl.py
+++ b/trimesh/exchange/stl.py
@@ -17,7 +17,7 @@ _stl_dtype = np.dtype([('normals', '<f4', (3)),
                        ('attributes', '<u2')])
 # define a numpy datatype for the header of a binary STL file
 _stl_dtype_header = np.dtype([('header', np.void, 80),
-                              ('face_count', '<i4')])
+                              ('face_count', '<u4')])
 
 
 def load_stl(file_obj, **kwargs):


### PR DESCRIPTION
In stl.py, the data type for face_count in the binary stl header should be an unsigned int and not a signed int, as mentioned in #1846. This creates potential problems when opening STLs with a face_count thats higher than 2147483647. This mini-PR simply changes "<i4" numpy-datatype to "<u4" to fix this issue.