### PR TITLE
Relese: Add AABB To Box Constructor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-20.04, macos-latest, windows-latest]
         exclude:
             # windows runners have gotten very flaky
             # exclude all windows test runs except for one
-          - os: windows-latest
-            python-version: 2.7
-          - os: windows-latest
-            python-version: 3.5
           - os: windows-latest
             python-version: 3.6
           - os: windows-latest
@@ -45,10 +41,6 @@ jobs:
             python-version: 3.9
           - os: macos-latest
             python-version: 3.9
-          - os: macos-latest
-            python-version: 2.7
-          - os: macos-latest
-            python-version: 3.5
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
       matrix:
         python-version: ["3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-          - os: ubuntu-latest
-            python-version: 2.7
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Run Pytest
       run: |
         python tests/test_cache.py
-        python -c "import numpy; a = np.random.random((100, 3)); a.astype()"
+        python -c "import numpy; a = numpy.random.random((100, 3)); a.astype()"
         pytest
   docker:
     name: Run Tests In Docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,9 @@ jobs:
     - name: Install Trimesh
       run: pip install .[easy,test]
     - name: Run Pytest
-      run: pytest
-
+      run: |
+        python tests/test_cache.py
+        pytest
   docker:
     name: Run Tests In Docker
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,6 @@ jobs:
       run: pip install .[easy,test]
     - name: Run Pytest
       run: |
-        python tests/test_cache.py
-        python -c "import numpy; a = numpy.random.random((100, 3)); a.astype()"
         pytest
   docker:
     name: Run Tests In Docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Run Pytest
       run: |
         python tests/test_cache.py
+        python -c "import numpy; a = np.random.random((100, 3)); a.astype()"
         pytest
   docker:
     name: Run Tests In Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye AS base
+FROM python:3.11-slim-bookworm AS base
 LABEL maintainer="mikedh@kerfed.com"
 
 # Install helper script to PATH.

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -64,11 +64,11 @@ with DummyProfiler() as _P:
     pass
 assert len(_P.output_text()) > 0
 
-# try:
-#    from pyinstrument import Profiler
-# except BaseException:
-# see if this is the segfaulter
-Profiler = DummyProfiler
+
+try:
+    from pyinstrument import Profiler
+except BaseException:
+    Profiler = DummyProfiler
 
 
 # should we require all soft dependencies
@@ -488,6 +488,7 @@ def scene_equal(a, b):
             m.volume, b.geometry[k].volume, rtol=0.001)
     # the axis aligned bounding box should be the same
     assert np.allclose(a.bounds, b.bounds)
