### PR TITLE
[WIP] Convexity Check Patch

### DIFF
--- a/tests/test_convex.py
+++ b/tests/test_convex.py
@@ -18,7 +18,10 @@ class ConvexTest(g.unittest.TestCase):
                   (True, g.trimesh.creation.box()),
                   (True, g.trimesh.creation.cylinder(
                       radius=1, height=10)),
-                  (True, g.trimesh.creation.capsule())]
+                  (True, g.trimesh.creation.capsule()),
+                  (False, g.trimesh.creation.box(extents=(1,1,1)).union( \
+                      g.trimesh.creation.box(extents=(1,1,1), \
+                      transform=g.trimesh.transformations.translation_matrix((10,0,0)))))]
 
         for is_convex, mesh in meshes:
             assert mesh.is_watertight

--- a/trimesh/convex.py
+++ b/trimesh/convex.py
@@ -197,6 +197,10 @@ def is_convex(mesh):
     if not mesh.is_watertight:
         return False
 
+    # meshes with multiple bodies are not convex
+    if mesh.body_count != 1:
+        return False
+
     # don't consider zero- area faces
     nonzero = mesh.area_faces > tol.zero
     # adjacencies with two nonzero faces


### PR DESCRIPTION
The current `is_convex` check for meshes returns true for trimesh objects containing disjoint meshes that are individually convex. I've added a test case for this in `test_convex.py`. I also tried to do a quick patch for the problem by just checking `body_count` of the mesh, and returning false if it is greater than 1. This also causes an issue as it looks like the uv_sphere in the test has a body count of 125 (even though it appears to be a single body). Any advice for how to fix this issue?