### PR TITLE
Release: Concat + Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ You can check out the [Github network](https://github.com/mikedh/trimesh/network
 - [urdfpy](https://github.com/mmatl/urdfpy) Load URDF robot descriptions in Python.
 - [moderngl-window](https://github.com/moderngl/moderngl-window) A helper to create GL contexts and load meshes.
 - [vedo](https://github.com/marcomusy/vedo) Visualize meshes interactively (see example [gallery](https://github.com/marcomusy/vedo/tree/master/examples/other/trimesh/)).
-- [fsleyes](https://users.fmrib.ox.ac.uk/~paulmc/fsleyes/userdoc/latest/quick_start.html) View MRI images and brain data.
+- [FSLeyes](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes) View MRI images and brain data.
 
 ## Which Mesh Format Should I Use?
 

--- a/docker/trimesh-setup
+++ b/docker/trimesh-setup
@@ -8,6 +8,7 @@ this exact configuration.
 """
 import os
 import sys
+import json
 import shutil
 import tarfile
 import tempfile
@@ -20,69 +21,91 @@ from fnmatch import fnmatch
 # define system packages for our debian docker image
 # someday possibly add this to the `pyproject.toml` config
 # but for now store them locally in the installer script
-config_toml = """
-[tool.trimesh-setup.apt]
-# for running with `trimesh-setup` usually in a Docker image
-# here are named groups of `apt-get install` Debian packages
-base = ["wget", "curl", "xz-utils", "git"]
-build = ["build-essential", "g++", "make"]
-docs = ["make", "pandoc"]
-llvmpipe = [
-  "libgl1-mesa-glx",
-  "libgl1-mesa-dri",
-  "xvfb",
-  "xauth",
-  "ca-certificates",
-  "freeglut3-dev"
-]
-test = ["blender", "openscad"]
-
-# libraries and tools that need to be downloaded are under `fetch`
-[tool.trimesh-setup.fetch.embree2]
-url = "https://github.com/embree/embree/releases/download/v2.17.7/embree-2.17.7.x86_64.linux.tar.gz"
-sha256 = "2c4bdacd8f3c3480991b99e85b8f584975ac181373a75f3e9675bf7efae501fe"
-target = "/usr/local"
-# the `bin` subdirectory is not required
-extract_skip = [ "bin/*", "doc/*", ]
-# skip the first component of the path in the archive
-# same behavior as in the `tar` command line interface
-strip_components = 1
-chmod = 755
-
-[tool.trimesh-setup.fetch.embree3]
-url = 'https://github.com/embree/embree/releases/download/v3.12.1/embree-3.12.1.x86_64.linux.tar.gz'
-sha256 = '5e218dd4e95c035c04aa893f7b1169ade11ecc57580e0027eae2ec84cdc9baff'
-target = "/usr/local"
-extract_skip = [ "bin/*", "doc/*", ]
-strip_components = 1
-
-
-[tool.trimesh-setup.fetch.embree4]
-url = 'https://github.com/embree/embree/releases/download/v4.0.0/embree-4.0.0.x86_64.linux.tar.gz'
-sha256 = '524842e2f141dca0db584c33a0821176373e7058f3ec2201bfb19d9e9a1b80b9'
-target = "/usr/local"
-extract_skip = [ "bin/*", "doc/*", ]
-strip_components = 1
-
-[tool.trimesh-setup.fetch.gltf_validator]
-url = 'https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz'
-sha256 = '374c7807e28fe481b5075f3bb271f580ddfc0af3e930a0449be94ec2c1f6f49a'
-target = "$PATH"
-chmod = 755
-extract_only = "gltf_validator"
-
-[tool.trimesh-setup.fetch.pandoc]
-url = 'https://github.com/jgm/pandoc/releases/download/3.1.1/pandoc-3.1.1-linux-amd64.tar.gz'
-sha256 = '52b25f0115517e32047a06d821e63729108027bd06d9605fe8eac0fa83e0bf81'
-target = "$PATH"
-chmod = 755
-extract_only = "pandoc"
-
-[tool.trimesh-setup.fetch.binvox]
-url = 'https://trimesh.s3-us-west-1.amazonaws.com/binvox'
-sha256 = '82ee314a75986f67f1d2b5b3ccdfb3661fe57a6b428aa0e0f798fdb3e1734fe0'
-target = "$PATH"
-chmod = 755
+config_json = """
+{
+  "apt": {
+    "base": [
+      "wget",
+      "curl",
+      "xz-utils",
+      "git"
+    ],
+    "build": [
+      "build-essential",
+      "g++",
+      "make"
+    ],
+    "docs": [
+      "make",
+      "pandoc"
+    ],
+    "llvmpipe": [
+      "libgl1-mesa-glx",
+      "libgl1-mesa-dri",
+      "xvfb",
+      "xauth",
+      "ca-certificates",
+      "freeglut3-dev"
+    ],
+    "test": [
+      "blender",
+      "openscad"
+    ]
+  },
+  "fetch": {
+    "embree2": {
+      "url": "https://github.com/embree/embree/releases/download/v2.17.7/embree-2.17.7.x86_64.linux.tar.gz",
+      "sha256": "2c4bdacd8f3c3480991b99e85b8f584975ac181373a75f3e9675bf7efae501fe",
+      "target": "/usr/local",
+      "extract_skip": [
+        "bin/*",
+        "doc/*"
+      ],
+      "strip_components": 1,
+      "chmod": 755
+    },
+    "embree3": {
+      "url": "https://github.com/embree/embree/releases/download/v3.12.1/embree-3.12.1.x86_64.linux.tar.gz",
+      "sha256": "5e218dd4e95c035c04aa893f7b1169ade11ecc57580e0027eae2ec84cdc9baff",
+      "target": "/usr/local",
+      "extract_skip": [
+        "bin/*",
+        "doc/*"
+      ],
+      "strip_components": 1
+    },
+    "embree4": {
+      "url": "https://github.com/embree/embree/releases/download/v4.0.0/embree-4.0.0.x86_64.linux.tar.gz",
+      "sha256": "524842e2f141dca0db584c33a0821176373e7058f3ec2201bfb19d9e9a1b80b9",
+      "target": "/usr/local",
+      "extract_skip": [
+        "bin/*",
+        "doc/*"
+      ],
+      "strip_components": 1
+    },
+    "gltf_validator": {
+      "url": "https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz",
+      "sha256": "374c7807e28fe481b5075f3bb271f580ddfc0af3e930a0449be94ec2c1f6f49a",
+      "target": "$PATH",
+      "chmod": 755,
+      "extract_only": "gltf_validator"
+    },
+    "pandoc": {
+      "url": "https://github.com/jgm/pandoc/releases/download/3.1.1/pandoc-3.1.1-linux-amd64.tar.gz",
+      "sha256": "52b25f0115517e32047a06d821e63729108027bd06d9605fe8eac0fa83e0bf81",
+      "target": "$PATH",
+      "chmod": 755,
+      "extract_only": "pandoc"
+    },
+    "binvox": {
+      "url": "https://trimesh.s3-us-west-1.amazonaws.com/binvox",
+      "sha256": "82ee314a75986f67f1d2b5b3ccdfb3661fe57a6b428aa0e0f798fdb3e1734fe0",
+      "target": "$PATH",
+      "chmod": 755
+    }
+  }
+}
 """
 
 
@@ -344,11 +367,11 @@ def handle_fetch(url,
             # python os.chmod takes an octal value
             os.chmod(path, int(str(chmod), base=8))
 
+
 def load_config():
     """
     """
-    from tomllib import loads
-    return loads(config_toml).get('tool', {}).get('trimesh-setup', {})
+    return json.loads(config_json)
 
 
 if __name__ == '__main__':
@@ -365,7 +388,7 @@ if __name__ == '__main__':
         '--install',
         type=str,
         action='append',
-        help=f'Install packages: {options}')
+        help=f'Install metapackages: {options}')
     args = parser.parse_args()
 
     # collect `apt-get install`-able package
@@ -375,11 +398,12 @@ if __name__ == '__main__':
 
     # allow comma delimeters and de-duplicate
     if args.install is None:
-        select = set()
+        parser.print_help()
+        exit()
     else:
         select = set(' '.join(args.install).replace(',', ' ').split())
 
-    log.debug(f'installing metapackages: {select}')
+    log.debug(f'installing metapackages: `{", ".join(select)}`')
 
     for key in select:
         for handle_name, handler in handlers.items():

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,9 +4,9 @@ sphinx==6.1.3
 jupyter==1.0.0
 sphinx_rtd_theme==1.2.0
 myst-parser==1.0.0
-pyopenssl==23.1.0
+pyopenssl==23.1.1
 autodocsumm==0.2.10
 jinja2==3.1.2
 matplotlib==3.7.1
-nbconvert==7.2.10
+nbconvert==7.3.1
 

--- a/models/obj_with_no_face_in_chunk.obj
+++ b/models/obj_with_no_face_in_chunk.obj
@@ -1,0 +1,9 @@
+g group1
+# of and space
+v 1 4 5
+v 1 2 3
+v 4 5 6
+
+g group2
+usemtl mat-1
+f 1 2 3

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -200,32 +200,41 @@ class CacheTest(g.unittest.TestCase):
         from trimesh.caching import tracked_array
 
         dim = (100, 3)
-        rng = np.random.RandomState(0)
 
         # generate a bunch of arguments for every function of an `ndarray` so
         # we can see if the functions mutate
-        flat = [2.3, 1, 10, 4.2, [3, -1], {'shape': 10}, np.int64, np.float64,
-                rng.random(dim), rng.random(dim[::1]), 'shape',
-                True, False]
+        flat = [2.3,
+                1,
+                10,
+                4.2,
+                [3, -1],
+                {'shape': 10},
+                np.int64,
+                np.float64,
+                True, True,
+                False, False,
+                g.random(dim),
+                g.random(dim[::1]),
+                'shape']
 
         # start with no arguments
         attempts = [tuple()]
         # add a single argument from our guesses
         attempts.extend([(A,) for A in flat])
         # add 2 and 3 length combinations of our guesses
-        attempts.extend([tuple(G) for G in itertools.combinations(flat, 2)])
-        attempts.extend([tuple(G) for G in itertools.combinations(flat, 3)])
-        attempts.extend([A[::-1] for A in attempts])
+        attempts.extend([tuple(G) for G in itertools.permutations(flat, 2)])
+        attempts.extend([tuple(G) for G in itertools.permutations(flat, 3)])
 
         # methods which mutate arrays
         mutate = []
         # collect functions which mutate arrays but don't change our hash
         broken = []
-        for method in list(dir(tracked_array(rng.random(dim)))):
-            failures = []
 
+        for method in list(dir(tracked_array(g.random(dim)))):
+            failures = []
+            g.log.debug('hash check: `{}`'.format(method))
             for A in attempts:
-                m = rng.random(dim)
+                m = g.random((100, 3))
                 true_pre = m.tobytes()
                 m = tracked_array(m)
                 hash_pre = hash(m)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -225,7 +225,7 @@ class CacheTest(g.unittest.TestCase):
                 hash_pre = hash(m)
 
                 try:
-                    eval(f'm.{method}(*A)')
+                    eval('m.{method}(*A)'.format(method=method))
                 except BaseException as J:
                     failures.append(str(J))
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -191,6 +191,10 @@ class CacheTest(g.unittest.TestCase):
         # of the subclassed `ndarray` and see if we can get trackedarray
         # to return incorrect hashes. Hopefully this catches new methods
 
+        # only run this test on python 3+ as they changed tobytes
+        if not g.PY3:
+            return
+
         import itertools
         import numpy as np
         from trimesh.caching import tracked_array

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -200,11 +200,13 @@ class CacheTest(g.unittest.TestCase):
         from trimesh.caching import tracked_array
 
         dim = (100, 3)
+        rng = np.random.RandomState(0)
 
         # generate a bunch of arguments for every function of an `ndarray` so
         # we can see if the functions mutate
         flat = [2.3, 1, 10, 4.2, [3, -1], {'shape': 10}, np.int64, np.float64,
-                np.random.random(dim), np.random.random(dim[::1]), 'shape']
+                rng.random(dim), rng.random(dim[::1]), 'shape',
+                True, False]
 
         # start with no arguments
         attempts = [tuple()]
@@ -219,11 +221,11 @@ class CacheTest(g.unittest.TestCase):
         mutate = []
         # collect functions which mutate arrays but don't change our hash
         broken = []
-        for method in list(dir(np.random.random(dim))):
+        for method in list(dir(tracked_array(rng.random(dim)))):
             failures = []
 
             for A in attempts:
-                m = np.random.random((100, 3))
+                m = rng.random(dim)
                 true_pre = m.tobytes()
                 m = tracked_array(m)
                 hash_pre = hash(m)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -221,12 +221,13 @@ class CacheTest(g.unittest.TestCase):
         attempts = [tuple()]
         # add a single argument from our guesses
         attempts.extend([(A,) for A in flat])
-        # add 2 and 3 length combinations of our guesses
+        # add 2 and 3 length permutations of our guesses
         attempts.extend([tuple(G) for G in itertools.permutations(flat, 2)])
-        attempts.extend([tuple(G) for G in itertools.permutations(flat, 3)])
 
-        # methods which mutate arrays
-        mutate = []
+        # adding 3-length permuations makes this test 10x slower but if you
+        # are suspicious of a method caching you could uncomment this out:
+        # attempts.extend([tuple(G) for G in itertools.permutations(flat, 3)])
+
         # collect functions which mutate arrays but don't change our hash
         broken = []
 
@@ -251,9 +252,6 @@ class CacheTest(g.unittest.TestCase):
                 # it indicates we have cached incorrectly
                 if (hash_pre == hash_post) != (true_pre == true_post):
                     broken.append((method, A))
-
-                if true_pre != true_post:
-                    mutate.append(method)
 
         if len(broken) > 0:
             method_busted = set([method for method, _ in broken])

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -86,6 +86,10 @@ class CacheTest(g.unittest.TestCase):
             # in place floor division :|
             a //= 2
             modified.append(hash(a))
+            # in-place sort
+            a.sort()
+            modified.append(hash(a))
+
             # these operations altered data and
             # the hash SHOULD have changed
             modified = g.np.array(modified, dtype=g.np.int64)

--- a/tests/test_convex.py
+++ b/tests/test_convex.py
@@ -19,9 +19,8 @@ class ConvexTest(g.unittest.TestCase):
                   (True, g.trimesh.creation.cylinder(
                       radius=1, height=10)),
                   (True, g.trimesh.creation.capsule()),
-                  (False, g.trimesh.creation.box(extents=(1,1,1)).union( \
-                      g.trimesh.creation.box(extents=(1,1,1), \
-                      transform=g.trimesh.transformations.translation_matrix((10,0,0)))))]
+                  (False, (g.trimesh.creation.box(extents=(1, 1, 1)) +
+                           g.trimesh.creation.box(bounds=[[10, 10, 10], [12, 12, 12]])))]
 
         for is_convex, mesh in meshes:
             assert mesh.is_watertight

--- a/tests/test_convex.py
+++ b/tests/test_convex.py
@@ -18,7 +18,10 @@ class ConvexTest(g.unittest.TestCase):
                   (True, g.trimesh.creation.box()),
                   (True, g.trimesh.creation.cylinder(
                       radius=1, height=10)),
-                  (True, g.trimesh.creation.capsule())]
+                  (True, g.trimesh.creation.capsule()),
+                  (False, g.trimesh.creation.box(extents=(1,1,1)).union( \
+                      g.trimesh.creation.box(extents=(1,1,1), \
+                      transform=g.trimesh.transformations.translation_matrix((10,0,0)))))]
 
         for is_convex, mesh in meshes:
             assert mesh.is_watertight

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -95,6 +95,8 @@ class CreationTest(g.unittest.TestCase):
             assert sphere.is_convex
             assert sphere.is_watertight
             assert sphere.is_winding_consistent
