### PR TITLE
Handle coplanar points in oriented_bounds

### DIFF
--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -98,7 +98,7 @@ class BoundsTest(g.unittest.TestCase):
             points = g.np.zeros((5, 3))
             points[:, :2] = g.np.random.random((points.shape[0], 2))
             rot, _ = g.np.linalg.qr(g.np.random.randn(3, 3))
-            points = points @ rot
+            points = g.np.matmul(points, rot)
             to_origin, extents = g.trimesh.bounds.oriented_bounds(points)
 
             assert g.trimesh.util.is_shape(to_origin, (4, 4))

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -81,14 +81,41 @@ class BoundsTest(g.unittest.TestCase):
                 transformed_bounds = [transformed.min(axis=0),
                                       transformed.max(axis=0)]
 
-                for i in transformed_bounds:
+                for j in transformed_bounds:
                     # assert that the points once our obb to_origin transform is applied
                     # has a bounding box centered on the origin
-                    assert g.np.allclose(g.np.abs(i), extents / 2.0)
+                    assert g.np.allclose(g.np.abs(j), extents / 2.0)
 
                 extents_tf = g.np.diff(
                     transformed_bounds, axis=0).reshape(dimension)
                 assert g.np.allclose(extents_tf, extents)
+
+    def test_obb_coplanar_points(self):
+        """
+        Test OBB functions with coplanar points as input
+        """
+        for i in range(5):
+            points = g.np.zeros((5, 3))
+            points[:, :2] = g.np.random.random((points.shape[0], 2))
+            rot, _ = g.np.linalg.qr(g.np.random.randn(3, 3))
+            points = points @ rot
+            to_origin, extents = g.trimesh.bounds.oriented_bounds(points)
+
+            assert g.trimesh.util.is_shape(to_origin, (4, 4))
+            assert g.trimesh.util.is_shape(extents, (3,))
+
+            transformed = g.trimesh.transform_points(points, to_origin)
+
+            transformed_bounds = [transformed.min(axis=0),
+                                  transformed.max(axis=0)]
+
+            for j in transformed_bounds:
+                # assert that the points once our obb to_origin transform is applied
+                # has a bounding box centered on the origin
+                assert g.np.allclose(g.np.abs(j), extents / 2.0)
+
+            extents_tf = g.np.diff(transformed_bounds, axis=0).reshape(3)
+            assert g.np.allclose(extents_tf, extents)
 
     def test_2D(self):
         for theta in g.np.linspace(0, g.np.pi * 2, 2000):

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -144,7 +144,8 @@ def oriented_bounds_coplanar(points, tol=1e-12):
     # Make extents 3D
     extents = np.append(extents_2d, 0.0)
     # convert transformation from 2D to 3D and combine
-    to_origin = np.matmul(transformations.planar_matrix_to_3D(to_origin_2d), to_2d)
+    to_origin = np.matmul(
+        transformations.planar_matrix_to_3D(to_origin_2d), to_2d)
 
     return to_origin, extents
 
