### PR TITLE
Two problems were solved about exporting a mesh into a GLTF format.

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -75,7 +75,9 @@ def export_gltf(scene,
                 include_normals=None,
                 merge_buffers=False,
                 unitize_normals=False,
-                tree_postprocessor=None):
+                tree_postprocessor=None,
+                embed_buffer=False,
+                return_json_string=False):
     """
     Export a scene object as a GLTF directory.
 
@@ -94,6 +96,10 @@ def export_gltf(scene,
       If passed will use to write each file.
     tree_postprocesser : None or callable
       Run this on the header tree before exiting.
+    embed_buffer : bool
+      Embed the buffer into the uri.
+    return_json_string : bool
+      return a JSON string if True, a dict if False.
 
     Returns
     ----------
@@ -118,13 +124,18 @@ def export_gltf(scene,
     # store files as {name : data}
     files = {}
 
+    embed_buffer_format = "data:application/octet-stream;base64,{}"
     if merge_buffers:
         views = _build_views(buffer_items)
-        buffer_name = "gltf_buffer.bin"
         buffer_data = bytes().join(buffer_items.values())
+        if embed_buffer:
+            buffer_name = embed_buffer_format.format(
+                    base64.b64encode(buffer_data).decode())
+        else:
+            buffer_name = "gltf_buffer.bin"
+            files[buffer_name] = buffer_data
         buffers = [{"uri": buffer_name,
                     "byteLength": len(buffer_data)}]
-        files[buffer_name] = buffer_data
     else:
         # make one buffer per buffer_items
         buffers = [None] * len(buffer_items)
@@ -135,10 +146,14 @@ def export_gltf(scene,
             views[i] = {"buffer": i,
                         "byteOffset": 0,
                         "byteLength": len(item)}
-            buffer_name = "gltf_buffer_{}.bin".format(i)
+            if embed_buffer:
+                buffer_name = embed_buffer_format.format(
+                        base64.b64encode(item).decode())
+            else:
+                buffer_name = "gltf_buffer_{}.bin".format(i)
+                files[buffer_name] = item
             buffers[i] = {"uri": buffer_name,
                           "byteLength": len(item)}
-            files[buffer_name] = item
 
     if len(buffers) > 0:
         tree["buffers"] = buffers
@@ -150,7 +165,10 @@ def export_gltf(scene,
     if tol.strict:
         validate(tree)
 
-    return files
+    if return_json_string:
+        return files["model.gltf"]
+    else:
+        return files
 
 
 def export_glb(


### PR DESCRIPTION
## version

>>> trimesh.__version__
'3.21.5'

## Problem 1

when I tried to export a mesh into a GLTF format, it failed.  This is because export_gltf() in gltf.py always return a dict.  But, export_mesh() expectes to have a string.

```
Traceback (most recent call last):
  File "/tmp/trimesh/test1.py", line 5, in <module>
    trimesh.exchange.export.export_mesh(mesh_tri, "mesh.gltf")
  File "/home/sakane/.local/lib/python3.10/site-packages/trimesh/exchange/export.py", line 86, in export_mesh
    result = util.write_encoded(file_obj, export)
  File "/home/sakane/.local/lib/python3.10/site-packages/trimesh/util.py", line 2099, in write_encoded
    file_obj.write(stuff)
TypeError: a bytes-like object is required, not 'dict'
```

The reproduction code is like below.

```
import trimesh

mesh_tri = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]],
                           faces=[[0, 1, 2]])
trimesh.exchange.export.export_mesh(mesh_tri, "mesh.gltf")
```

## Problem 2

export_gltf() doesn't support to embed the buffer into the Uri.

## an idea to solve for the problem 1

Added a flag into export_gltf() to return a JSON string.  The default of the flag is False.  It means to return a dict to preserve the original behavior.

## an idea to solve for the problem 2

Added a flag into export_gltf() to embed the buffer into the URI.  The default of the flag is False.  It means to put the buffer into a different place in the dict to preserve the original behavior.

## proposal fix and the flags.

I made a pull request that solves above two problem.

When return_json_strin is true, it can export GLTF into a file.

```
import trimesh

mesh_tri = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]],
                           faces=[[0, 1, 2]])
trimesh.exchange.export.export_mesh(mesh_tri, "mesh.gltf",
                                    return_json_string=True)
```

When embed_buffer is true, it embeds the buffer into the URI.

```
import trimesh

mesh_tri = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]],
                           faces=[[0, 1, 2]])
trimesh.exchange.export.export_mesh(mesh_tri, "mesh.gltf",
                                    embed_buffer=True,
                                    return_json_string=True)
```

