### PR TITLE
Generalize empty OpenSCAD message extraction.

### DIFF
--- a/trimesh/interfaces/scad.py
+++ b/trimesh/interfaces/scad.py
@@ -54,7 +54,7 @@ def interface_scad(meshes, script, debug=False, **kwargs):
     except CalledProcessError as e:
         # Check if scad is complaining about an empty top level geometry.
         # If so, just return an empty Trimesh object.
-        if "Current top level object is empty." in e.output.decode().split("\n"):
+        if "Current top level object is empty." in e.output.decode():
             from .. import Trimesh
             return Trimesh()
         else:


### PR DESCRIPTION
Unfortunately Windows uses different newline characters than Linux, so my previous implementation doesn't work in general. This change should be general enough to work on Windows and Linux. I tested this fix in a downstream [project](https://github.com/BerkeleyLearnVerify/Scenic/blob/d2383203a1aa532556043bb5def2f189af8d9d2f/src/scenic/core/regions.py#L1399) and it passes our tests (which include the empty top level region behavior in OpenSCAD) on Windows and Linux.