### PR TITLE
Expand uesr and vars in path

### DIFF
--- a/trimesh/interfaces/vhacd.py
+++ b/trimesh/interfaces/vhacd.py
@@ -5,10 +5,8 @@ from .generic import MeshScript
 from ..constants import log
 from ..util import which
 
-_search_path = str.join(
-    ":",
-    [os.path.expanduser(os.path.expandvars(p)) for p in os.environ["PATH"].split(":")],
-)
+_search_path = ":".join([os.path.expanduser(os.path.expandvars(p)) for p in os.environ["PATH"].split(":")])
+
 
 if platform.system() == 'Windows':
     # split existing path by delimiter

--- a/trimesh/interfaces/vhacd.py
+++ b/trimesh/interfaces/vhacd.py
@@ -5,7 +5,11 @@ from .generic import MeshScript
 from ..constants import log
 from ..util import which
 
-_search_path = os.environ['PATH']
+_search_path = str.join(
+    ":",
+    [os.path.expanduser(os.path.expandvars(p)) for p in os.environ["PATH"].split(":")],
+)
+
 if platform.system() == 'Windows':
     # split existing path by delimiter
     _search_path = [i for i in _search_path.split(';') if len(i) > 0]

--- a/trimesh/interfaces/vhacd.py
+++ b/trimesh/interfaces/vhacd.py
@@ -5,8 +5,7 @@ from .generic import MeshScript
 from ..constants import log
 from ..util import which
 
-_search_path = ":".join([os.path.expanduser(os.path.expandvars(p)) for p in os.environ["PATH"].split(":")])
-
+_search_path = os.environ["PATH"]
 
 if platform.system() == 'Windows':
     # split existing path by delimiter
@@ -15,6 +14,8 @@ if platform.system() == 'Windows':
     _search_path.append(r'C:\Program Files (x86)')
     _search_path = ';'.join(_search_path)
     log.debug('searching for vhacd in: %s', _search_path)
+else:
+    _search_path = ":".join([os.path.expanduser(os.path.expandvars(p)) for p in _search_path.split(":")])
 
 _vhacd_executable = None
 for _name in ['vhacd', 'testVHACD', 'TestVHACD']:

--- a/trimesh/interfaces/vhacd.py
+++ b/trimesh/interfaces/vhacd.py
@@ -15,7 +15,9 @@ if platform.system() == 'Windows':
     _search_path = ';'.join(_search_path)
     log.debug('searching for vhacd in: %s', _search_path)
 else:
-    _search_path = ":".join([os.path.expanduser(os.path.expandvars(p)) for p in _search_path.split(":")])
+    _search_path = ":".join(
+        [os.path.expanduser(os.path.expandvars(p)) for p in _search_path.split(":")]
+    )
 
 _vhacd_executable = None
 for _name in ['vhacd', 'testVHACD', 'TestVHACD']:


### PR DESCRIPTION
There's an issue in searching for the v-hacd executable if the directory in `$PATH` is defined using any environment variables or the `~` abbreviation for the home user.

E.g. I put `TestVHACD` in `~/bin` and had it listed in my `$PATH` variable as such but trimesh couldn't find it. 

It looks like this also effects other external interfaces as well, but I haven't tried to test those.

I just through together a quick 1-line fix for v-hacd, but it would be easy to extend to the others if desired.