### PR TITLE
Assert all meshes have trimesh type in concatenation

### DIFF
--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -71,7 +71,7 @@ def mesh_other(mesh,
         """
         Return a combination of mesh vertices and surface samples
         with vertices chosen by likelihood to be important
-        to registation.
+        to registration.
         """
         if len(m.vertices) < (count / 2):
             return np.vstack((

--- a/trimesh/transformations.py
+++ b/trimesh/transformations.py
@@ -2149,14 +2149,14 @@ def transform_points(points,
 
 def fix_rigid(matrix, max_deviance=1e-5):
     """
-    If a homogenous transformation matrix is *almost* a rigid
+    If a homogeneous transformation matrix is *almost* a rigid
     transform but many matrix-multiplies have accumulated some
     floating point error try to restore the matrix using SVD.
 
     Parameters
     -----------
     matrix : (4, 4) or (3, 3) float
-      Homogenous transformation matrix.
+      Homogeneous transformation matrix.
     max_deviance : float
       Do not alter the matrix if it is not rigid by more
       than this amount.
@@ -2164,7 +2164,7 @@ def fix_rigid(matrix, max_deviance=1e-5):
     Returns
     ----------
     repaired : (4, 4) or (3, 3) float
-      Repaired homogenous transformation matrix
+      Repaired homogeneous transformation matrix
     """
     dim = matrix.shape[0] - 1
     check = np.abs(np.dot(matrix[:dim, :dim], matrix[:dim, :dim].T)

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1466,8 +1466,9 @@ def concatenate(a, b=None):
         return []
 
     # extract the trimesh type to avoid a circular import
-    # and assert that both inputs are Trimesh objects
+    # and assert that all inputs are Trimesh objects
     trimesh_type = type_named(meshes[0], 'Trimesh')
+    assert all(isinstance(mesh, trimesh_type) for mesh in meshes)
 
     # append faces and vertices of meshes
     vertices, faces = append_faces(


### PR DESCRIPTION
See https://github.com/mikedh/trimesh/issues/1900

In util.concatenate(), there is a comment that says we are asserting that the meshes have trimesh type. However, we are only asserting on the first mesh. This leads to unhelpful attribute errors when dumping scenes that contain e.g. Path3D geometries. This change fixes this.
