### PR TITLE
fix: re-enable passing facet color by color keyward

### DIFF
--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -706,6 +706,12 @@ def icosphere(subdivisions=3, radius=1.0, **kwargs):
         unit = vectors / scalar.reshape((-1, 1))
         ico.vertices += unit * (radius - scalar).reshape((-1, 1))
 
+    if "color" in kwargs:  # NOTE: for backward compatibiliy.
+        # Previously we could specify facet_color by "color" keyward
+        # but this was disabled by the following commit:
+        # 147b1774da51c735d5fa4daa02260ea146b5dfd7
+        kwargs["face_colors"] = kwargs.pop("color")
+
     return Trimesh(vertices=ico.vertices,
                    faces=ico.faces,
                    metadata={'shape': 'sphere',


### PR DESCRIPTION
After this commits, we cannot create icosphere with `color` keyward.  
https://github.com/mikedh/trimesh/commit/147b1774da51c735d5fa4daa02260ea146b5dfd7

Although, we can do that with `facet_colors` keyward arg thanks to https://github.com/mikedh/trimesh/pull/1942, it still has been lose backward compatibility. 

This PR recover the compatibility with 3.22.0. 