### PR TITLE
Release: EmbreeX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ LABEL maintainer="mikedh@kerfed.com"
 COPY --chmod=755 docker/trimesh-setup /usr/local/bin/
 
 # Install base `apt` packages required for everything
-# Install `embree`, Intel's fast ray checking engine
-RUN trimesh-setup --install base,embree2
+RUN trimesh-setup --install base
 
 # Create a local non-root user.
 RUN useradd -m -s /bin/bash user
@@ -32,7 +31,6 @@ USER user
 
 # install trimesh into .local
 RUN pip install /home/user[all]
-RUN pip install https://github.com/scopatz/pyembree/releases/download/0.1.6/pyembree-0.1.6.tar.gz
 
 ####################################
 ### Build output image most things should run on

--- a/docker/trimesh-setup
+++ b/docker/trimesh-setup
@@ -53,37 +53,6 @@ config_json = """
     ]
   },
   "fetch": {
-    "embree2": {
-      "url": "https://github.com/embree/embree/releases/download/v2.17.7/embree-2.17.7.x86_64.linux.tar.gz",
-      "sha256": "2c4bdacd8f3c3480991b99e85b8f584975ac181373a75f3e9675bf7efae501fe",
-      "target": "/usr/local",
-      "extract_skip": [
-        "bin/*",
-        "doc/*"
-      ],
-      "strip_components": 1,
-      "chmod": 755
-    },
-    "embree3": {
-      "url": "https://github.com/embree/embree/releases/download/v3.12.1/embree-3.12.1.x86_64.linux.tar.gz",
-      "sha256": "5e218dd4e95c035c04aa893f7b1169ade11ecc57580e0027eae2ec84cdc9baff",
-      "target": "/usr/local",
-      "extract_skip": [
-        "bin/*",
-        "doc/*"
-      ],
-      "strip_components": 1
-    },
-    "embree4": {
-      "url": "https://github.com/embree/embree/releases/download/v4.0.0/embree-4.0.0.x86_64.linux.tar.gz",
-      "sha256": "524842e2f141dca0db584c33a0821176373e7058f3ec2201bfb19d9e9a1b80b9",
-      "target": "/usr/local",
-      "extract_skip": [
-        "bin/*",
-        "doc/*"
-      ],
-      "strip_components": 1
-    },
     "gltf_validator": {
       "url": "https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz",
       "sha256": "374c7807e28fe481b5075f3bb271f580ddfc0af3e930a0449be94ec2c1f6f49a",

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,10 @@ if os.path.exists('README.md'):
         long_description = f.read()
 
 # minimal requirements for installing trimesh
-# note that `pip` requires setuptools itself
 requirements_default = set(['numpy'])
 
 # "easy" requirements should install without compiling
-# anything on Windows, Linux, and Mac, for Python 3.6+
+# anything on Windows, Linux, and Mac, for Python >= 3.6
 requirements_easy = set([
     'scipy',     # provide convex hulls, fast graph ops, etc
     'networkx',  # provide slow graph ops with a nice API
@@ -41,6 +40,7 @@ requirements_easy = set([
     'svg.path',  # handle SVG format path strings
     'sympy',     # do analytical math
     'pillow',    # load images
+    'embreex',   # Intel's Embree ray check engine with wheels
     'requests',  # do network requests
     'xxhash',    # hash ndarrays faster than built-in MD5/CRC
     'setuptools',  # do setuptools stuff
@@ -60,7 +60,6 @@ requirements_all = requirements_easy.union([
     'meshio',        # load a number of additional mesh formats; Python 3.5+
     'scikit-image',  # marching cubes and other nice stuff
     'xatlas',        # texture unwrapping
-    'embreex',   # Intel's Embree ray check engine with wheels
     'pyglet<2',  # render preview windows nicely : note pyglet 2.0 is basically a re-write
 ])
 # requirements for running unit tests

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if os.path.exists('README.md'):
 requirements_default = set(['numpy'])
 
 # "easy" requirements should install without compiling
-# anything on Windows, Linux, and Mac, for Python 2.7-3.4+
+# anything on Windows, Linux, and Mac, for Python 3.6+
 requirements_easy = set([
     'scipy',     # provide convex hulls, fast graph ops, etc
     'networkx',  # provide slow graph ops with a nice API
@@ -60,6 +60,7 @@ requirements_all = requirements_easy.union([
     'meshio',        # load a number of additional mesh formats; Python 3.5+
     'scikit-image',  # marching cubes and other nice stuff
     'xatlas',        # texture unwrapping
+    'embreex',   # Intel's Embree ray check engine with wheels
     'pyglet<2',  # render preview windows nicely : note pyglet 2.0 is basically a re-write
 ])
 # requirements for running unit tests

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ lock = [((3, 4), 'lxml', '4.3.5'),
         ((3, 6), 'pyglet<2', None),
         ((3, 6), 'autopep8', None),
         ((3, 6), 'ruff', None),
+        ((3, 5), 'embreex', None),
         ((3, 6), 'svg.path', '4.1')]
 for max_python, name, version in lock:
     if current <= max_python:

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -103,8 +103,8 @@ class RayTests(g.unittest.TestCase):
             assert test_centroid.all()
 
     def test_on_vertex(self):
-        for _use_embree in [True, False]:
-            m = g.trimesh.primitives.Box(use_embree=False)
+        for use_embree in [False]:
+            m = g.trimesh.creation.box(use_embree=use_embree)
 
             origins = g.np.zeros_like(m.vertices)
             vectors = m.vertices.copy()
@@ -123,8 +123,8 @@ class RayTests(g.unittest.TestCase):
             assert (hit_count == 1).all()
 
     def test_on_edge(self):
-        for _use_embree in [True, False]:
-            m = g.get_mesh('7_8ths_cube.stl')
+        for use_embree in [True, False]:
+            m = g.get_mesh('7_8ths_cube.stl', use_embree=use_embree)
 
             points = [[4.5, 0, -23], [4.5, 0, -2], [0, 0, -1e-6], [0, 0, -1]]
             truth = [False, True, True, True]
@@ -156,8 +156,8 @@ class RayTests(g.unittest.TestCase):
 
         for use_embree in [True, False]:
             # Generate a 1 x 1 x 1 cube using the trimesh box primitive
-            cube_mesh = g.trimesh.primitives.Box(extents=[2, 2, 2],
-                                                 use_embree=use_embree)
+            cube_mesh = g.trimesh.creation.box(extents=[2, 2, 2],
+                                               use_embree=use_embree)
 
             # Perform 256 * 256 raycasts, one for each pixel on the image
             # plane. We only want the 'first' hit.

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -75,12 +75,18 @@ class SampleTest(g.unittest.TestCase):
     def test_deterministic_sample(self):
         m = g.get_mesh('featuretype.STL')
 
-        # Deterministic execution
-        even_first, index_first = g.trimesh.sample.sample_surface_even(m, 1000)
-        even_last, index_last = g.trimesh.sample.sample_surface_even(m, 1000)
-        
+        # Without seed passed should return non-deterministic results
+        even_first, index_first = g.trimesh.sample.sample_surface(m, 10000)
+        even_last, index_last = g.trimesh.sample.sample_surface(m, 10000)
+        assert not (even_first == even_last).all()
+        assert not (index_first == index_last).all()
+
+        # With seed passed should return identical results
+        even_first, index_first = g.trimesh.sample.sample_surface(m, 10000, seed=10)
+        even_last, index_last = g.trimesh.sample.sample_surface(m, 10000, seed=10)
         assert (even_first == even_last).all()
         assert (index_first == index_last).all()
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -1,14 +1,14 @@
 """
