### PR TITLE
Skip non-mesh geometries in scene dump concatenation

### DIFF
--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -843,6 +843,16 @@ class Scene(Geometry3D):
             transform, geometry_name = self.graph[node_name]
             # get a copy of the geometry
             current = self.geometry[geometry_name].copy()
+
+            if concatenate:
+                try:
+                    util.type_named(current, 'Trimesh')
+                except ValueError:
+                    util.log.warning(
+                        'Skipping non-mesh geometry in concatenation'
+                    )
+                    continue
+
             # move the geometry vertices into the requested frame
             current.apply_transform(transform)
             current.metadata['name'] = geometry_name


### PR DESCRIPTION
See #1902

Relates to #1900 and #1901

If a scene has non-mesh geometries, for example Path3Ds, scene.dump(concatenate=True) will fail. It is useful to have a way to still concatenate the meshes, skipping the others with a warning, and returning the result. This change implements this.