### PR TITLE
Fix ply uv export

### DIFF
--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -199,6 +199,22 @@ class PlyTest(g.unittest.TestCase):
             m = g.get_mesh(mesh_name)
             assert hasattr(m, 'visual') and hasattr(m.visual, 'uv')
             assert m.visual.uv.shape[0] == m.vertices.shape[0]
+    
+    def test_uv_export(self):
+        m = g.get_mesh("fuze.ply")
+        assert hasattr(m, 'visual') and hasattr(m.visual, 'uv')
+        assert m.visual.uv.shape[0] == m.vertices.shape[0]
+
+        # create empty file to export to
+        f = g.tempfile.NamedTemporaryFile(suffix='.ply', delete=False)
+        f.close()
+
+        # export should contain the uv data
+        m.export(f.name)
+        m2 = g.trimesh.load(f.name)
+
+        assert hasattr(m2, 'visual') and hasattr(m2.visual, 'uv')
+        assert g.np.allclose(m.visual.uv, m2.visual.uv)
 
     def test_fix_texture(self):
         # test loading of face indices when uv-coordinates are also contained

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -263,6 +263,10 @@ def export_ply(mesh,
     # if we want to include mesh attributes in the export
     if include_attributes:
         if hasattr(mesh, 'vertex_attributes'):
+            # make sure to export texture coordinates as well
+            if hasattr(mesh, "visual") and hasattr(mesh.visual, "uv"):
+                mesh.vertex_attributes["s"] = mesh.visual.uv[:, 0]
+                mesh.vertex_attributes["t"] = mesh.visual.uv[:, 1]
             _assert_attributes_valid(mesh.vertex_attributes)
         if hasattr(mesh, 'face_attributes'):
             _assert_attributes_valid(mesh.face_attributes)


### PR DESCRIPTION
Hey,

while working on the same project as mentioned here https://github.com/mikedh/trimesh/issues/1880 , I noticed that the PLY export ignores the texture coordinates. This PR should fix that.