-Ray queries using the pyembree package with the
+Ray queries using the embreex package with the
 API wrapped to match our native raytracer.
 """
 import numpy as np
 
 from copy import deepcopy
 
-from pyembree import __version__ as _wrapper_version
-from pyembree import rtcore_scene
-from pyembree.mesh_construction import TriangleMesh
+from embreex import __version__ as _wrapper_version
+from embreex import rtcore_scene
+from embreex.mesh_construction import TriangleMesh
 
 from .ray_util import contains_points
 
@@ -24,7 +24,7 @@ _ray_offset_factor = 1e-4
 # we want to clip our offset to a sane distance
 _ray_offset_floor = 1e-8
 
-# see if we're using a newer version of the pyembree wrapper
+# see if we're using a newer version of the embreex wrapper
 _embree_new = tuple([int(i) for i in _wrapper_version.split('.')]) >= (0, 1, 4)
 # both old and new versions require exact but different type
 _embree_dtype = [np.float64, np.float32][int(_embree_new)]
@@ -68,7 +68,7 @@ class RayMeshIntersector(object):
     @caching.cache_decorator
     def _scene(self):
         """
-        A cached version of the pyembree scene.
+        A cached version of the embreex scene.
         """
         return _EmbreeWrap(vertices=self.mesh.vertices,
                            faces=self.mesh.faces,
@@ -176,7 +176,7 @@ class RayMeshIntersector(object):
         # if a ray is offset from a triangle and then is reported
         # hitting itself this could get stuck on that one triangle
         for _ in range(max_hits):
-            # run the pyembree query
+            # run the embreex query
             # if you set output=1 it will calculate distance along
             # ray, which is bizzarely slower than our calculation
 
@@ -319,7 +319,7 @@ class RayMeshIntersector(object):
 
 class _EmbreeWrap(object):
     """
