### PR TITLE
Bugfix/1933 mesh other pass kwargs

### DIFF
--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -158,6 +158,12 @@ class RegistrationTest(g.unittest.TestCase):
 
         assert distance.mean() < noise
 
+    def test_mesh_no_reflection(self):
+        # see if ICP alignment works with meshes
+        m = g.trimesh.creation.box()
+        matrix, cost = g.trimesh.registration.mesh_other(
+            m, m, scale=False, reflection=False)
+        assert(cost < 0.01)
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -25,9 +25,9 @@ except BaseException as E:
 def mesh_other(mesh,
                other,
                samples=500,
-               scale=False,
                icp_first=10,
-               icp_final=50):
+               icp_final=50,
+               **kwargs):
     """
     Align a mesh with another mesh or a PointCloud using
     the principal axes of inertia as a starting point which
@@ -41,14 +41,14 @@ def mesh_other(mesh,
       Mesh or points in space
     samples : int
       Number of samples from mesh surface to align
-    scale : bool
-      Allow scaling in transform
     icp_first : int
       How many ICP iterations for the 9 possible
       combinations of sign flippage
     icp_final : int
       How many ICP iterations for the closest
       candidate from the wider search
+    **kwargs : Passed through to icp, which passes through to procrustes
+
 
     Returns
     -----------
@@ -145,7 +145,7 @@ def mesh_other(mesh,
                                  b=search,
                                  initial=a_to_b,
                                  max_iterations=int(icp_first),
-                                 scale=scale)
+                                 **kwargs)
 
         # save transform and costs from ICP
         transforms[i] = matrix
@@ -156,7 +156,7 @@ def mesh_other(mesh,
                              b=search,
                              initial=transforms[np.argmin(costs)],
                              max_iterations=int(icp_final),
-                             scale=scale)
+                             **kwargs)
 
     # convert to per- point distance average
     cost /= len(points)


### PR DESCRIPTION
Fixing https://github.com/mikedh/trimesh/issues/1933 by actually passing on kwargs to ICP as described in docu for version 3.21.7.

Scale no longer needs to be explicitly passed on, is now part of kwargs.