@@ -188,7 +189,8 @@ def oriented_bounds(obj,
             # cache rather than recomputing. This version of the cached convex hull has
             # normals pointing in arbitrary directions (straight from qhull)
             # using this avoids having to compute the expensive corrected normals
-            # that mesh.convex_hull uses since normal directions don't matter here
+            # that mesh.convex_hull uses since normal directions don't matter
+            # here
             hull = obj.convex_hull
         elif util.is_sequence(obj):
             # we've been passed a list of points
@@ -203,7 +205,8 @@ def oriented_bounds(obj,
             raise ValueError(
                 'Oriented bounds must be passed a mesh or a set of points!')
     except QhullError:
-        # Try to recover from Qhull error if due to mesh being less than 3 dimensional
+        # Try to recover from Qhull error if due to mesh being less than 3
+        # dimensional
         if hasattr(obj, 'vertices'):
             points = obj.vertices.view(np.ndarray)
         elif util.is_sequence(obj):

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -213,10 +213,7 @@ def oriented_bounds(obj,
             points = np.asanyarray(obj)
         else:
             raise
-        if np.linalg.matrix_rank(points - np.mean(points, axis=0)) == 2:
-            return oriented_bounds_coplanar(points)
-        else:
-            raise
+        return oriented_bounds_coplanar(points)
 
     vertices = hull.vertices
     hull_adj = hull.face_adjacency.T

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -130,21 +130,21 @@ def oriented_bounds_coplanar(points, tol=1e-12):
     points_mean = np.mean(points, axis=0)
     points_demeaned = points - points_mean
     _, _, vh = np.linalg.svd(points_demeaned, full_matrices=False)
-    points_2d = points_demeaned @ vh.T
+    points_2d = np.matmul(points_demeaned, vh.T)
     if np.any(np.abs(points_2d[:, 2]) > tol):
         raise ValueError('Points must be coplanar')
 
     # Construct a homogeneous matrix representing the transformation above
     to_2d = np.eye(4)
     to_2d[:3, :3] = vh
-    to_2d[:3, 3] = -vh @ points_mean
+    to_2d[:3, 3] = -np.matmul(vh, points_mean)
 
     # Find the 2D bounding box using the polygon
     to_origin_2d, extents_2d = oriented_bounds_2D(points_2d[:, :2])
     # Make extents 3D
     extents = np.append(extents_2d, 0.0)
     # convert transformation from 2D to 3D and combine
-    to_origin = transformations.planar_matrix_to_3D(to_origin_2d) @ to_2d
+    to_origin = np.matmul(transformations.planar_matrix_to_3D(to_origin_2d), to_2d)
 
     return to_origin, extents
 

--- a/trimesh/comparison.py
+++ b/trimesh/comparison.py
@@ -126,7 +126,7 @@ def identifier_simple(mesh):
     if len(mesh.faces) > 50:
         # does this mesh have edges that differ substantially in length?
         # if not this method for detecting reflection will not work
-        # and the result will definitly be garbage
+        # and the result will definitely be garbage
         edges_length = mesh.edges_unique_length
         variance = edges_length.std() / edges_length.mean()
         if variance > 0.25:

--- a/trimesh/path/packing.py
+++ b/trimesh/path/packing.py
@@ -184,7 +184,7 @@ def rectangles_single(extents, size=None, shuffle=False, rotate=True):
     bounds : (m, 2, dim) float
       Axis aligned resulting bounds in space
     transforms : (m, dim + 1, dim + 1) float
-      Homogenous transformation including rotation.
+      Homogeneous transformation including rotation.
     consume : (n,) bool
       Which of the original rectangles were packed,
       i.e. `consume.sum() == m`
@@ -323,7 +323,7 @@ def paths(paths, **kwargs):
     packed : trimesh.path.Path2D
       All paths packed into a single path object.
     transforms : (m, 3, 3) float
-      Homogenous transforms to move paths from their
+      Homogeneous transforms to move paths from their
       original position to the new one.
     consume : (n,) bool
       Which of the original paths were inserted,
@@ -553,7 +553,7 @@ def meshes(meshes, **kwargs):
     placed : (m,) trimesh.Trimesh
       Meshes moved into the rectangular volume.
     transforms : (m, 4, 4) float
-      Homogenous transform moving mesh from original
+      Homogeneous transform moving mesh from original
       position to being packed in a rectangular volume.
     consume : (n,) bool
       Which of the original meshes were inserted,
@@ -617,7 +617,7 @@ def visualize(extents, bounds):
 def roll_transform(bounds, extents):
     """
     Packing returns rotations with integer "roll" which
-    needs to be converted into a homogenous rotation matrix.
+    needs to be converted into a homogeneous rotation matrix.
 
     Currently supports `dimension=2` and `dimension=3`.
 
@@ -632,7 +632,7 @@ def roll_transform(bounds, extents):
     Returns
     ----------
     transforms : (n, dimension + 1, dimension + 1) float
-      Homogenous transformation to move cuboid at the origin
+      Homogeneous transformation to move cuboid at the origin
       into the position determined by `bounds`.
     """
     if len(bounds) != len(extents):

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -254,7 +254,7 @@ def polygon_bounds(polygon, matrix=None):
     polygon : shapely.geometry.Polygon
       Polygon pre-transform
     matrix : (3, 3) float or None.
-      Homogenous transform moving polygon in space
+      Homogeneous transform moving polygon in space
 
     Returns
     ------------

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -444,7 +444,7 @@ class Scene(Geometry3D):
 
         Parameters
         transform : (4, 4) float
-          Homogenous transformation matrix.
+          Homogeneous transformation matrix.
 
         Returns
         -------------


### PR DESCRIPTION
A potential solution to issue https://github.com/mikedh/trimesh/issues/1848

These changes check for this specific issue in `oriented_bounds` by catching Qhull errors and confirming that the points are all co-planar (rank 2). If this is the case, the bounds are computed with a dedicated function that transforms the points onto the xy plane and then uses `oriented_bounds_2D` to find the bounds.

This solution feels a little excessive, so I would be very much open to suggestion. The Qhull error could also be avoided by adding `QJ` to the `qhull_options` of `trimesh.convex.convex.hull`, but I'm not sure we want to joggle points by default.