### PR TITLE
Release: fix two numpy deprecations

### DIFF
--- a/tests/corpus.py
+++ b/tests/corpus.py
@@ -155,7 +155,7 @@ def equal(a, b):
         # are similar and JPEG produces diffs that are like 25%
         # different but something is better than nothing I suppose
         aa, bb = np.array(a), np.array(b)
-        percent = np.abs(aa - bb).sum() / (np.product(aa.shape) * 256)
+        percent = np.abs(aa - bb).sum() / (np.prod(aa.shape) * 256)
         return percent < 0.5
 
     # try built-in eq method

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -145,7 +145,7 @@ class BoundsTest(g.unittest.TestCase):
             # check to make sure result is actually returning an OBB
             assert g.np.allclose(origin, 0.0)
             # make sure OBB has less or same area as naive AABB
-            assert g.np.product(rectangle) <= g.np.product(rectangle_pre)
+            assert g.np.prod(rectangle) <= g.np.prod(rectangle_pre)
 
     def test_cylinder(self):
         """
@@ -249,7 +249,7 @@ class BoundsTest(g.unittest.TestCase):
 
             # make sure mesh isn't reversing windings
             assert g.np.isclose(obb.to_mesh().volume,
-                                g.np.product(extents))
+                                g.np.prod(extents))
 
             # make sure OBB has the same bounds as the source mesh
             # since it is a box the AABB of the OBB should be

--- a/tests/test_fill.py
+++ b/tests/test_fill.py
@@ -16,7 +16,7 @@ class FillTest(g.unittest.TestCase):
         # topology should be good now
         assert len(a.paths) == 1
         # it is a rectangle
-        assert g.np.isclose(a.area, g.np.product(a.extents))
+        assert g.np.isclose(a.area, g.np.prod(a.extents))
 
         # a path with a bowtie and a .05 gap
         b = g.get_mesh('2D/broken_pair.dxf')
@@ -28,7 +28,7 @@ class FillTest(g.unittest.TestCase):
         b.fill_gaps(.06)
         assert len(b.paths) == 1
         # it is a rectangle
-        assert g.np.isclose(b.area, g.np.product(b.extents))
+        assert g.np.isclose(b.area, g.np.prod(b.extents))
 
 
 if __name__ == '__main__':

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -41,7 +41,7 @@ class MinimalTest(unittest.TestCase):
         extents = bounds.reshape((-1, 2)).ptp(axis=0)
         assert np.allclose(extents, [2, 3])
         assert bounds.shape == (2, 2, 2)
-        density = 5.0 / np.product(extents)
+        density = 5.0 / np.prod(extents)
         assert density > .833
 
     def test_load(self):

--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -59,7 +59,7 @@ def _solid_image(color, size):
 
     # create a one pixel RGB image
     image = Image.fromarray(
-        g.np.tile(color, (g.np.product(size), 1)).reshape(
+        g.np.tile(color, (g.np.prod(size), 1)).reshape(
             (size[0], size[1], 3)))
     assert image.size == tuple(size[::-1])
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -49,7 +49,7 @@ class PointsTest(g.unittest.TestCase):
 
         # AABB volume should be same as points
         assert g.np.isclose(cloud.bounding_box.volume,
-                            g.np.product(points.ptp(axis=0)))
+                            g.np.prod(points.ptp(axis=0)))
 
         # will populate all bounding primitives
         assert cloud.bounding_primitive.volume > 0.0

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -92,8 +92,8 @@ class SceneTests(g.unittest.TestCase):
 
                     # make sure the extents are similar before and after
                     assert g.np.allclose(
-                        g.np.product(s.extents),
-                        g.np.product(r.extents))
+                        g.np.prod(s.extents),
+                        g.np.prod(r.extents))
 
                 # move the scene to origin
                 s.rezero()

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -173,7 +173,7 @@ class TextureTest(g.unittest.TestCase):
         c = g.trimesh.util.concatenate(meshes)
         assert isinstance(c.visual, g.trimesh.visual.TextureVisuals)
         assert len(c.faces) == sum(len(i.faces) for i in meshes)
-        assert g.np.product(c.visual.material.image.size) >= 4
+        assert g.np.prod(c.visual.material.image.size) >= 4
 
         # convert texture back to color
         roundtrip = c.visual.to_color()

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -86,7 +86,7 @@ def oriented_bounds_2D(points, qhull_options='QbB'):
     # calculate the extents and area for each edge vector pair
     extents = np.diff(bounds.reshape((-1, 2, 2)),
                       axis=1).reshape((-1, 2))
-    area = np.product(extents, axis=1)
+    area = np.prod(extents, axis=1)
     area_min = area.argmin()
 
     # (2,) float of smallest rectangle size

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -535,7 +535,7 @@ def _data_append(acc, buff, blob, data):
 
     if kind == 'SCALAR':
         # is probably (n, 1)
-        blob['count'] = int(np.product(data.shape))
+        blob['count'] = int(np.prod(data.shape))
         blob['max'] = np.array(
             [data.max()], dtype=dtype).tolist()
         blob['min'] = np.array(
@@ -1359,7 +1359,7 @@ def _read_buffers(header,
             shape = np.append(count, per_item)
             # number of items when flattened
             # i.e. a (4, 4) MAT4 has 16
-            per_count = np.abs(np.product(per_item))
+            per_count = np.abs(np.prod(per_item))
             if 'bufferView' in a:
                 # data was stored in a buffer view so get raw bytes
 

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -592,7 +592,7 @@ def _parse_vertices(text):
         # what should our shape be
         shape = (len(value), per_row[k])
         # check shape of flat data
-        if len(array) == np.product(shape):
+        if len(array) == np.prod(shape):
             # we have a nice 2D array
             result[k] = array.reshape(shape)
         else:

--- a/trimesh/exchange/stl.py
+++ b/trimesh/exchange/stl.py
@@ -125,7 +125,7 @@ def load_stl_binary(file_obj):
 
     # all of our vertices will be loaded in order
     # so faces are just sequential indices reshaped.
-    faces = np.arange(header['face_count'] * 3).reshape((-1, 3))
+    faces = np.arange(header['face_count'][0] * 3).reshape((-1, 3))
 
     # there are two bytes per triangle saved for anything
     # which is sometimes used for face color

--- a/trimesh/interfaces/vhacd.py
+++ b/trimesh/interfaces/vhacd.py
@@ -5,7 +5,8 @@ from .generic import MeshScript
 from ..constants import log
 from ..util import which
 
-_search_path = os.environ['PATH']
+_search_path = os.environ["PATH"]
+
 if platform.system() == 'Windows':
     # split existing path by delimiter
     _search_path = [i for i in _search_path.split(';') if len(i) > 0]
@@ -13,6 +14,10 @@ if platform.system() == 'Windows':
     _search_path.append(r'C:\Program Files (x86)')
     _search_path = ';'.join(_search_path)
     log.debug('searching for vhacd in: %s', _search_path)
+else:
+    _search_path = ":".join(
+        [os.path.expanduser(os.path.expandvars(p)) for p in _search_path.split(":")]
+    )
 
 _vhacd_executable = None
 for _name in ['vhacd', 'testVHACD', 'TestVHACD']:

--- a/trimesh/path/arc.py
+++ b/trimesh/path/arc.py
@@ -51,11 +51,11 @@ def arc_center(points, return_normal=True, return_angle=True):
     # half the total length of the edges
     half = edges.sum() / 2.0
     # check the denominator for the radius calculation
-    denom = half * np.product(half - edges)
+    denom = half * np.prod(half - edges)
     if denom < tol.merge:
         raise ValueError('arc is colinear!')
     # find the radius and scale back after the operation
-    radius = scale * ((np.product(edges) / 4.0) / np.sqrt(denom))
+    radius = scale * ((np.prod(edges) / 4.0) / np.sqrt(denom))
 
     # use a barycentric approach to get the center
     ba2 = (abc2[[1, 2, 0, 0, 2, 1, 0, 1, 2]] *

--- a/trimesh/path/packing.py
+++ b/trimesh/path/packing.py
@@ -241,7 +241,7 @@ def rectangles_single(extents, size=None, shuffle=False, rotate=True):
                 np.fill_diagonal(ch, stack.sum(axis=0))
 
                 # choose the new AABB by which one minimizes hyper-volume
-                choice_prod = np.product(ch, axis=1)
+                choice_prod = np.prod(ch, axis=1)
                 if choice_prod.min() < best:
                     choices = ch
                     choices_idx = choice_prod.argmin()
@@ -449,7 +449,7 @@ def rectangles(extents,
     extents += spacing * 2.0
 
     # hyper-volume: area in 2D, volume in 3D, party in 4D
-    area = np.product(extents, axis=1)
+    area = np.prod(extents, axis=1)
     # best density percentage in 0.0 - 1.0
     best_density = 0.0
     # how many rect were inserted
@@ -469,7 +469,7 @@ def rectangles(extents,
             extents = np.ceil(extents_all / quanta) * quanta
 
         # calculate the packing density
-        density = area[insert].sum() / np.product(extents_all)
+        density = area[insert].sum() / np.prod(extents_all)
 
         # compare this packing density against our best
         if density > best_density or count > best_count:

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -1018,8 +1018,8 @@ class Path2D(Path):
         return matrix
 
     def rasterize(self,
-                  pitch,
-                  origin,
+                  pitch=None,
+                  origin=None,
                   resolution=None,
                   fill=True,
                   width=None,

--- a/trimesh/path/raster.py
+++ b/trimesh/path/raster.py
@@ -21,8 +21,8 @@ except BaseException as E:
 
 
 def rasterize(path,
-              pitch,
-              origin,
+              pitch=None,
+              origin=None,
               resolution=None,
               fill=True,
               width=None):
@@ -50,6 +50,12 @@ def rasterize(path,
       Rasterized version of input as `mode 1` image
     """
 
