### PR TITLE
Allow using a supplied SceneViewer class to show Scene

### DIFF
--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -1,6 +1,7 @@
 import numpy as np
 import collections
 import uuid
+import inspect
 
 from . import cameras
 from . import lighting
@@ -1269,6 +1270,8 @@ class Scene(Geometry3D):
         elif viewer == 'notebook':
             from ..viewer import scene_to_notebook
             return scene_to_notebook(self, **kwargs)
+        elif inspect.isclass(viewer):
+            return viewer(self,**kwargs)
         else:
             raise ValueError('viewer must be "gl", "notebook", or None')
 


### PR DESCRIPTION
Currently it is very hard ( or impossible ) to extend functionality of `SceneViewer`
e.g. adapting how trackball works or adding additional key-handler or tweak the `SceneViewer` behavior
because the class is hardcoded in `Scene` code.

I tried to setup an additional key/mouse handler locally ( using `pyglet.event` decorator on a local  function )
but that handler is called before the `SceneViewer` key/mouse handler method is called, making it impossible to overwrite
functionality that is within the `SceneViewer` method - because the latter will trump any change that was done in the custom key/mouse handler.

This proposed change allows caller of `Scene.show()` to supply a `SceneViewer` compatible / derived class with the `viewer` keyword argument,  that will be used when creating an instance of the viewer for current scene.

Not sure if `inspect` is the right thing to use to simply check that argument is a "compatible" class.
I just wanted to avoid importing `ScenViewer` ( like in line 1268 ) just for the type check.