### PR TITLE
Reduce name collisions to speed up loading of gltfs

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1365,7 +1365,7 @@ def _read_buffers(header,
     # load data from accessors into Trimesh objects
     meshes = collections.OrderedDict()
 
-    names_original = collections.defaultdict(list)
+    start_increments = {}
 
     for index, m in enumerate(header.get("meshes", [])):
 
@@ -1389,9 +1389,8 @@ def _read_buffers(header,
                 attr = p['attributes']
                 # create a unique mesh name per- primitive
                 name = m.get('name', 'GLTF')
-                names_original[index].append(name)
                 # make name unique across multiple meshes
-                name = unique_name(name, meshes)
+                name = unique_name(name, meshes, start_increments)
 
                 if mode == _GL_LINES:
                     # load GL_LINES into a Path object
@@ -1463,7 +1462,6 @@ def _read_buffers(header,
                     # each primitive gets it's own Trimesh object
                     if len(m["primitives"]) > 1:
                         kwargs['metadata']['from_gltf_primitive'] = True
-                        name = unique_name(name, meshes)
                     else:
                         kwargs['metadata']['from_gltf_primitive'] = False
 
@@ -1545,9 +1543,13 @@ def _read_buffers(header,
     # to a dict comprehension as it will be checking
     # the mutated dict in every loop
     name_index = {}
+    start_increments = {}
     for i, n in enumerate(nodes):
         name_index[unique_name(
-            n.get('name', str(i)), name_index)] = i
+            n.get('name', str(i)),
+            name_index,
+            start_increments
+        )] = i
     # invert the dict so we can look up by index
     # node index (int) : name (str)
     names = {v: k for k, v in name_index.items()}

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -2389,7 +2389,7 @@ def is_ccw(points):
     return ccw
 
 
-def unique_name(start, contains):
+def unique_name(start, contains, start_increments={}):
     """
     Deterministically generate a unique name not
     contained in a dict, set or other grouping with
@@ -2402,6 +2402,9 @@ def unique_name(start, contains):
       Initial guess for name.
     contains : dict, set, or list
       Bundle of existing names we can *not* use.
+    start_increments : dict
+      Maps name starts encountered before to increments in
+      order to speed up finding a unique name.
 
     Returns
     ---------
@@ -2414,13 +2417,13 @@ def unique_name(start, contains):
             start not in contains):
         return start
 
-    # start checking with zero index
-    increment = 0
+    # start checking with zero index unless found
+    increment = start_increments.get(start, 0)
     if start is not None and len(start) > 0:
         formatter = start + '_{}'
         # split by our delimiter once
         split = start.rsplit('_', 1)
-        if len(split) == 2:
+        if len(split) == 2 and increment == 0:
             try:
                 # start incrementing from the existing
                 # trailing value
@@ -2437,6 +2440,7 @@ def unique_name(start, contains):
     for i in range(increment + 1, 2 + increment + len(contains)):
         check = formatter.format(i)
         if check not in contains:
+            start_increments[start] = i
             return check
 
     # this should really never happen since we looped


### PR DESCRIPTION
`unique_name` can become incredibly slow because of [this loop](https://github.com/mikedh/trimesh/blob/main/trimesh/util.py#L2437) if given many colliding names. For example, if loading a model without geometry or node names, or with many repeated names, `unique_name` will identify that there is a conflict and then try appending and then incrementing an integer until the name is unique. For later names, when there are already many with appended integers, this approaches a double for loop over all the names.

The change here adds an optional argument to `unique_name` that can allow it to keep track of how far it has incremented for different input names and start from this point, significantly speeding it up in certain cases.

Description from first attempt
~~The changes here append a unique integer to each name before checking it's uniqueness, to significantly reduce the number of name collisions. The side effect is that all the geometry and node names have an integer appended. If it is important to preserve the original names if at all possible, another option would be to create a unique name generator that keeps track of base names that have been seen before with a counter for each.~~