### PR TITLE
Pass through node extension data from gltfs

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -585,12 +585,14 @@ class GLTFTest(g.unittest.TestCase):
             sphere1,
             node_name="Sphere1",
             geom_name="Geom Sphere1",
-            transform=tf1)
+            transform=tf1,
+            extras={'field': 'extra_data1'})
         s.add_geometry(sphere2,
                        node_name="Sphere2",
                        geom_name="Geom Sphere2",
                        parent_node_name="Sphere1",
-                       transform=tf2)
+                       transform=tf2,
+                       extras={'field': 'extra_data2'})
 
         # Test extras appear in the exported model nodes
         files = s.export(None, "gltf")
@@ -606,8 +608,15 @@ class GLTFTest(g.unittest.TestCase):
         files = r.export(None, "gltf")
         gltf_data = files["model.gltf"]
         assert 'test_value' in gltf_data.decode('utf8')
+        assert 'extra_data1' in gltf_data.decode('utf8')
+
         edge = r.graph.transforms.edge_data[("world", "Sphere1")]
         assert g.np.allclose(edge['matrix'], tf1)
+        assert edge['extras']['field'] == 'extra_data1'
+
+        edge = r.graph.transforms.edge_data[("Sphere1", "Sphere2")]
+        assert g.np.allclose(edge['matrix'], tf2)
+        assert edge['extras']['field'] == 'extra_data2'
 
         # all geometry should be the same
         assert set(r.geometry.keys()) == set(s.geometry.keys())

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -592,6 +592,7 @@ class GLTFTest(g.unittest.TestCase):
                        geom_name="Geom Sphere2",
                        parent_node_name="Sphere1",
                        transform=tf2,
+                       extensions={'my_ext': {'ext_data': 1.23}},
                        extras={'field': 'extra_data2'})
 
         # Test extras appear in the exported model nodes
@@ -617,6 +618,7 @@ class GLTFTest(g.unittest.TestCase):
         edge = r.graph.transforms.edge_data[("Sphere1", "Sphere2")]
         assert g.np.allclose(edge['matrix'], tf2)
         assert edge['extras']['field'] == 'extra_data2'
+        assert edge['extensions']['my_ext']['ext_data'] == 1.23
 
         # all geometry should be the same
         assert set(r.geometry.keys()) == set(s.geometry.keys())

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -595,7 +595,9 @@ class GLTFTest(g.unittest.TestCase):
             transform=tf1,
             metadata={'field': 'extra_data1'})
         node_extensions = {'mesh_ext': {'ext_data': 1.23}}
