### PR TITLE
Release: Convex Coplanar, Normalize PCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![trimesh](https://trimsh.org/images/logotype-a.svg)](http://trimsh.org)
 
 -----------
-[![Github Actions](https://github.com/mikedh/trimesh/workflows/Release%20Trimesh/badge.svg)](https://github.com/mikedh/trimesh/actions)  [![PyPI version](https://badge.fury.io/py/trimesh.svg)](https://badge.fury.io/py/trimesh) [![codecov](https://codecov.io/gh/mikedh/trimesh/branch/main/graph/badge.svg?token=4PVRQXyl2h)](https://codecov.io/gh/mikedh/trimesh)  [![Docker Image Version (latest by date)](https://img.shields.io/docker/v/trimesh/trimesh?label=docker)](https://hub.docker.com/repository/docker/trimesh/trimesh/)
+[![Github Actions](https://github.com/mikedh/trimesh/workflows/Release%20Trimesh/badge.svg)](https://github.com/mikedh/trimesh/actions)  [![PyPI version](https://badge.fury.io/py/trimesh.svg)](https://badge.fury.io/py/trimesh) [![codecov](https://codecov.io/gh/mikedh/trimesh/branch/main/graph/badge.svg?token=4PVRQXyl2h)](https://codecov.io/gh/mikedh/trimesh)  [![Docker Image Version (latest by date)](https://img.shields.io/docker/v/trimesh/trimesh?label=docker)](https://hub.docker.com/r/trimesh/trimesh/tags)
 
 
 Trimesh is a pure Python (2.7-3.5+) library for loading and using [triangular meshes](https://en.wikipedia.org/wiki/Triangle_mesh) with an emphasis on watertight surfaces. The goal of the library is to provide a full featured and well tested Trimesh object which allows for easy manipulation and analysis, in the style of the Polygon object in the [Shapely library](https://github.com/Toblerity/Shapely).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -82,6 +82,10 @@ autopep8 --recursive --verbose --in-place --aggressive trimesh
 flake8 trimesh
 ```
 
+## Docstrings
+
+Trimesh uses the [Sphinx Numpy-style](https://www.sphinx-doc.org/en/master/usage/extensions/example_numpy.html#example-numpy) docstrings which get parsed into the API reference page. 
+
 ## General Tips
 
 Python can be fast but only when you use it as little as possible. In general, if you ever have a block which loops through faces and vertices it will be basically unusable with even moderately sized meshes. All operations on face or vertex arrays should be vectorized numpy operations unless absolutely unavoidable. Profiling helps figure out what is slow, but some general advice:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,14 @@ requires = [
 ]
 
 [tool.ruff]
-select = ["E", "F"] # the default rules
-         # "T201",   # disallow print statements
-	 # "B"]      # pass bugbear
+select = ["E", "F", # the default rules
+          "T201",   # disallow print statements
+	  "B",      # pass bugbear
+          "I001",   # isort
+          "D"]      # pydocstyle
 ignore = ["B905"] # `zip()` without an explicit `strict=`
 line-length = 90
+
+
+[tool.ruff.pydocstyle]
+convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,11 @@ requires = [
 [tool.ruff]
 select = ["E", "F", # the default rules
           "T201",   # disallow print statements
-	  "B",      # pass bugbear
-          "I001",   # isort
-          "D"]      # pydocstyle
-ignore = ["B905"] # `zip()` without an explicit `strict=`
+	  "B"]      # pass bugbear
+          #"I001",   # isort
+          #"D"]      # pydocstyle
+ignore = ["B905", # `zip()` without an explicit `strict=`
+          "B904"] # `raise ... from err` is silly
 line-length = 90
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ requires = [
 ]
 
 [tool.ruff]
-select = ["E", "F", # the default rules
-          "T201",   # disallow print statements
-	  "B"]      # pass bugbear
+select = ["E", "F"] # the default rules
+          # "T201",   # disallow print statements
+	  # "B"]      # pass bugbear
           #"I001",   # isort
           #"D"]      # pydocstyle
 ignore = ["B905", # `zip()` without an explicit `strict=`

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -81,14 +81,41 @@ class BoundsTest(g.unittest.TestCase):
                 transformed_bounds = [transformed.min(axis=0),
                                       transformed.max(axis=0)]
 
-                for i in transformed_bounds:
+                for j in transformed_bounds:
                     # assert that the points once our obb to_origin transform is applied
                     # has a bounding box centered on the origin
-                    assert g.np.allclose(g.np.abs(i), extents / 2.0)
+                    assert g.np.allclose(g.np.abs(j), extents / 2.0)
 
                 extents_tf = g.np.diff(
                     transformed_bounds, axis=0).reshape(dimension)
                 assert g.np.allclose(extents_tf, extents)
+
+    def test_obb_coplanar_points(self):
+        """
+        Test OBB functions with coplanar points as input
+        """
+        for i in range(5):
+            points = g.np.zeros((5, 3))
+            points[:, :2] = g.np.random.random((points.shape[0], 2))
+            rot, _ = g.np.linalg.qr(g.np.random.randn(3, 3))
+            points = g.np.matmul(points, rot)
+            to_origin, extents = g.trimesh.bounds.oriented_bounds(points)
+
+            assert g.trimesh.util.is_shape(to_origin, (4, 4))
+            assert g.trimesh.util.is_shape(extents, (3,))
+
+            transformed = g.trimesh.transform_points(points, to_origin)
+
+            transformed_bounds = [transformed.min(axis=0),
+                                  transformed.max(axis=0)]
+
+            for j in transformed_bounds:
+                # assert that the points once our obb to_origin transform is applied
+                # has a bounding box centered on the origin
+                assert g.np.allclose(g.np.abs(j), extents / 2.0)
+
+            extents_tf = g.np.diff(transformed_bounds, axis=0).reshape(3)
+            assert g.np.allclose(extents_tf, extents)
 
     def test_2D(self):
         for theta in g.np.linspace(0, g.np.pi * 2, 2000):

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -116,6 +116,15 @@ class IdentifierTest(g.unittest.TestCase):
                      for group in b])
         assert a_set == b_set
 
+        ptp = []
+        for group in b:
+            current = []
+            for node in group:
+                _, geom = d.graph[node]
+                current.append(d.geometry[geom].identifier)
+            ptp.append(g.np.ptp(current, axis=0))
+            assert (ptp[-1] < 0.01).all()
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -110,11 +110,10 @@ class IdentifierTest(g.unittest.TestCase):
         # should be the same in both forms
         assert len(a) == len(b)
 
-        a_set = set([tuple(sorted([clean_name(i) for i in g]))
-                     for g in a])
-        b_set = set([tuple(sorted([clean_name(i) for i in g]))
-                     for g in b])
-
+        a_set = set([tuple(sorted([clean_name(i) for i in group]))
+                     for group in a])
+        b_set = set([tuple(sorted([clean_name(i) for i in group]))
+                     for group in b])
         assert a_set == b_set
 
 

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -28,12 +28,9 @@ class IdentifierTest(g.unittest.TestCase):
             ok = (result[0] == result[1:]).all()
 
             if not ok:
-                debug = [g.trimesh.util.sigfig_int(
-                    i, g.trimesh.comparison.id_sigfig)
-                    for i in identifier]
+                ptp = g.np.ptp(identifier, axis=0)
                 g.log.error('Hashes on %s differ after transform:\n %s\n',
-                            mesh.metadata['file_name'],
-                            str(g.np.array(debug, dtype=g.np.int64)))
+                            mesh.metadata['file_name'], str(ptp))
                 raise ValueError('values differ after transform!')
 
             # stretch the mesh by a small amount
@@ -93,6 +90,32 @@ class IdentifierTest(g.unittest.TestCase):
         assert g.np.isclose(a.volume, b.volume)
         # hash should differ
         assert a.identifier_hash != b.identifier_hash
+
+    def test_duplicates(self):
+        def clean_name(name):
+            return name.split('_', 1)[0].split('#', 1)[0]
+
+        # a scene with instances
+        s = g.get_mesh('cycloidal.3DXML')
+        # a flat scene dump
+        d = g.trimesh.Scene(s.dump())
+
+        # should have the same number of geometry nodes
+        assert len(s.graph.nodes_geometry) == len(d.graph.nodes_geometry)
+
+        # uses the identifier to calculate
+        a = s.duplicate_nodes
+        b = d.duplicate_nodes
+
+        # should be the same in both forms
+        assert len(a) == len(b)
+
+        a_set = set([tuple(sorted([clean_name(i) for i in g]))
+                     for g in a])
+        b_set = set([tuple(sorted([clean_name(i) for i in g]))
+                     for g in b])
+
+        assert a_set == b_set
 
 
 if __name__ == '__main__':

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -10,7 +10,7 @@ from . import transformations
 
 try:
     # scipy is a soft dependency
-    from scipy.spatial import ConvexHull, QhullError
+    from scipy.spatial import ConvexHull
     from scipy import optimize
 except BaseException as E:
     # raise the exception when someone tries to use it
@@ -18,6 +18,10 @@ except BaseException as E:
     ConvexHull = exceptions.ExceptionWrapper(E)
     optimize = exceptions.ExceptionWrapper(E)
 
+try:
+    from scipy.spatial import QhullError
+except BaseException:
+    QhullError = BaseException
 
 # a 90 degree rotation
 _flip = transformations.planar_matrix(theta=np.pi / 2)

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -10,7 +10,7 @@ from . import transformations
 
 try:
     # scipy is a soft dependency
-    from scipy.spatial import ConvexHull
+    from scipy.spatial import ConvexHull, QhullError
     from scipy import optimize
 except BaseException as E:
     # raise the exception when someone tries to use it
@@ -136,28 +136,82 @@ def oriented_bounds(obj,
       The extents of the mesh once transformed with to_origin
     """
 
-    # extract a set of convex hull vertices and normals from the input
-    # we bother to do this to avoid recomputing the full convex hull if
-    # possible
-    if hasattr(obj, 'convex_hull'):
-        # if we have been passed a mesh, use its existing convex hull to pull from
-        # cache rather than recomputing. This version of the cached convex hull has
-        # normals pointing in arbitrary directions (straight from qhull)
-        # using this avoids having to compute the expensive corrected normals
-        # that mesh.convex_hull uses since normal directions don't matter here
-        hull = obj.convex_hull
-    elif util.is_sequence(obj):
-        # we've been passed a list of points
-        points = np.asanyarray(obj)
-        if util.is_shape(points, (-1, 2)):
-            return oriented_bounds_2D(points)
-        elif util.is_shape(points, (-1, 3)):
-            hull = convex.convex_hull(points, repair=False)
+    def oriented_bounds_coplanar(points, tol=1e-12):
+        """
+        Find an oriented bounding box for an array of coplanar 3D points.
+
+        Parameters
+        ----------
+        points : (n, 3) float
+          Points in 3D that occupy a 2D subspace.
+        tol : float
+          Tolerance for deviation from coplanar.
+
+        Returns
+        ----------
+        to_origin : (4, 4) float
+          Transformation matrix which will move the center of the
+          bounding box of the input mesh to the origin.
+        extents : (3,) float
+          The extents of the mesh once transformed with to_origin
+        """
+        # Shift points about the origin and rotate into the xy plane
+        points_mean = np.mean(points, axis=0)
+        points_demeaned = points - points_mean
+        _, _, vh = np.linalg.svd(points_demeaned, full_matrices=False)
+        points_2d = np.matmul(points_demeaned, vh.T)
+        if np.any(np.abs(points_2d[:, 2]) > tol):
+            raise ValueError('Points must be coplanar')
+
+        # Construct a homogeneous matrix representing the transformation above
+        to_2d = np.eye(4)
+        to_2d[:3, :3] = vh
+        to_2d[:3, 3] = -np.matmul(vh, points_mean)
+
+        # Find the 2D bounding box using the polygon
+        to_origin_2d, extents_2d = oriented_bounds_2D(points_2d[:, :2])
+        # Make extents 3D
+        extents = np.append(extents_2d, 0.0)
+        # convert transformation from 2D to 3D and combine
+        to_origin = np.matmul(
+            transformations.planar_matrix_to_3D(to_origin_2d), to_2d)
+
+        return to_origin, extents
+
+    try:
+        # extract a set of convex hull vertices and normals from the input
+        # we bother to do this to avoid recomputing the full convex hull if
+        # possible
+        if hasattr(obj, 'convex_hull'):
+            # if we have been passed a mesh, use its existing convex hull to pull from
+            # cache rather than recomputing. This version of the cached convex hull has
+            # normals pointing in arbitrary directions (straight from qhull)
+            # using this avoids having to compute the expensive corrected normals
+            # that mesh.convex_hull uses since normal directions don't matter
+            # here
+            hull = obj.convex_hull
+        elif util.is_sequence(obj):
+            # we've been passed a list of points
+            points = np.asanyarray(obj)
+            if util.is_shape(points, (-1, 2)):
+                return oriented_bounds_2D(points)
+            elif util.is_shape(points, (-1, 3)):
+                hull = convex.convex_hull(points, repair=False)
+            else:
+                raise ValueError('Points are not (n,3) or (n,2)!')
         else:
-            raise ValueError('Points are not (n,3) or (n,2)!')
-    else:
-        raise ValueError(
-            'Oriented bounds must be passed a mesh or a set of points!')
+            raise ValueError(
+                'Oriented bounds must be passed a mesh or a set of points!')
+    except QhullError:
+        # Try to recover from Qhull error if due to mesh being less than 3
+        # dimensional
+        if hasattr(obj, 'vertices'):
+            points = obj.vertices.view(np.ndarray)
+        elif util.is_sequence(obj):
+            points = np.asanyarray(obj)
+        else:
+            raise
+        return oriented_bounds_coplanar(points)
 
     vertices = hull.vertices
     hull_adj = hull.face_adjacency.T

--- a/trimesh/comparison.py
+++ b/trimesh/comparison.py
@@ -15,7 +15,7 @@ from .constants import tol
 # how many significant figures to use for each
 # field of the identifier based on hand-tuning
 id_sigfig = np.array(
-    [4,   # area
+    [5,   # area
      10,  # euler number
      5,  # area/volume ratio
      2,  # convex/mesh area ratio

--- a/trimesh/convex.py
+++ b/trimesh/convex.py
@@ -63,9 +63,10 @@ def convex_hull(obj, qhull_options='QbB Pp Qt', repair=True):
     try:
         hull = ConvexHull(points, qhull_options=qhull_options)
     except QhullError:
-        util.log.warning(
-            'Failed to compute convex hull! trying `Qj`',
+        util.log.debug(
+            'Failed to compute convex hull: retrying with `Qj`',
             exc_info=True)
+        # try with "joggle" enabled
         hull = ConvexHull(points, qhull_options='Qj')
 
     # hull object doesn't remove unreferenced vertices

--- a/trimesh/convex.py
+++ b/trimesh/convex.py
@@ -18,10 +18,14 @@ from . import triangles
 
 
 try:
-    from scipy.spatial import ConvexHull, QhullError
+    from scipy.spatial import ConvexHull
 except ImportError as E:
     from .exceptions import ExceptionWrapper
     ConvexHull = ExceptionWrapper(E)
+
+try:
+    from scipy.spatial import QhullError
+except BaseException:
     QhullError = BaseException
 
 

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -918,7 +918,7 @@ def cylinder(radius,
 
     if height is None:
         raise ValueError('either `height` or `segment` must be passed!')
-
+    
     half = abs(float(height)) / 2.0
     # create a profile to revolve
     linestring = [[0, -half],

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -918,7 +918,7 @@ def cylinder(radius,
 
     if height is None:
         raise ValueError('either `height` or `segment` must be passed!')
-    
+
     half = abs(float(height)) / 2.0
     # create a profile to revolve
     linestring = [[0, -half],

--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -194,7 +194,7 @@ def _parse_node(node,
                 local_material_map[symbol] = _parse_material(m, resolver)
 
         # Iterate over primitives of geometry
-        for i, primitive in enumerate(geometry.primitives):
+        for primitive in geometry.primitives:
             if isinstance(primitive, collada.polylist.Polylist):
                 primitive = primitive.triangleset()
             if isinstance(primitive, collada.triangleset.TriangleSet):

--- a/trimesh/inertia.py
+++ b/trimesh/inertia.py
@@ -197,7 +197,7 @@ def radial_symmetry(mesh):
     scalar = mesh.principal_inertia_components.copy()
 
     # exit early if inertia components are all zero
-    if util.allclose(scalar, 0.0):
+    if (scalar < 1e-12).any():
         return None, None, None
 
     # normalize the PCI so we can compare them
@@ -209,13 +209,9 @@ def radial_symmetry(mesh):
     # we are checking if a geometry has radial symmetry
     # if 2 of the PCI are equal, it is a revolved 2D profile
     # if 3 of the PCI (all of them) are equal it is a sphere
-    # thus we take the diff of the sorted PCI, scale it as a ratio
-    # of the largest PCI, and then scale to the tolerance we care about
-    # if tol is 1e-3, that means that 2 components are identical if they
-    # are within .1% of the maximum PCI.
     diff = np.abs(np.diff(scalar[order]))
     # diffs that are within tol of zero
-    diff_zero = diff < 1e-5
+    diff_zero = diff < 1e-4
 
     if diff_zero.all():
         # this is the case where all 3 PCI are identical

--- a/trimesh/inertia.py
+++ b/trimesh/inertia.py
@@ -197,11 +197,11 @@ def radial_symmetry(mesh):
     scalar = mesh.principal_inertia_components.copy()
 
     # exit early if inertia components are all zero
-    if scalar.ptp() < 1e-12:
+    if util.allclose(scalar, 0.0):
         return None, None, None
 
     # normalize the PCI so we can compare them
-    scalar /= np.linalg.norm(scalar)
+    scalar = scalar / np.linalg.norm(scalar)
     vector = mesh.principal_inertia_vectors
     # the sorted order of the principal components
     order = scalar.argsort()
@@ -214,9 +214,8 @@ def radial_symmetry(mesh):
     # if tol is 1e-3, that means that 2 components are identical if they
     # are within .1% of the maximum PCI.
     diff = np.abs(np.diff(scalar[order]))
-    diff /= np.abs(scalar).max()
     # diffs that are within tol of zero
-    diff_zero = (diff / 1e-3).astype(int) == 0
+    diff_zero = diff < 1e-5
 
     if diff_zero.all():
         # this is the case where all 3 PCI are identical
@@ -242,8 +241,8 @@ def radial_symmetry(mesh):
 
         # since two vectors are the same, we know the middle
         # one is one of those two
-        section_index = order[np.array([[0, 1],
-                                        [1, -1]])[diff_zero]].flatten()
+        section_index = order[
+            np.array([[0, 1], [1, -1]])[diff_zero]].flatten()
         section = vector[section_index]
 
         # we know the rotation axis is the sole unique value

--- a/trimesh/inertia.py
+++ b/trimesh/inertia.py
@@ -194,12 +194,14 @@ def radial_symmetry(mesh):
     """
 
     # shortcuts to avoid typing and hitting cache
-    scalar = mesh.principal_inertia_components
+    scalar = mesh.principal_inertia_components.copy()
 
     # exit early if inertia components are all zero
-    if scalar.ptp() < 1e-4:
+    if scalar.ptp() < 1e-12:
         return None, None, None
 
+    # normalize the PCI so we can compare them
+    scalar /= np.linalg.norm(scalar)
     vector = mesh.principal_inertia_vectors
     # the sorted order of the principal components
     order = scalar.argsort()

--- a/trimesh/path/packing.py
+++ b/trimesh/path/packing.py
@@ -183,7 +183,7 @@ def rectangles_single(extents, size=None, shuffle=False, rotate=True):
     bounds : (m, 2, dim) float
       Axis aligned resulting bounds in space
     transforms : (m, dim + 1, dim + 1) float
-      Homogenous transformation including rotation.
+      Homogeneous transformation including rotation.
     consume : (n,) bool
       Which of the original rectangles were packed,
       i.e. `consume.sum() == m`
@@ -322,7 +322,7 @@ def paths(paths, **kwargs):
     packed : trimesh.path.Path2D
       All paths packed into a single path object.
     transforms : (m, 3, 3) float
-      Homogenous transforms to move paths from their
+      Homogeneous transforms to move paths from their
       original position to the new one.
     consume : (n,) bool
       Which of the original paths were inserted,
@@ -552,7 +552,7 @@ def meshes(meshes, **kwargs):
     placed : (m,) trimesh.Trimesh
       Meshes moved into the rectangular volume.
     transforms : (m, 4, 4) float
-      Homogenous transform moving mesh from original
+      Homogeneous transform moving mesh from original
       position to being packed in a rectangular volume.
     consume : (n,) bool
       Which of the original meshes were inserted,
@@ -616,7 +616,7 @@ def visualize(extents, bounds):
 def roll_transform(bounds, extents):
     """
     Packing returns rotations with integer "roll" which
-    needs to be converted into a homogenous rotation matrix.
+    needs to be converted into a homogeneous rotation matrix.
 
     Currently supports `dimension=2` and `dimension=3`.
 
@@ -631,7 +631,7 @@ def roll_transform(bounds, extents):
     Returns
     ----------
     transforms : (n, dimension + 1, dimension + 1) float
-      Homogenous transformation to move cuboid at the origin
+      Homogeneous transformation to move cuboid at the origin
       into the position determined by `bounds`.
     """
     if len(bounds) != len(extents):

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -731,7 +731,6 @@ def projected(mesh,
               rpad=1e-5,
               apad=None,
               tol_dot=0.01,
-              debug=False,
               max_regions=200):
     """
     Project a mesh onto a plane and then extract the polygon
@@ -822,7 +821,7 @@ def projected(mesh,
 
     # a sequence of face indexes that are connected
     face_groups = graph.connected_components(
-        adjacency, min_len=2, nodes=np.nonzero(side)[0])
+        adjacency, nodes=np.nonzero(side)[0])
 
     # if something is goofy we may end up with thousands of
     # regions that do nothing except hang for an hour then segfault

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -275,7 +275,7 @@ def polygon_bounds(polygon, matrix=None):
     return bounds
 
 
-def plot(polygon, show=True, axes=None, **kwargs):
+def plot(polygon=None, show=True, axes=None, **kwargs):
     """
     Plot a shapely polygon using matplotlib.
 
@@ -303,7 +303,7 @@ def plot(polygon, show=True, axes=None, **kwargs):
         [plot_single(i) for i in polygon.geoms]
     elif hasattr(polygon, '__iter__'):
         [plot_single(i) for i in polygon]
-    else:
+    elif polygon is not None:
         plot_single(polygon)
 
     if show:
@@ -731,6 +731,7 @@ def projected(mesh,
               rpad=1e-5,
               apad=None,
               tol_dot=0.01,
+              debug=False,
               max_regions=200):
     """
     Project a mesh onto a plane and then extract the polygon
@@ -821,7 +822,7 @@ def projected(mesh,
 
     # a sequence of face indexes that are connected
     face_groups = graph.connected_components(
-        adjacency, nodes=np.nonzero(side)[0])
+        adjacency, min_len=2, nodes=np.nonzero(side)[0])
 
     # if something is goofy we may end up with thousands of
     # regions that do nothing except hang for an hour then segfault
@@ -847,6 +848,15 @@ def projected(mesh,
         polygons.extend(edges_to_polygons(
             edges=edge[group], vertices=vertices_2D))
 
+    if debug:
+        vis = mesh.copy()
+        vis.visual.face_colors = [100, 100, 100, 255]
+        for f in face_groups:
+            vis.visual.face_colors = [255,0,0,255]
+        vis.show()
+        for p in polygons:
+            plot(p)
+        
     padding = 0.0
     if apad is not None:
         # set padding by absolute value

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -254,7 +254,7 @@ def polygon_bounds(polygon, matrix=None):
     polygon : shapely.geometry.Polygon
       Polygon pre-transform
     matrix : (3, 3) float or None.
-      Homogenous transform moving polygon in space
+      Homogeneous transform moving polygon in space
 
     Returns
     ------------
@@ -848,15 +848,6 @@ def projected(mesh,
         polygons.extend(edges_to_polygons(
             edges=edge[group], vertices=vertices_2D))
 
-    if debug:
-        vis = mesh.copy()
-        vis.visual.face_colors = [100, 100, 100, 255]
-        for f in face_groups:
-            vis.visual.face_colors = [255,0,0,255]
-        vis.show()
-        for p in polygons:
-            plot(p)
-        
     padding = 0.0
     if apad is not None:
         # set padding by absolute value

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -444,7 +444,7 @@ class Scene(Geometry3D):
 
         Parameters
         transform : (4, 4) float
-          Homogenous transformation matrix.
+          Homogeneous transformation matrix.
 
         Returns
         -------------

--- a/trimesh/transformations.py
+++ b/trimesh/transformations.py
@@ -2142,9 +2142,9 @@ def transform_points(points,
         # apply translation and rotation
         stack = np.column_stack((points, np.ones(count)))
         return np.dot(matrix, stack.T).T[:, :dim]
-    else:
-        # only apply the rotation
-        return np.dot(matrix[:dim, :dim], points.T)
+
+    # only apply the rotation
+    return np.dot(matrix[:dim, :dim], points.T).T
 
 
 def fix_rigid(matrix, max_deviance=1e-5):

--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -52,10 +52,11 @@ def area(triangles=None, crosses=None, sum=False):
     """
     if crosses is None:
         crosses = cross(triangles)
-    area = (np.sum(crosses**2, axis=1)**.5) * .5
+    areas = np.sqrt((crosses ** 2).sum(axis=1)) / 2.0
     if sum:
-        return np.sum(area)
-    return area
+        return areas.sum()
+    return areas
+
 
 
 def normals(triangles=None, crosses=None):

--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -58,7 +58,6 @@ def area(triangles=None, crosses=None, sum=False):
     return areas
 
 
-
 def normals(triangles=None, crosses=None):
     """
     Calculates the normals of input triangles

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.20.1'
+__version__ = '3.20.2'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script

--- a/trimesh/voxel/runlength.py
+++ b/trimesh/voxel/runlength.py
@@ -666,6 +666,7 @@ def rle_strip(rle_data):
             break
         else:
             end += count
+
     rle_data = rle_data[i:None if j == 0 else -j].reshape((-1,))
     return rle_data, (start, end)
 


### PR DESCRIPTION
- normalize `principal_inertia_components` before checking for radial symmetry
- release #1849 
- add `trimesh.transformations.fix_rigid` which tries `numpy.svd` to remove accumulated floating point error in rotation matrices, and add an option to `trimesh.scene.transforms` which enables matrix repair by default. This may not be a good idea but a long debugging process of something unrelated ended up being accumulated floating point error in `M @ M.T` differing from identity by 0.0001. It looks like it's passing tests and we can revert this if it's a problem.