+    if pitch is None:
+        pitch = path.extents.max() / 2048
+
+    if origin is None:
+        origin = path.bounds[0] - (pitch * 2.0)
+    
     # check inputs
     pitch = np.asanyarray(pitch, dtype=np.float64)
     origin = np.asanyarray(origin, dtype=np.float64)

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -840,7 +840,7 @@ class Box(_Primitive):
         volume : float
           Volume of box.
         """
-        volume = float(np.product(self.primitive.extents))
+        volume = float(np.prod(self.primitive.extents))
         return volume
 
     def _create_mesh(self):

--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -267,11 +267,11 @@ def mass_properties(triangles,
     inertia[2, 2] = integrated[4] + integrated[5] - \
         (volume * (center_mass[[0, 1]]**2).sum())
     inertia[0, 1] = - (
-        integrated[7] - (volume * np.product(center_mass[[0, 1]])))
+        integrated[7] - (volume * np.prod(center_mass[[0, 1]])))
     inertia[1, 2] = - (
-        integrated[8] - (volume * np.product(center_mass[[1, 2]])))
+        integrated[8] - (volume * np.prod(center_mass[[1, 2]])))
     inertia[0, 2] = - (
-        integrated[9] - (volume * np.product(center_mass[[0, 2]])))
+        integrated[9] - (volume * np.prod(center_mass[[0, 2]])))
     inertia[2, 0] = inertia[0, 2]
     inertia[2, 1] = inertia[1, 2]
     inertia[1, 0] = inertia[0, 1]

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -1,4 +1,4 @@
-__version__ = '3.22.2'
+__version__ = '3.22.3'
 
 if __name__ == '__main__':
     # print version if run directly i.e. in a CI script

--- a/trimesh/voxel/ops.py
+++ b/trimesh/voxel/ops.py
@@ -181,8 +181,8 @@ def sparse_to_matrix(sparse):
         raise ValueError('sparse must be (n,3)!')
 
     shape = sparse.max(axis=0) + 1
-    matrix = np.zeros(np.product(shape), dtype=bool)
-    multiplier = np.array([np.product(shape[1:]), shape[2], 1])
+    matrix = np.zeros(np.prod(shape), dtype=bool)
+    multiplier = np.array([np.prod(shape[1:]), shape[2], 1])
 
     index = (sparse * multiplier).sum(axis=1)
     matrix[index] = True


### PR DESCRIPTION
- `np.product` -> `np.prod`
- Using a structured array with one element as a scalar
- release #1960 
- provide default args so that `path.rasterize()` produces an image if you don't care about metric accuracy