-        sphere2_metadata = {'field': 'extra_data2', 'gltf_extensions': node_extensions}
+        sphere2_metadata = {
+            'field': 'extra_data2',
+            'gltf_extensions': node_extensions}
         s.add_geometry(sphere2,
                        node_name="Sphere2",
                        geom_name="Geom Sphere2",

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -635,7 +635,8 @@ def _create_gltf_structure(scene,
             # fail here if data isn't json compatible
             # only export the extras if there is something there
             tree['scenes'][0]['extras'] = _jsonify(scene.metadata)
-            extensions = tree['scenes'][0]['extras'].pop('gltf_extensions', None)
+            extensions = tree['scenes'][0]['extras'].pop(
+                'gltf_extensions', None)
             if isinstance(extensions, dict):
                 tree['scenes'][0]['extensions'] = extensions
         except BaseException:
@@ -696,7 +697,8 @@ def _create_gltf_structure(scene,
     # Add any mesh extensions used
     for mesh in tree['meshes']:
         if 'extensions' in mesh:
-            extensions_used = extensions_used.union(set(mesh['extensions'].keys()))
+            extensions_used = extensions_used.union(
+                set(mesh['extensions'].keys()))
     # Add any extensions already in the tree (e.g. node extensions)
     if 'extensionsUsed' in tree:
         extensions_used = extensions_used.union(set(tree['extensionsUsed']))

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1639,7 +1639,7 @@ def _read_buffers(header,
                 np.diag(np.concatenate((child['scale'], [1.0]))))
 
         if "extras" in child:
-            kwargs["metadata"] = child["extras"]
+            kwargs["extras"] = child["extras"]
 
         if "mesh" in child:
             geometries = mesh_prim[child["mesh"]]

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1638,6 +1638,9 @@ def _read_buffers(header,
                 kwargs["matrix"],
                 np.diag(np.concatenate((child['scale'], [1.0]))))
 
+        if "extensions" in child:
+            kwargs["extensions"] = child["extensions"]
+
         if "extras" in child:
             kwargs["extras"] = child["extras"]
 

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -635,6 +635,9 @@ def _create_gltf_structure(scene,
             # fail here if data isn't json compatible
             # only export the extras if there is something there
             tree['scenes'][0]['extras'] = _jsonify(scene.metadata)
+            extensions = tree['scenes'][0]['extras'].pop('gltf_extensions', None)
+            if isinstance(extensions, dict):
+                tree['scenes'][0]['extensions'] = extensions
         except BaseException:
             log.debug(
                 'failed to export scene metadata!', exc_info=True)
@@ -684,6 +687,21 @@ def _create_gltf_structure(scene,
     nodes = scene.graph.to_gltf(
         scene=scene, mesh_index=mesh_index)
     tree.update(nodes)
+
+    extensions_used = set()
+    # Add any scene extensions used
+    if 'extensions' in tree['scenes'][0]:
+        extensions_used = extensions_used.union(
+            set(tree['scenes'][0]['extensions'].keys()))
+    # Add any mesh extensions used
+    for mesh in tree['meshes']:
+        if 'extensions' in mesh:
+            extensions_used = extensions_used.union(set(mesh['extensions'].keys()))
+    # Add any extensions already in the tree (e.g. node extensions)
+    if 'extensionsUsed' in tree:
+        extensions_used = extensions_used.union(set(tree['extensionsUsed']))
+    if len(extensions_used) > 0:
+        tree['extensionsUsed'] = list(extensions_used)
 
     if buffer_postprocessor is not None:
         buffer_postprocessor(buffer_items, tree)
@@ -768,6 +786,11 @@ def _append_mesh(mesh,
     try:
         # skip jsonify any metadata, skipping internal keys
         current['extras'] = _jsonify(mesh.metadata)
+
+        # extract extensions if any
+        extensions = current['extras'].pop('gltf_extensions', None)
+        if isinstance(extensions, dict):
+            current['extensions'] = extensions
 
         if mesh.units not in [None, 'm', 'meters', 'meter']:
             current["extras"]["units"] = str(mesh.units)
@@ -1378,6 +1401,9 @@ def _read_buffers(header,
             # try to load all mesh metadata
             if isinstance(m.get('extras'), dict):
                 metadata.update(m['extras'])
+            # put any mesh extensions in a field of the metadata
+            if 'extensions' in m:
+                metadata['gltf_extensions'] = m['extensions']
 
             for p in m["primitives"]:
                 # if we don't have a triangular mesh continue
@@ -1638,11 +1664,15 @@ def _read_buffers(header,
                 kwargs["matrix"],
                 np.diag(np.concatenate((child['scale'], [1.0]))))
 
-        if "extensions" in child:
-            kwargs["extensions"] = child["extensions"]
+        # treat node metadata similarly to mesh metadata
+        if isinstance(child.get("extras"), dict):
+            kwargs["metadata"] = child["extras"]
 
-        if "extras" in child:
-            kwargs["extras"] = child["extras"]
+        # put any node extensions in a field of the metadata
+        if "extensions" in child:
+            if "metadata" not in kwargs:
+                kwargs["metadata"] = {}
+            kwargs["metadata"]["gltf_extensions"] = child["extensions"]
 
         if "mesh" in child:
             geometries = mesh_prim[child["mesh"]]
@@ -1684,6 +1714,15 @@ def _read_buffers(header,
         # use a try except to avoid nested key checks
         result['metadata'] = header['scenes'][
             header['scene']]['extras']
+    except BaseException:
+        pass
+    try:
+        # load any scene extensions into a field of scene.metadata
+        # use a try except to avoid nested key checks
+        if "metadata" not in result:
+            result["metadata"] = {}
+        result['metadata']['gltf_extensions'] = header['scenes'][
+            header['scene']]['extensions']
     except BaseException:
         pass
 

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -107,8 +107,7 @@ class Scene(Geometry3D):
                      geom_name=None,
                      parent_node_name=None,
                      transform=None,
-                     extensions=None,
-                     extras=None):
+                     metadata=None):
         """
         Add a geometry to the scene.
 
@@ -124,8 +123,7 @@ class Scene(Geometry3D):
         geom_name: Name of the added geometry.
         parent_node_name: Name of the parent node in the graph.
         transform: Transform that applies to the added node.
-        extensions: Optional extension-specific data.
-        extras: Optional metadata for the node.
+        metadata: Optional metadata for the node.
 
         Returns
         ----------
@@ -145,15 +143,13 @@ class Scene(Geometry3D):
                 geom_name=geom_name,
                 parent_node_name=parent_node_name,
                 transform=transform,
-                extensions=extensions,
-                extras=extras) for value in geometry]
+                metadata=metadata) for value in geometry]
         elif isinstance(geometry, dict):
             # if someone passed us a dict of geometry
             return {k: self.add_geometry(
                     geometry=v,
                     geom_name=k,
-                    extensions=extensions,
-                    extras=extras) for k, v in geometry.items()}
+                    metadata=metadata) for k, v in geometry.items()}
 
         elif isinstance(geometry, Scene):
             # concatenate current scene with passed scene
@@ -207,8 +203,7 @@ class Scene(Geometry3D):
                           matrix=transform,
                           geometry=name,
                           geometry_flags={'visible': True},
-                          extensions=extensions,
-                          extras=extras)
+                          metadata=metadata)
 
         return node_name
 
@@ -1118,8 +1113,8 @@ class Scene(Geometry3D):
                             parent_node_name=p,
                             transform=result.graph.transforms.edge_data[(
                                 p, n)].get('matrix', None),
-                            extras=result.graph.transforms.edge_data[(
-                                p, n)].get('extras', None))
+                            metadata=result.graph.transforms.edge_data[(
+                                p, n)].get('metadata', None))
                     result.delete_geometry(geom_name)
 
             # Convert all 2D paths to 3D paths

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -149,8 +149,11 @@ class Scene(Geometry3D):
                 extras=extras) for value in geometry]
         elif isinstance(geometry, dict):
             # if someone passed us a dict of geometry
-            return {k: self.add_geometry(v, geom_name=k, extensions=extensions, extras=extras)
-                    for k, v in geometry.items()}
+            return {k: self.add_geometry(
+                    geometry=v,
+                    geom_name=k,
+                    extensions=extensions,
+                    extras=extras) for k, v in geometry.items()}
 
         elif isinstance(geometry, Scene):
             # concatenate current scene with passed scene

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -107,6 +107,7 @@ class Scene(Geometry3D):
                      geom_name=None,
                      parent_node_name=None,
                      transform=None,
+                     extensions=None,
                      extras=None):
         """
         Add a geometry to the scene.
@@ -123,6 +124,7 @@ class Scene(Geometry3D):
         geom_name: Name of the added geometry.
         parent_node_name: Name of the parent node in the graph.
         transform: Transform that applies to the added node.
+        extensions: Optional extension-specific data.
         extras: Optional metadata for the node.
 
         Returns
@@ -143,10 +145,11 @@ class Scene(Geometry3D):
                 geom_name=geom_name,
                 parent_node_name=parent_node_name,
                 transform=transform,
+                extensions=extensions,
                 extras=extras) for value in geometry]
         elif isinstance(geometry, dict):
             # if someone passed us a dict of geometry
-            return {k: self.add_geometry(v, geom_name=k, extras=extras)
+            return {k: self.add_geometry(v, geom_name=k, extensions=extensions, extras=extras)
                     for k, v in geometry.items()}
 
         elif isinstance(geometry, Scene):
@@ -201,6 +204,7 @@ class Scene(Geometry3D):
                           matrix=transform,
                           geometry=name,
                           geometry_flags={'visible': True},
+                          extensions=extensions,
                           extras=extras)
 
         return node_name


### PR DESCRIPTION
It would be great to pass through any node extension data from gltf files. Putting the extension data in `extras` seems simplest since the field appears unused for gltfs (it looks like the actual extras are put in `metadata`, is this intended?) but is [passed on when constructing the graph](https://github.com/mikedh/trimesh/blob/main/trimesh/scene/transforms.py#L75).