+
+            assert sphere.body_count == 1
             assert sphere.metadata['shape'] == 'sphere'
 
             # all vertices should have radius of exactly 1.0

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -87,6 +87,12 @@ class CreationTest(g.unittest.TestCase):
         assert len(mesh.split(only_watertight=True)) == 0
         assert len(mesh.split(only_watertight=False)) == count
 
+    def test_capsule(self):
+        mesh = g.trimesh.creation.capsule(radius=1.0, height=2.0)
+        assert mesh.is_volume
+        assert mesh.body_count == 1
+        assert g.np.allclose(mesh.extents, [2, 2, 4], atol=0.05)
+
     def test_spheres(self):
         # test generation of UV spheres and icospheres
         for sphere in [g.trimesh.creation.uv_sphere(),

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -906,6 +906,21 @@ class GLTFTest(g.unittest.TestCase):
         # will run a kdtree check
         g.texture_equal(s, m)
 
+    def test_gltf_by_name(self):
+        m = g.trimesh.creation.icosphere()
+
+        with g.TemporaryDirectory() as d:
+            # export the GLTF file by name
+            file_path = g.os.path.join(d, 'hi.gltf')
+            # export the file by path
+            m.export(file_path)
+            # reload the gltf from the file path
+            r = g.trimesh.load(file_path)
+
+            assert isinstance(r, g.trimesh.Scene)
+            assert len(r.geometry) == 1
+            assert g.np.isclose(next(iter(r.geometry.values())).volume, m.volume)
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -437,6 +437,12 @@ class OBJTest(g.unittest.TestCase):
         m = g.get_mesh('face_in_group_name_mid_file.obj')
         assert len(m.vertices) == 5
         assert len(m.faces) == 2
+        
+    def test_chunk_parsing_with_no_faces_but_with_f_in_chunk(self):
+        # Checks that a chunk with no faces but with 'f ' in it loads properly
+        m = g.get_mesh('obj_with_no_face_in_chunk.obj')
+        assert len(m.vertices) == 3
+        assert len(m.faces) == 1
 
 
 def simple_load(text):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -449,6 +449,13 @@ class SceneTests(g.unittest.TestCase):
         # scene bounds should exactly match mesh bounds
         assert g.np.allclose(m.bounds, dump.bounds)
 
+    def test_concatenate_mixed(self):
+        scene = g.trimesh.Scene([g.trimesh.creation.icosphere(),
+                                 g.trimesh.path.creation.rectangle([[0, 0], [1, 1]])])
+
+        dump = scene.dump(concatenate=True)
+        assert isinstance(dump, g.trimesh.Trimesh)
+
     def test_append_scenes(self):
         scene_0 = g.trimesh.Scene(base_frame='not_world')
         scene_1 = g.trimesh.Scene(base_frame='not_world')

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -465,6 +465,49 @@ class SceneTests(g.unittest.TestCase):
 
         assert scene_sum.graph.base_frame == 'not_world'
 
+    def test_scene_concat(self):
+        # check that primitives get upgraded to meshes
+        a = g.trimesh.Scene([g.trimesh.primitives.Sphere(center=[5,5,5]),
+                           g.trimesh.primitives.Box()])
+        c = a.dump(concatenate=True)
+        assert isinstance(c, g.trimesh.Trimesh)
+        assert g.np.allclose(c.bounds, a.bounds)
+
+        c = a.dump(concatenate=False)
+        assert len(c) == len(a.geometry)
+
+        # scene 2D
+        scene_2D = g.trimesh.Scene(g.get_mesh('2D/250_cycloidal.DXF').split())
+        concat = scene_2D.dump(concatenate=True)
+        assert isinstance(concat, g.trimesh.path.Path2D)
+
+
+        dump = scene_2D.dump(concatenate=False)
+        assert len(dump) == len(scene_2D.geometry)
+        assert all(isinstance(i, g.trimesh.path.Path2D) for i in dump)
+
+        # all Path3D objects
+        scene_3D = g.trimesh.Scene(
+            [i.to_3D() for i in
+             g.get_mesh('2D/250_cycloidal.DXF').split()])
+
+        dump= scene_3D.dump(concatenate=False)
+        assert len(dump) >= 5
+        assert all(isinstance(i, g.trimesh.path.Path3D) for i in dump)
+
+        concat = scene_3D.dump(concatenate=True)
+        assert isinstance(concat, g.trimesh.path.Path3D)
+
+        mixed = list(scene_2D.geometry.values())
+        mixed.extend(scene_3D.geometry.values())
+        scene_mixed = g.trimesh.Scene(mixed)
+
+        dump = scene_mixed.dump(concatenate=False)
+        assert len(dump) == len(mixed)
+
+        concat = scene_mixed.dump(concatenate=True)
+        assert isinstance(concat, g.trimesh.path.Path3D)
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -172,7 +172,8 @@ class TextureTest(g.unittest.TestCase):
 
         c = g.trimesh.util.concatenate(meshes)
         assert isinstance(c.visual, g.trimesh.visual.TextureVisuals)
-        assert (g.np.array(c.visual.material.image.size) >= 2).all()
+        assert len(c.faces) == sum(len(i.faces) for i in meshes)
+        assert g.np.product(c.visual.material.image.size) >= 4
 
         # convert texture back to color
         roundtrip = c.visual.to_color()

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -240,14 +240,8 @@ class TrackedArray(np.ndarray):
             # we have a valid hash without recomputing.
             return self._hashed
 
-        if self.flags['C_CONTIGUOUS']:
-            hashed = hash_fast(self)
-        else:
-            # the case where we have sliced our nice
-            # contiguous array into a non- contiguous block
-            # for example (note slice *after* track operation):
-            # t = tracked_array(np.random.random(10))[::-1]
-            hashed = hash_fast(np.ascontiguousarray(self))
+        # run a hashing function on the C-order bytes copy
+        hashed = hash_fast(self.tobytes(order='C'))
 
         # assign the value and set the flag
         self._hashed = hashed

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -342,6 +342,11 @@ class TrackedArray(np.ndarray):
         super(self.__class__, self).__setslice__(
             *args, **kwargs)
 
+    def sort(self, *args, **kwargs):
+        self._dirty_hash = True
+        super(self.__class__, self).sort(
+            *args, **kwargs)
+
 
 class Cache(object):
     """

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -272,6 +272,31 @@ class TrackedArray(np.ndarray):
         return super(self.__class__, self).__isub__(
             *args, **kwargs)
 
+    def fill(self, *args, **kwargs):
+        self._dirty_hash = True
+        return super(self.__class__, self).fill(
+            *args, **kwargs)
+
+    def partition(self, *args, **kwargs):
+        self._dirty_hash = True
+        return super(self.__class__, self).partition(
+            *args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        self._dirty_hash = True
+        return super(self.__class__, self).put(
+            *args, **kwargs)
+
+    def byteswap(self, *args, **kwargs):
+        self._dirty_hash = True
+        return super(self.__class__, self).byteswap(
+            *args, **kwargs)
+
+    def itemset(self, *args, **kwargs):
+        self._dirty_hash = True
+        return super(self.__class__, self).itemset(
+            *args, **kwargs)
+
     def __imul__(self, *args, **kwargs):
         self._dirty_hash = True
         return super(self.__class__, self).__imul__(

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -297,6 +297,16 @@ class TrackedArray(np.ndarray):
         return super(self.__class__, self).itemset(
             *args, **kwargs)
 
+    def sort(self, *args, **kwargs):
+        self._dirty_hash = True
+        return super(self.__class__, self).sort(
+            *args, **kwargs)
+
+    def setflags(self, *args, **kwargs):
+        self._dirty_hash = True
+        return super(self.__class__, self).setflags(
+            *args, **kwargs)
+
     def __imul__(self, *args, **kwargs):
         self._dirty_hash = True
         return super(self.__class__, self).__imul__(
@@ -359,17 +369,12 @@ class TrackedArray(np.ndarray):
 
     def __setitem__(self, *args, **kwargs):
         self._dirty_hash = True
-        super(self.__class__, self).__setitem__(
+        return super(self.__class__, self).__setitem__(
             *args, **kwargs)
 
     def __setslice__(self, *args, **kwargs):
         self._dirty_hash = True
-        super(self.__class__, self).__setslice__(
-            *args, **kwargs)
-
-    def sort(self, *args, **kwargs):
-        self._dirty_hash = True
-        super(self.__class__, self).sort(
+        return super(self.__class__, self).__setslice__(
             *args, **kwargs)
 
 

--- a/trimesh/convex.py
+++ b/trimesh/convex.py
@@ -197,6 +197,10 @@ def is_convex(mesh):
     if not mesh.is_watertight:
         return False
 
+    # meshes with multiple bodies are not convex
+    if mesh.body_count != 1:
+        return False
+
     # don't consider zero- area faces
     nonzero = mesh.area_faces > tol.zero
     # adjacencies with two nonzero faces

--- a/trimesh/convex.py
+++ b/trimesh/convex.py
@@ -194,11 +194,8 @@ def is_convex(mesh):
       Was passed mesh convex or not
     """
     # non-watertight meshes are not convex
-    if not mesh.is_watertight:
-        return False
-
     # meshes with multiple bodies are not convex
-    if mesh.body_count != 1:
+    if not mesh.is_watertight or mesh.body_count != 1:
         return False
 
     # don't consider zero- area faces
@@ -219,7 +216,6 @@ def is_convex(mesh):
     # if projections of vertex onto plane of adjacent
     # face is negative, it means the face pair is locally
     # convex, and if that is true for all faces the mesh is convex
-
     convex = bool(mesh.face_adjacency_projections[adj_ok].max() < threshold)
 
     return convex

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -164,6 +164,7 @@ def revolve(linestring,
         # it should really be a valid volume, unless the sign
         # reversed on the input linestring
         assert mesh.is_volume
+        assert mesh.body_count == 1
 
     return mesh
 
@@ -705,10 +706,7 @@ def icosphere(subdivisions=3, radius=1.0, color=None):
     return ico
 
 
-def uv_sphere(radius=1.0,
-              count=None,
-              theta=None,
-              phi=None):
+def uv_sphere(radius=1.0, count=None, transform=None):
     """
     Create a UV sphere (latitude + longitude) centered at the
     origin. Roughly one order of magnitude faster than an
@@ -720,16 +718,14 @@ def uv_sphere(radius=1.0,
       Radius of sphere
     count : (2,) int
       Number of latitude and longitude lines
-    theta : (n,) float
-      Optional theta angles in radians
-    phi :   (n,) float
-      Optional phi angles in radians
 
     Returns
     ----------
     mesh : trimesh.Trimesh
        Mesh of UV sphere with specified parameters
     """
+
+    # set the resolution of the uv sphere
     if count is None:
         count = np.array([32, 64], dtype=np.int64)
     else:
@@ -737,50 +733,16 @@ def uv_sphere(radius=1.0,
         count += np.mod(count, 2)
         count[1] *= 2
 
-    # generate vertices on a sphere using spherical coordinates
-    if theta is None:
-        theta = np.linspace(0, np.pi, count[0])
-    if phi is None:
-        phi = np.linspace(0, np.pi * 2, count[1])[:-1]
-    spherical = np.dstack((np.tile(phi, (len(theta), 1)).T,
-                           np.tile(theta, (len(phi), 1)))).reshape((-1, 2))
-    vertices = util.spherical_to_vector(spherical) * radius
+    # generate the 2D curve for the UV sphere
+    theta = np.linspace(0.0, np.pi, num=count[0])
+    linestring = np.column_stack((np.sin(theta), -np.cos(theta))) * radius
 
-    # generate faces by creating a bunch of pie wedges
-    c = len(theta)
-    # a quad face as two triangles
-    pairs = np.array([[c, 0, 1],
-                      [c + 1, c, 1]])
-
-    # increment both triangles in each quad face by the same offset
-    incrementor = np.tile(np.arange(c - 1), (2, 1)).T.reshape((-1, 1))
-    # create the faces for a single pie wedge of the sphere
-    strip = np.tile(pairs, (c - 1, 1))
-    strip += incrementor
-    # the first and last faces will be degenerate since the first
-    # and last vertex are identical in the two rows
-    strip = strip[1:-1]
-
-    # tile pie wedges into a sphere
-    faces = np.vstack([strip + (i * c) for i in range(len(phi))])
-
-    # poles are repeated in every strip, so a mask to merge them
-    mask = np.arange(len(vertices))
-    # the top pole are all the same vertex
-    mask[0::c] = 0
-    # the bottom pole are all the same vertex
-    mask[c - 1::c] = c - 1
-
-    # faces masked to remove the duplicated pole vertices
-    # and mod to wrap to fill in the last pie wedge
-    faces = mask[np.mod(faces, len(vertices))]
-
-    # we save a lot of time by not processing again
-    # since we did some bookkeeping mesh is watertight
-    mesh = Trimesh(vertices=vertices, faces=faces, process=False,
+    # revolve the curve to create a volume
+    return revolve(linestring=linestring,
+                   sections=count[1],
+                   transform=transform,
                    metadata={'shape': 'sphere',
                              'radius': radius})
-    return mesh
 
 
 def capsule(height=1.0,

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -751,7 +751,9 @@ def _preprocess_faces(text):
         # Discard the g tag line in the list of faces
         elif chunk.startswith('g '):
             _, chunk = chunk.split('\n', 1)
-        if 'f ' in chunk:
+        # If we have an f at the beginning of a line
+        # then add it to the list of faces chunks
+        if chunk.startswith('f ') or '\nf' in chunk:
             face_tuples.append((current_mtl, current_obj, chunk))
     return face_tuples
 

--- a/trimesh/path/util.py
+++ b/trimesh/path/util.py
@@ -20,6 +20,11 @@ def concatenate(paths):
     if len(paths) == 1:
         return paths[0].copy()
 
+    # upgrade to 3D if we have mixed 2D and 3D paths
+    dimensions = set(i.vertices.shape[1] for i in paths)
+    if len(dimensions) > 1:
+        paths = [i.to_3D() if hasattr(i, 'to_3D') else i for i in paths]
+
     # length of vertex arrays
     vert_len = np.array([len(i.vertices) for i in paths])
     # how much to offset each paths vertex indices by

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -71,7 +71,7 @@ def mesh_other(mesh,
         """
         Return a combination of mesh vertices and surface samples
         with vertices chosen by likelihood to be important
-        to registation.
+        to registration.
         """
         if len(m.vertices) < (count / 2):
             return np.vstack((

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -843,6 +843,16 @@ class Scene(Geometry3D):
             transform, geometry_name = self.graph[node_name]
             # get a copy of the geometry
             current = self.geometry[geometry_name].copy()
+
+            if concatenate:
+                try:
+                    util.type_named(current, 'Trimesh')
+                except ValueError:
+                    util.log.warning(
+                        'Skipping non-mesh geometry in concatenation'
+                    )
+                    continue
+
             # move the geometry vertices into the requested frame
             current.apply_transform(transform)
             current.metadata['name'] = geometry_name

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -851,10 +851,10 @@ class Scene(Geometry3D):
                 check = util.isclose(transform, util._IDENTITY, atol=1e-8)
                 check[:2, :3] = True
                 if not check.all():
-                    # transform moves in 3D
+                    # transform moves in 3D so we put this on the Z=0 plane
                     current = current.to_3D()
                 else:
-                    # transform moves in 2D
+                    # transform moves in 2D so clip off the last row and column
                     transform = transform[:3, :3]
 
             # move the geometry vertices into the requested frame

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -834,24 +834,28 @@ class Scene(Geometry3D):
 
         Returns
         ----------
-        dumped : (n,) Trimesh or Trimesh
-          Trimesh objects transformed to their
-          location the scene.graph
+        dumped : (n,) Trimesh, Path2D, Path3D, PointCloud
+          Depending on what the scene contains. If `concatenate`
+          then some geometry may be dropped if it doesn't match.
         """
+
         result = []
         for node_name in self.graph.nodes_geometry:
             transform, geometry_name = self.graph[node_name]
             # get a copy of the geometry
             current = self.geometry[geometry_name].copy()
 
-            if concatenate:
-                try:
-                    util.type_named(current, 'Trimesh')
-                except ValueError:
-                    util.log.warning(
-                        'Skipping non-mesh geometry in concatenation'
-                    )
-                    continue
+            # if the geometry is 2D see if we have to upgrade to 3D
+            if hasattr(current, 'to_3D'):
+                # check to see if the scene is transforming the path out of plane
+                check = util.isclose(transform, util._IDENTITY, atol=1e-8)
+                check[:2, :3] = True
+                if not check.all():
+                    # transform moves in 3D
+                    current = current.to_3D()
+                else:
+                    # transform moves in 2D
+                    transform = transform[:3, :3]
 
             # move the geometry vertices into the requested frame
             current.apply_transform(transform)
@@ -862,6 +866,7 @@ class Scene(Geometry3D):
             result.append(current)
 
         if concatenate:
+            # if scene has mixed geometry this may drop some of it
             return util.concatenate(result)
 
         return np.array(result)

--- a/trimesh/transformations.py
+++ b/trimesh/transformations.py
@@ -2149,14 +2149,14 @@ def transform_points(points,
 
 def fix_rigid(matrix, max_deviance=1e-5):
     """
-    If a homogenous transformation matrix is *almost* a rigid
+    If a homogeneous transformation matrix is *almost* a rigid
     transform but many matrix-multiplies have accumulated some
     floating point error try to restore the matrix using SVD.
 
     Parameters
     -----------
     matrix : (4, 4) or (3, 3) float
-      Homogenous transformation matrix.
+      Homogeneous transformation matrix.
     max_deviance : float
       Do not alter the matrix if it is not rigid by more
       than this amount.
@@ -2164,7 +2164,7 @@ def fix_rigid(matrix, max_deviance=1e-5):
     Returns
     ----------
     repaired : (4, 4) or (3, 3) float
-      Repaired homogenous transformation matrix
+      Repaired homogeneous transformation matrix
     """
     dim = matrix.shape[0] - 1
     check = np.abs(np.dot(matrix[:dim, :dim], matrix[:dim, :dim].T)

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -70,6 +70,9 @@ TOL_MERGE = 1e-8
 # enable additional potentially slow checks
 _STRICT = False
 
+_IDENTITY = np.eye(4, dtype=np.float64)
+_IDENTITY.flags['WRITEABLE'] = False
+
 
 def has_module(name):
     """
@@ -1408,9 +1411,7 @@ def type_bases(obj, depth=4):
         bases = np.hstack(bases)
     except IndexError:
         bases = []
-    # we do the hasattr as None/NoneType can be in the list of bases
-    bases = [i for i in bases if hasattr(i, '__name__')]
-    return np.array(bases)
+    return [i for i in bases if hasattr(i, '__name__')]
 
 
 def type_named(obj, name):
@@ -1420,12 +1421,15 @@ def type_named(obj, name):
 
     Parameters
     ------------
-    obj: object to look for class of
-    name : str, name of class
+    obj : any
+      Object to look for class of
+    name : str
+      Nnme of class
 
     Returns
     ----------
-    named class, or None
+    class : Optional[Callable]
+      Camed class, or None
     """
     # if obj is a member of the named class, return True
     name = str(name)
@@ -1454,37 +1458,56 @@ def concatenate(a, b=None):
     result : trimesh.Trimesh
       Concatenated mesh
     """
-    if b is None:
-        b = []
-    # stack meshes into flat list
-    meshes = np.append(a, b)
 
-    # if there is only one mesh just return the first
-    if len(meshes) == 1:
-        return meshes[0].copy()
-    elif len(meshes) == 0:
+    # get a flat list of meshes
+    flat = []
+    if a is not None:
+        if is_sequence(a):
+            flat.extend(a)
+        else:
+            flat.append(a)
+    if b is not None:
+        if is_sequence(b):
+            flat.extend(b)
+        else:
+            flat.append(b)
+
+    if len(flat) == 1:
+        # if there is only one mesh just return the first
+        return flat[0].copy()
+    elif len(flat) == 0:
+        # if there are no meshes return an empty list
+        return []
+
+    is_mesh = [f for f in flat if is_instance_named(f, 'Trimesh')]
+    is_path = [f for f in flat if is_instance_named(f, 'Path')]
+
+    if len(is_path) > len(is_mesh):
+        from .path.util import concatenate as concatenate_path
+        return concatenate_path(is_path)
+
+    if len(is_mesh) == 0:
         return []
 
     # extract the trimesh type to avoid a circular import
     # and assert that all inputs are Trimesh objects
-    trimesh_type = type_named(meshes[0], 'Trimesh')
-    assert all(isinstance(mesh, trimesh_type) for mesh in meshes)
+    trimesh_type = type_named(is_mesh[0], 'Trimesh')
 
     # append faces and vertices of meshes
     vertices, faces = append_faces(
-        [m.vertices.copy() for m in meshes],
-        [m.faces.copy() for m in meshes])
+        [m.vertices.copy() for m in is_mesh],
+        [m.faces.copy() for m in is_mesh])
 
     # only save face normals if already calculated
     face_normals = None
-    if all('face_normals' in m._cache for m in meshes):
+    if all('face_normals' in m._cache for m in is_mesh):
         face_normals = np.vstack(
-            [m.face_normals for m in meshes])
+            [m.face_normals for m in is_mesh])
 
     try:
         # concatenate visuals
-        visual = meshes[0].visual.concatenate(
-            [m.visual for m in meshes[1:]])
+        visual = is_mesh[0].visual.concatenate(
+            [m.visual for m in is_mesh[1:]])
     except BaseException:
         log.debug('failed to combine visuals', exc_info=True)
         visual = None

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1466,8 +1466,9 @@ def concatenate(a, b=None):
         return []
 
     # extract the trimesh type to avoid a circular import
-    # and assert that both inputs are Trimesh objects
+    # and assert that all inputs are Trimesh objects
     trimesh_type = type_named(meshes[0], 'Trimesh')
+    assert all(isinstance(mesh, trimesh_type) for mesh in meshes)
 
     # append faces and vertices of meshes
     vertices, faces = append_faces(

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.21.5'
+__version__ = '3.21.6'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script


### PR DESCRIPTION
- release #1912 fixing caching bug on `TrackedArray`
  - added test which runs through all methods and tries to break our hashing, which caught the same bug on `{'put', 'itemset', 'byteswap', 'sort', 'fill', 'partition', 'setflags'}` which are now fixed. 
  - switched hash of `hash_function(object)` to `hash_function(object.tobytes(order='C'))` which seems slightly slower in some cases, but I'm a little unclear as to what properties the hash function was actually hashing before even though it worked. This also removes a conditional inside our check block as we're always hashing on the C-order version of the data.
- release #1904 fixing readme 
- release #1917 and also convert `trimesh.creation.uv_sphere` to use the `revolve` method which fixes a bookkeeping issue. 
- release #1903 and #1901 which update the concatenate logic to handle mixed values