+
 
 def texture_equal(a, b):
     """

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -64,10 +64,11 @@ with DummyProfiler() as _P:
     pass
 assert len(_P.output_text()) > 0
 
-try:
-    from pyinstrument import Profiler
-except BaseException:
-    Profiler = DummyProfiler
+# try:
+#    from pyinstrument import Profiler
+# except BaseException:
+# see if this is the segfaulter
+Profiler = DummyProfiler
 
 
 # should we require all soft dependencies

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -78,6 +78,20 @@ class BooleanTest(g.unittest.TestCase):
             assert g.np.isclose(r.volume,
                                 8.617306056726884)
 
+    def test_empty(self):
+        engines = [
+            ('blender', g.trimesh.interfaces.blender.exists),
+            ('scad', g.trimesh.interfaces.scad.exists)]
+        for engine, exists in engines:
+            if not exists:
+                continue
+
+            a = g.trimesh.primitives.Sphere(center=[0, 0, 0])
+            b = g.trimesh.primitives.Sphere(center=[5, 0, 0])
+
+            i = a.intersection(b, engine=engine)
+
+            assert i.is_empty
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -228,10 +228,17 @@ class CacheTest(g.unittest.TestCase):
         # are suspicious of a method caching you could uncomment this out:
         # attempts.extend([tuple(G) for G in itertools.permutations(flat, 3)])
 
+        # currently segfaulting when called with `(2.3, 1)`
+        skip = set(['__array_ufunc__'])
+
         # collect functions which mutate arrays but don't change our hash
         broken = []
 
         for method in list(dir(tracked_array(g.random(dim)))):
+
+            if method in skip:
+                continue
+
             failures = []
             g.log.debug('hash check: `{}`'.format(method))
             for A in attempts:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -242,6 +242,7 @@ class CacheTest(g.unittest.TestCase):
             failures = []
             g.log.debug('hash check: `{}`'.format(method))
             for A in attempts:
+                g.log.debug('{}({})'.format(method, ', '.join(str(i) for i in A)))
                 m = g.random((100, 3))
                 true_pre = m.tobytes()
                 m = tracked_array(m)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -228,8 +228,9 @@ class CacheTest(g.unittest.TestCase):
         # are suspicious of a method caching you could uncomment this out:
         # attempts.extend([tuple(G) for G in itertools.permutations(flat, 3)])
 
-        # currently segfaulting when called with `(2.3, 1)`
-        skip = set(['__array_ufunc__'])
+        skip = set(['__array_ufunc__', # currently segfaulting when called with `(2.3, 1)`
+                    'astype', 
+                    ])
 
         # collect functions which mutate arrays but don't change our hash
         broken = []
@@ -242,12 +243,10 @@ class CacheTest(g.unittest.TestCase):
             failures = []
             g.log.debug('hash check: `{}`'.format(method))
             for A in attempts:
-                g.log.debug('{}({})'.format(method, ', '.join(str(i) for i in A)))
                 m = g.random((100, 3))
                 true_pre = m.tobytes()
                 m = tracked_array(m)
                 hash_pre = hash(m)
-
                 try:
                     eval('m.{method}(*A)'.format(method=method))
                 except BaseException as J:

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -311,6 +311,21 @@ class PrimitiveTest(g.unittest.TestCase):
         s.center[:2] = [0, 3]
         assert g.np.allclose(s.center, [0, 3, 1])
 
+    def test_box_bounds_constructor(self):
+        # check to see that we can construct a box using AABB
+        bounds = [[0.2, 0.3, 0.4], [10, 11, 12.2]]
+        prim = g.trimesh.primitives.Box(bounds=bounds)
+
+        # bounds should match requesta
+        assert g.np.allclose(prim.bounds, bounds)
+
+        try:
+            # should raise a ValueError
+            g.trimesh.primitives.Box(extents=bounds[0], bounds=bounds)
+            raise AssertionError("box shouldn't have accepted both bounds and extents!")
+        except ValueError:
+            pass
+
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -709,6 +709,12 @@ def icosphere(subdivisions=3, radius=1.0, **kwargs):
         unit = vectors / scalar.reshape((-1, 1))
         ico.vertices += unit * (radius - scalar).reshape((-1, 1))
 
+    if "color" in kwargs:  # NOTE: for backward compatibiliy.
+        # Previously we could specify facet_color by "color" keyward
+        # but this was disabled by the following commit:
+        # 147b1774da51c735d5fa4daa02260ea146b5dfd7
+        kwargs["face_colors"] = kwargs.pop("color")
+
     return Trimesh(vertices=ico.vertices,
                    faces=ico.faces,
                    metadata={'shape': 'sphere',

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -599,9 +599,12 @@ def box(extents=None, transform=None, bounds=None, **kwargs):
 
     # resize cube based on passed extents
     if bounds is not None:
-        bounds = np.array(bounds, dtype=np.float64)
+
         if transform is not None or extents is not None:
             raise ValueError('`bounds` overrides `extents`/`transform`!')
+        bounds = np.array(bounds, dtype=np.float64)
+        if bounds.shape != (2, 3):
+            raise ValueError('`bounds` must be (2, 3) float!')
         extents = bounds.ptp(axis=0)
         vertices *= extents
         vertices += bounds[0]

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -18,6 +18,8 @@ from . import exceptions
 from . import transformations as tf
 
 import numpy as np
+
+import warnings
 import collections
 
 try:
@@ -709,10 +711,12 @@ def icosphere(subdivisions=3, radius=1.0, **kwargs):
         unit = vectors / scalar.reshape((-1, 1))
         ico.vertices += unit * (radius - scalar).reshape((-1, 1))
 
-    if "color" in kwargs:  # NOTE: for backward compatibiliy.
-        # Previously we could specify facet_color by "color" keyward
-        # but this was disabled by the following commit:
-        # 147b1774da51c735d5fa4daa02260ea146b5dfd7
+    if "color" in kwargs:
+        warnings.warn(
+            '`icosphere(color=...)` is deprecated and will ' +
+            'be removed in June 2024: replace with Trimesh constructor ' +
+            'kewyword argument `icosphere(face_colors=...)`',
+            category=DeprecationWarning, stacklevel=2)
         kwargs["face_colors"] = kwargs.pop("color")
 
     return Trimesh(vertices=ico.vertices,

--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -4,7 +4,7 @@ import subprocess
 
 from string import Template
 from tempfile import NamedTemporaryFile
-from subprocess import check_call
+from subprocess import check_output, CalledProcessError
 
 from .. import exchange
 from ..util import log
@@ -73,24 +73,26 @@ class MeshScript:
         command_run = Template(command).substitute(
             self.replacement).split()
         # run the binary
-        # avoid resourcewarnings with null
-        with open(os.devnull, 'w') as devnull:
-            startupinfo = None
-            if platform.system() == 'Windows':
-                startupinfo = subprocess.STARTUPINFO()
-                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            if self.debug:
-                # in debug mode print the output
-                stdout = None
-            else:
-                stdout = devnull
+        startupinfo = None
+        if platform.system() == 'Windows':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
+        if self.debug:
+            log.info('executing: {}'.format(' '.join(command_run)))
+
+        try:
+            output = check_output(command_run,
+                stderr=subprocess.STDOUT,
+                startupinfo=startupinfo)
+        except CalledProcessError as e:
+            # Log output if debug is enabled
             if self.debug:
-                log.info('executing: {}'.format(' '.join(command_run)))
-            check_call(command_run,
-                       stdout=stdout,
-                       stderr=subprocess.STDOUT,
-                       startupinfo=startupinfo)
+                log.info(e.output.decode())
+            raise
+
+        if self.debug:
+            log.info(output.decode())
 
         # bring the binaries result back as a set of Trimesh kwargs
         mesh_results = exchange.load.load_mesh(

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -1,7 +1,6 @@
 import numpy as np
 import collections
 import uuid
-import inspect
 
 from . import cameras
 from . import lighting
@@ -1246,8 +1245,8 @@ class Scene(Geometry3D):
 
         Parameters
         -----------
-        viewer: str
-          What kind of viewer to open, including
+        viewer : Union[str, callable, None]
+          What kind of viewer to use, such as
           'gl' to open a pyglet window, 'notebook'
           for a jupyter notebook or None
         kwargs : dict
@@ -1258,9 +1257,10 @@ class Scene(Geometry3D):
         if viewer is None:
             # check to see if we are in a notebook or not
             from ..viewer import in_notebook
-            viewer = 'gl'
             if in_notebook():
                 viewer = 'notebook'
+            else:
+                viewer = 'gl'
 
         if viewer == 'gl':
             # this imports pyglet, and will raise an ImportError
@@ -1270,10 +1270,12 @@ class Scene(Geometry3D):
         elif viewer == 'notebook':
             from ..viewer import scene_to_notebook
             return scene_to_notebook(self, **kwargs)
-        elif inspect.isclass(viewer):
-            return viewer(self,**kwargs)
+        elif callable(viewer):
+            # if a callable method like a custom class
+            # constructor was passed run using that
+            return viewer(self, **kwargs)
         else:
-            raise ValueError('viewer must be "gl", "notebook", or None')
+            raise ValueError('viewer must be "gl", "notebook", callable, or None')
 
     def __add__(self, other):
         """

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -1,6 +1,7 @@
 import numpy as np
 import collections
 import uuid
+import inspect
 
 from . import cameras
 from . import lighting
@@ -1269,6 +1270,8 @@ class Scene(Geometry3D):
         elif viewer == 'notebook':
             from ..viewer import scene_to_notebook
             return scene_to_notebook(self, **kwargs)
+        elif inspect.isclass(viewer):
+            return viewer(self,**kwargs)
         else:
             raise ValueError('viewer must be "gl", "notebook", or None')
 

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.22.1'
+__version__ = '3.22.2'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script


### PR DESCRIPTION
- add `bounds` to box constructor which substitutes for `extents` and `transform`
- release #1940 
- add deprecation schedule and release #1954
- allow viewer classes to be passed to `scene.show` release #1952 
- remove Python 2.7 from test matrix towards #1951 