-    A light wrapper for PyEmbree scene objects which
+    A light wrapper for Embreex scene objects which
     allows queries to be scaled to help with precision
     issues, as well as selecting the correct dtypes.
     """

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -22,8 +22,7 @@ from ..constants import log_time
 _ray_offset_factor = 1e-4
 # we want to clip our offset to a sane distance
 _ray_offset_floor = 1e-8
-
-# both old and new versions require exact but different type
+# pass embree floats as 32 bit
 _embree_dtype = np.float32
 
 

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -23,10 +23,8 @@ _ray_offset_factor = 1e-4
 # we want to clip our offset to a sane distance
 _ray_offset_floor = 1e-8
 
-# see if we're using a newer version of the embreex wrapper
-_embree_new = tuple([int(i) for i in _wrapper_version.split('.')]) >= (0, 1, 4)
 # both old and new versions require exact but different type
-_embree_dtype = [np.float64, np.float32][int(_embree_new)]
+_embree_dtype = np.float32
 
 
 class RayMeshIntersector(object):

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from copy import deepcopy
 
-from embreex import __version__ as _wrapper_version
 from embreex import rtcore_scene
 from embreex.mesh_construction import TriangleMesh
 

--- a/trimesh/sample.py
+++ b/trimesh/sample.py
@@ -15,8 +15,12 @@ if hasattr(np.random, 'default_rng'):
     # newer versions of Numpy
     default_rng = np.random.default_rng
 else:
-    # Python 2 numpy
-    default_rng = np.random.RandomState
+    # Python 2 Numpy
+    def default_rng(seed):
+        rng = np.random.RandomState(seed)
+        # provide the same interface as the new default_rng
+        rng.random = rng.__call__
+        return rng
 
 
 def sample_surface(mesh, count, face_weight=None, sample_color=False, seed=None):

--- a/trimesh/sample.py
+++ b/trimesh/sample.py
@@ -19,7 +19,7 @@ else:
     def default_rng(seed):
         rng = np.random.RandomState(seed)
         # provide the same interface as the new default_rng
-        rng.random = rng.__call__
+        rng.random = rng
         return rng
 
 

--- a/trimesh/sample.py
+++ b/trimesh/sample.py
@@ -11,6 +11,13 @@ from . import util
 from . import transformations
 from .visual import uv_to_interpolated_color
 
+if hasattr(np.random, 'default_rng'):
+    # newer versions of Numpy
+    default_rng = np.random.default_rng
+else:
+    # Python 2 numpy
+    default_rng = np.random.RandomState
+
 
 def sample_surface(mesh, count, face_weight=None, sample_color=False, seed=None):
     """
