### PR TITLE
Checks that only chunks having faces are added to faces tuples

### DIFF
--- a/models/obj_with_no_face_in_chunk.obj
+++ b/models/obj_with_no_face_in_chunk.obj
@@ -1,0 +1,9 @@
+g group1
+# of and space
+v 1 4 5
+v 1 2 3
+v 4 5 6
+
+g group2
+usemtl mat-1
+f 1 2 3

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -437,6 +437,12 @@ class OBJTest(g.unittest.TestCase):
         m = g.get_mesh('face_in_group_name_mid_file.obj')
         assert len(m.vertices) == 5
         assert len(m.faces) == 2
+        
+    def test_chunk_parsing_with_no_faces_but_with_f_in_chunk(self):
+        # Checks that a chunk with no faces but with 'f ' in it loads properly
+        m = g.get_mesh('obj_with_no_face_in_chunk.obj')
+        assert len(m.vertices) == 3
+        assert len(m.faces) == 1
 
 
 def simple_load(text):

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -751,7 +751,9 @@ def _preprocess_faces(text):
         # Discard the g tag line in the list of faces
         elif chunk.startswith('g '):
             _, chunk = chunk.split('\n', 1)
-        if 'f ' in chunk:
+        # If we have an f at the beginning of a line
+        # then add it to the list of faces chunks
+        if chunk.startswith('f ') or '\nf' in chunk:
             face_tuples.append((current_mtl, current_obj, chunk))
     return face_tuples
 


### PR DESCRIPTION
Covers a rare case where a chunk could contain 'f ' without having a face when loading an obj.

This rare case happens when a comment in a group having no faces contains 'f '.

The fix checks that at least one line in the chunk starts with 'f ', which is the proper definition of a face.

An alternative solution would be to remove comment lines (starting with #) but checking for the actual occurence of at least one face felt more appropriate.