### PR TITLE
Cache calculation of children

### DIFF
--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -722,14 +722,17 @@ class EnforcedForest(object):
         children : dict
           Keyed {node : [child, child, ...]}
         """
+        if 'children' in self._cache:
+            return self._cache['children']
         child = collections.defaultdict(list)
         # append children to parent references
         # skip self-references to avoid a node loop
         [child[v].append(u) for u, v in
          self.parents.items() if u != v]
 
-        # return as a vanilla dict
-        return dict(child)
+        # cache and return as a vanilla dict
+        self._cache['children'] = dict(child)
+        return self._cache['children']
 
     def successors(self, node):
         """


### PR DESCRIPTION
When using `successors` across all nodes of a large model, it's call to `children` appears to be the main computational bottleneck.
These changes cache the result of `children` (in the same structure as paths are cached).

Test script
```
import numpy as np
from trimesh.scene.transforms import EnforcedForest

def random_chr():
    return chr(ord('a') + int(round(np.random.random() * 25)))

if __name__ == '__main__':
    graph = EnforcedForest()
    for i in range(100):
        level1 = 'a_{}'.format(i)
        graph.add_edge('base_frame', level1)
        for j in range(50):
            level2 = 'b_{}_{}'.format(i, j)
            graph.add_edge(level1, level2)

    for n in graph.nodes:
        succ = graph.successors(n)
```
Profiling results before change
```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 10:48:07  Samples:  4189
 /_//_/// /_\ / //_// / //_'/ //     Duration: 4.219     CPU time: 7.341
/   _/                      v4.4.0

Program: test.py

4.219 <module>  test.py:1
├─ 3.868 EnforcedForest.successors  trimesh/scene/transforms.py:734
│  └─ 3.862 EnforcedForest.children  trimesh/scene/transforms.py:715
│     ├─ 3.807 <listcomp>  trimesh/scene/transforms.py:728
│     │  ├─ 2.831 [self]  None
```
Profiling results after change
```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 10:48:19  Samples:  280
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.312     CPU time: 3.389
/   _/                      v4.4.0

Program: test.py

0.311 <module>  test.py:1
├─ 0.242 <module>  trimesh/__init__.py:1
│  ├─ 0.225 <module>  trimesh/base.py:1
│  │  ├─ 0.128 <module>  trimesh/ray/__init__.py:1
│  │  │  └─ 0.127 <module>  trimesh/ray/ray_triangle.py:1
│  │  │     └─ 0.127 <module>  trimesh/ray/ray_util.py:1
│  │  │        ├─ 0.121 <module>  trimesh/bounds.py:1
```