### PR TITLE
Add Support for Empty OpenSCAD Outputs

### DIFF
--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -78,6 +78,20 @@ class BooleanTest(g.unittest.TestCase):
             assert g.np.isclose(r.volume,
                                 8.617306056726884)
 
+    def test_empty(self):
+        engines = [
+            ('blender', g.trimesh.interfaces.blender.exists),
+            ('scad', g.trimesh.interfaces.scad.exists)]
+        for engine, exists in engines:
+            if not exists:
+                continue
+
+            a = g.trimesh.primitives.Sphere(center=[0, 0, 0])
+            b = g.trimesh.primitives.Sphere(center=[5, 0, 0])
+
+            i = a.intersection(b, engine=engine)
+
+            assert i.is_empty
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -89,7 +89,7 @@ class MeshScript:
             # Log output if debug is enabled
             if self.debug:
                 log.info(e.output.decode())
-            raise e
+            raise
 
         if self.debug:
             log.info(output.decode())

--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -4,7 +4,7 @@ import subprocess
 
 from string import Template
 from tempfile import NamedTemporaryFile
-from subprocess import check_call
+from subprocess import check_output, CalledProcessError
 
 from .. import exchange
 from ..util import log
@@ -87,10 +87,16 @@ class MeshScript:
 
             if self.debug:
                 log.info('executing: {}'.format(' '.join(command_run)))
-            check_call(command_run,
-                       stdout=stdout,
-                       stderr=subprocess.STDOUT,
-                       startupinfo=startupinfo)
+
+            try:
+                check_output(command_run,
+                    stderr=subprocess.STDOUT,
+                    startupinfo=startupinfo)
+            except CalledProcessError as e:
+                # Log output if debug is enabled
+                if self.debug:
+                    log.info(e.output.decode())
+                raise e
 
         # bring the binaries result back as a set of Trimesh kwargs
         mesh_results = exchange.load.load_mesh(

--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -73,33 +73,26 @@ class MeshScript:
         command_run = Template(command).substitute(
             self.replacement).split()
         # run the binary
-        # avoid resourcewarnings with null
-        with open(os.devnull, 'w') as devnull:
-            startupinfo = None
-            if platform.system() == 'Windows':
-                startupinfo = subprocess.STARTUPINFO()
-                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            if self.debug:
-                # in debug mode print the output
-                stdout = None
-            else:
-                stdout = devnull
+        startupinfo = None
+        if platform.system() == 'Windows':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
-            if self.debug:
-                log.info('executing: {}'.format(' '.join(command_run)))
+        if self.debug:
+            log.info('executing: {}'.format(' '.join(command_run)))
 
-            try:
-                output = check_output(command_run,
-                    stderr=subprocess.STDOUT,
-                    startupinfo=startupinfo)
-            except CalledProcessError as e:
-                # Log output if debug is enabled
-                if self.debug:
-                    log.info(e.output.decode())
-                raise e
-
+        try:
+            output = check_output(command_run,
+                stderr=subprocess.STDOUT,
+                startupinfo=startupinfo)
+        except CalledProcessError as e:
+            # Log output if debug is enabled
             if self.debug:
-                log.info(output.decode())
+                log.info(e.output.decode())
+            raise e
+
+        if self.debug:
+            log.info(output.decode())
 
         # bring the binaries result back as a set of Trimesh kwargs
         mesh_results = exchange.load.load_mesh(

--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -89,7 +89,7 @@ class MeshScript:
                 log.info('executing: {}'.format(' '.join(command_run)))
 
             try:
-                check_output(command_run,
+                output = check_output(command_run,
                     stderr=subprocess.STDOUT,
                     startupinfo=startupinfo)
             except CalledProcessError as e:
@@ -97,6 +97,9 @@ class MeshScript:
                 if self.debug:
                     log.info(e.output.decode())
                 raise e
+
+            if self.debug:
+                log.info(output.decode())
 
         # bring the binaries result back as a set of Trimesh kwargs
         mesh_results = exchange.load.load_mesh(

--- a/trimesh/interfaces/scad.py
+++ b/trimesh/interfaces/scad.py
@@ -1,5 +1,6 @@
 import os
 import platform
+from subprocess import CalledProcessError
 
 from ..util import which
 from .generic import MeshScript
@@ -46,8 +47,18 @@ def interface_scad(meshes, script, debug=False, **kwargs):
         raise ValueError('No SCAD available!')
     # OFF is a simple text format that references vertices by-index
     # making it slightly preferable to STL for this kind of exchange duty
-    with MeshScript(meshes=meshes, script=script, debug=debug, exchange='off') as scad:
-        result = scad.run(_scad_executable + ' $SCRIPT -o $MESH_POST')
+    try:
+        with MeshScript(meshes=meshes, script=script, debug=debug, exchange='off') as scad:
+            result = scad.run(_scad_executable + ' $SCRIPT -o $MESH_POST')
+    except CalledProcessError as e:
+        # Check if scad is complaining about an empty top level geometry.
+        # If so, just return an empty Trimesh object.
+        if "Current top level object is empty." in e.output.decode().split("\n"):
+            from .. import Trimesh
+            return Trimesh()
+        else:
+            raise e
+
     return result
 
 

--- a/trimesh/interfaces/scad.py
+++ b/trimesh/interfaces/scad.py
@@ -48,7 +48,8 @@ def interface_scad(meshes, script, debug=False, **kwargs):
     # OFF is a simple text format that references vertices by-index
     # making it slightly preferable to STL for this kind of exchange duty
     try:
-        with MeshScript(meshes=meshes, script=script, debug=debug, exchange='off') as scad:
+        with MeshScript(meshes=meshes, script=script, 
+            debug=debug, exchange='off') as scad:
             result = scad.run(_scad_executable + ' $SCRIPT -o $MESH_POST')
     except CalledProcessError as e:
         # Check if scad is complaining about an empty top level geometry.

--- a/trimesh/interfaces/scad.py
+++ b/trimesh/interfaces/scad.py
@@ -58,7 +58,7 @@ def interface_scad(meshes, script, debug=False, **kwargs):
             from .. import Trimesh
             return Trimesh()
         else:
-            raise e
+            raise
 
     return result
 


### PR DESCRIPTION
OpenSCAD currently raises an error if the intersection of two meshes is empty. This PR changes the way subprocess is used, capturing the output of the call and including it in any CalledProcessError that is raised. This allows better handling of the above error, replacing it with an empty Trimesh object (similar to how Blender handles this). I also added a test to confirm the crash no longer occurs.