### PR TITLE
fix crash on tex-coord pointcloud

### DIFF
--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -541,26 +541,25 @@ def _elements_to_kwargs(elements,
             # we may have mixed quads and triangles handle them with function
             faces = triangulate_quads(faces)
 
-    if texcoord is None:
-        # ply has no clear definition of how texture coordinates are stored,
-        # unfortunately there are many common names that we need to try
-        texcoord_names = [('texture_u', 'texture_v'), ('u', 'v'), ('s', 't')]
-        for names in texcoord_names:
-            # If texture coordinates are defined with vertices
-            try:
-                t_u = elements['vertex']['data'][names[0]]
-                t_v = elements['vertex']['data'][names[1]]
-                texcoord = np.stack((
-                    t_u[faces.reshape(-1)],
-                    t_v[faces.reshape(-1)]), axis=-1).reshape(
-                        (faces.shape[0], -1))
-                # stop trying once succeeded
-                break
-            except (ValueError, KeyError):
-                # if the fields didn't exist
-                pass
+        if texcoord is None:
+            # ply has no clear definition of how texture coordinates are stored,
+            # unfortunately there are many common names that we need to try
+            texcoord_names = [('texture_u', 'texture_v'), ('u', 'v'), ('s', 't')]
+            for names in texcoord_names:
+                # If texture coordinates are defined with vertices
+                try:
+                    t_u = elements['vertex']['data'][names[0]]
+                    t_v = elements['vertex']['data'][names[1]]
+                    texcoord = np.stack((
+                        t_u[faces.reshape(-1)],
+                        t_v[faces.reshape(-1)]), axis=-1).reshape(
+                            (faces.shape[0], -1))
+                    # stop trying once succeeded
+                    break
+                except (ValueError, KeyError):
+                    # if the fields didn't exist
+                    pass
 
-    if faces is not None:
         shape = np.shape(faces)
 
         # PLY stores texture coordinates per-face which is


### PR DESCRIPTION
Hey there,

when trying to import a PLY with per-vertex UV coords, but no faces (i.e. a point cloud), the importer crashes, as it doesn't check if faces exist in the first place:

```
Traceback (most recent call last):
...
  File "/usr/local/lib/python3.10/site-packages/trimesh/exchange/load.py", line 132, in load
    loaded = load_mesh(file_obj,
  File "/usr/local/lib/python3.10/site-packages/trimesh/exchange/load.py", line 215, in load_mesh
    results = loader(file_obj,
  File "/usr/local/lib/python3.10/site-packages/trimesh/exchange/ply.py", line 122, in load_ply
    kwargs = _elements_to_kwargs(
  File "/usr/local/lib/python3.10/site-packages/trimesh/exchange/ply.py", line 554, in _elements_to_kwargs
    t_u[faces.reshape(-1)],
AttributeError: 'NoneType' object has no attribute 'reshape'
```

[halfcone_mc1.ply.zip](https://github.com/mikedh/trimesh/files/11712409/halfcone_mc1.ply.zip)
