### PR TITLE
Hotfix: Sparse

### DIFF
--- a/tests/test_normals.py
+++ b/tests/test_normals.py
@@ -37,7 +37,8 @@ class NormalsTest(g.unittest.TestCase):
 
         def compare_trimesh_to_groundtruth(
                 mesh,
-                truth, atol=g.trimesh.tol.merge):
+                truth,
+                atol=g.trimesh.tol.merge):
             # force fallback to loop normal summing by passing None
             # as the sparse matrix
             normals = g.trimesh.geometry.weighted_vertex_normals(
@@ -45,7 +46,7 @@ class NormalsTest(g.unittest.TestCase):
                 faces=mesh.faces,
                 face_normals=mesh.face_normals,
                 face_angles=mesh.face_angles)
-            assert g.np.allclose(normals - truth, 0.0, atol=atol)
+            assert g.np.allclose(normals, truth, atol=atol)
 
             # make sure the automatic sparse matrix generation works
             normals = g.trimesh.geometry.weighted_vertex_normals(

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -366,28 +366,7 @@ def weighted_vertex_normals(vertex_count,
         # figure out the summed normal at each vertex
         # allow cached sparse matrix to be passed
         # fill the matrix with vertex-corner angles as weights
-        corner_angles = face_angles[np.repeat(np.arange(len(faces)), 3),
-                                    np.argsort(faces, axis=1).ravel()]
-        # create a sparse matrix
-        matrix = index_sparse(vertex_count, faces)
-        # assign the corner angles to the sparse matrix data        
-        matrix.data = corner_angles
-        
-
-        
-        nond = index_sparse(vertex_count, faces, data=corner_angles)
-        
-        # assign the corner angles to the sparse matrix data
-        
-        # why does this work...
-        shouldnt = util.unitize(matrix.dot(face_normals))
-        check = util.unitize(summed_loop())
-        ours = util.unitize(nond.dot(face_normals))
-        
-        if not np.allclose(check, ours):
-            from IPython import embed
-            embed()
-            
+        matrix = index_sparse(vertex_count, faces, data=face_angles.ravel())
         return matrix.dot(face_normals)
 
     def summed_loop():
@@ -489,7 +468,7 @@ co
 
     if dtype is not None:
         data = data.astype(dtype)
-    
+
     # assemble into sparse matrix
     matrix = scipy.sparse.coo_matrix((data, (row, col)),
                                      shape=shape,

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -370,6 +370,7 @@ def weighted_vertex_normals(vertex_count,
                                     np.argsort(faces, axis=1).ravel()]
         # create a sparse matrix
         matrix = index_sparse(vertex_count, faces).astype(np.float64)
+        # assign the corner angles to the sparse matrix data
         matrix.data = corner_angles
         
 
@@ -378,18 +379,16 @@ def weighted_vertex_normals(vertex_count,
         
         # assign the corner angles to the sparse matrix data
         
-        #
+        # why does this work...
         shouldnt = util.unitize(matrix.dot(face_normals))
         check = util.unitize(summed_loop())
         ours = util.unitize(nond.dot(face_normals))
-
         
         if not np.allclose(check, ours):
             from IPython import embed
             embed()
-
             
-        return nond.dot(face_normals)
+        return matrix.dot(face_normals)
 
     def summed_loop():
         summed = np.zeros((vertex_count, 3), np.float64)

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -369,8 +369,8 @@ def weighted_vertex_normals(vertex_count,
         corner_angles = face_angles[np.repeat(np.arange(len(faces)), 3),
                                     np.argsort(faces, axis=1).ravel()]
         # create a sparse matrix
-        matrix = index_sparse(vertex_count, faces).astype(np.float64)
-        # assign the corner angles to the sparse matrix data
+        matrix = index_sparse(vertex_count, faces)
+        # assign the corner angles to the sparse matrix data        
         matrix.data = corner_angles
         
 


### PR DESCRIPTION
Behavior of Scipy COO matrices changed, and our kind of weird post-creation data assignment in `weighted_vertex_normals` broke. 