@@ -33,7 +40,9 @@ def sample_surface(mesh, count, face_weight=None, sample_color=False, seed=None)
       Option to calculate the color of the sampled points.
       Default is False.
     seed : None or int
-      Provides deterministic values
+      If passed as an integer will provide deterministic results
+      otherwise pulls the seed from operating system entropy.
+
     Returns
     ---------
     samples : (count, 3) float
@@ -50,15 +59,14 @@ def sample_surface(mesh, count, face_weight=None, sample_color=False, seed=None)
         # of each face of the mesh
         face_weight = mesh.area_faces
 
-    # seed used to provide deterministic values
-    if seed is None :
-        seed = np.random.randint(1)
     # cumulative sum of weights (len(mesh.faces))
     weight_cum = np.cumsum(face_weight)
 
+    # seed the random number generator as requested
+    random = default_rng(seed).random
+
     # last value of cumulative sum is total summed weight/area
-    rng = np.random.default_rng(seed)
-    face_pick = rng.random(count) * weight_cum[-1]
+    face_pick = random(count) * weight_cum[-1]
     # get the index of the selected faces
     face_index = np.searchsorted(weight_cum, face_pick)
 
@@ -79,9 +87,8 @@ def sample_surface(mesh, count, face_weight=None, sample_color=False, seed=None)
         uv_origins = uv_origins[face_index]
         uv_vectors = uv_vectors[face_index]
 
-    # randomly generate two 0-1 scalar components to multiply edge vectors by
-    rnge = np.random.default_rng(seed)
-    random_lengths = rnge.random((len(tri_vectors), 2, 1))
+    # randomly generate two 0-1 scalar components to multiply edge vectors b
+    random_lengths = random((len(tri_vectors), 2, 1))
 
     # points will be distributed on a quadrilateral if we use 2 0-1 samples
     # if the two scalar components sum less than 1.0 the point will be
@@ -184,7 +191,7 @@ def sample_surface_even(mesh, count, radius=None, seed=None):
     radius : None or float
       Removes samples below this radius
     seed : None or int
-      Provides deterministic values 
+      Provides deterministic values
 
     Returns
     ---------
@@ -200,7 +207,7 @@ def sample_surface_even(mesh, count, radius=None, seed=None):
         radius = np.sqrt(mesh.area / (3 * count))
 
     # get points on the surface
-    points, index = sample_surface(mesh, count * 3, seed)
+    points, index = sample_surface(mesh, count * 3, seed=seed)
 
     # remove the points closer than radius
     points, mask = remove_close(points, radius)

--- a/trimesh/sample.py
+++ b/trimesh/sample.py
@@ -16,11 +16,9 @@ if hasattr(np.random, 'default_rng'):
     default_rng = np.random.default_rng
 else:
     # Python 2 Numpy
-    def default_rng(seed):
-        rng = np.random.RandomState(seed)
-        # provide the same interface as the new default_rng
-        rng.random = rng
-        return rng
+    class default_rng(np.random.RandomState):
+        def random(self, *args, **kwargs):
+            return self.random_sample(*args, **kwargs)
 
 
 def sample_surface(mesh, count, face_weight=None, sample_color=False, seed=None):

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.21.7'
+__version__ = '3.22.0'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script


### PR DESCRIPTION
Embree has been a bit of a bear to install for non-conda people, hopefully the fork [mikedh/embreeX](https://github.com/mikedh/embreex) helps. It currently is releasing wheels  for Mac/Windows/Linux for Python>=3.6.

- switch [scopatz/pyembree](https://github.com/scopatz/pyembree) binding to identical-but-has-wheels [mikedh/embreeX](https://github.com/mikedh/embreex) binding.
- release #1931 which allows a seed to be passed to `sample_surface` if you want deterministic results. 