### PR TITLE
bubble up the 'extension' to root

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -650,7 +650,7 @@ def _create_gltf_structure(scene,
             extensions = tree['scenes'][0]['extras'].pop(
                 'gltf_extensions', None)
             if isinstance(extensions, dict):
-                tree['scenes'][0]['extensions'] = extensions
+                tree['extensions'] = extensions
         except BaseException:
             log.debug(
                 'failed to export scene metadata!', exc_info=True)
@@ -703,9 +703,9 @@ def _create_gltf_structure(scene,
 
     extensions_used = set()
     # Add any scene extensions used
-    if 'extensions' in tree['scenes'][0]:
+    if 'extensions' in tree:
         extensions_used = extensions_used.union(
-            set(tree['scenes'][0]['extensions'].keys()))
+            set(tree['extensions'].keys()))
     # Add any mesh extensions used
     for mesh in tree['meshes']:
         if 'extensions' in mesh:
@@ -1742,8 +1742,7 @@ def _read_buffers(header,
         # use a try except to avoid nested key checks
         if "metadata" not in result:
             result["metadata"] = {}
-        result['metadata']['gltf_extensions'] = header['scenes'][
-            header['scene']]['extensions']
+        result['metadata']['gltf_extensions'] = header['extensions']
     except BaseException:
         pass
 


### PR DESCRIPTION
# Overview

This change will write the `extensions` provided with `scene.metadata` at the top-most level, so that assets such as GLTF lights are written at the correct level.

https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_lights_punctual/README.md#adding-light-instances-to-nodes

This enables writing lights which are exportable in Blender.

# Example code:

We try to add a single red point-light in an empty scene, and then import it in Blender. The code:

```
import trimesh
import numpy as np

scene = trimesh.Scene()
scene_metadata = {"gltf_extensions": {"KHR_lights_punctual": {"lights": []} }}

# add a light
scene_metadata["gltf_extensions"]["KHR_lights_punctual"]["lights"].append(
    {
        "name": "light1",
        "color": [1.0,0.0,0.0],
        "intensity": 50,
        "type": "point",
        "range": 10
    })
light_metadata = {"gltf_extensions": {"KHR_lights_punctual": {"light": 0}}}
mesh = trimesh.Trimesh() # a placeholder empty mesh for the light
scene.add_geometry(mesh, node_name="light1", transform=np.eye(4), metadata=light_metadata)

# update the scene with 
scene.metadata.update(scene_metadata)

# write the scene
scene.export("./single_light.gltf")
```

# Output of the current main
```
{
    "scene": 0,
    "scenes": [
        {
            "nodes": [
                0
            ],
            "extras": {},
            "extensions": {
                "KHR_lights_punctual": {
                    "lights": [
                        {
                            "name": "light1",
                            "color": [
                                1.0,
                                0.0,
                                0.0
                            ],
                            "intensity": 50,
                            "type": "point",
                            "range": 10
                        }
                    ]
                }
            }
        }
    ],
    "asset": {
        "version": "2.0",
        "generator": "https://github.com/mikedh/trimesh"
    },
    "nodes": [
        {
            "name": "world",
            "children": [
                1
            ]
        },
        {
            "name": "light1",
            "extensions": {
                "KHR_lights_punctual": {
                    "light": 0
                }
            },
            "extras": {}
        }
    ],
    "extensionsUsed": [
        "KHR_lights_punctual"
    ]
}
```
When we import this gltf file in Blender, we get this error message:
![image](https://github.com/mikedh/trimesh/assets/13609663/fc7373e6-545b-4a1a-bd1e-7600c6b866b7)

Which means that extensions needs to be at the top-most level of the tree.

# Output of this branch

This GLTF json is shown below, followed by the visualization on importing in Blender:
```
{
    "scene": 0,
    "scenes": [
        {
            "nodes": [
                0
            ],
            "extras": {}
        }
    ],
    "asset": {
        "version": "2.0",
        "generator": "https://github.com/mikedh/trimesh"
    },
    "extensions": {
        "KHR_lights_punctual": {
            "lights": [
                {
                    "name": "light1",
                    "color": [
                        1.0,
                        0.0,
                        0.0
                    ],
                    "intensity": 50,
                    "type": "point",
                    "range": 10
                }
            ]
        }
    },
    "nodes": [
        {
            "name": "world",
            "children": [
                1
            ]
        },
        {
            "name": "light1",
            "extensions": {
                "KHR_lights_punctual": {
                    "light": 0
                }
            },
            "extras": {}
        }
    ],
    "extensionsUsed": [
        "KHR_lights_punctual"
    ]
}
```
This GLTF is nicely importable in Blender, and produces the expected result:

![image](https://github.com/mikedh/trimesh/assets/13609663/4279a00d-b65e-43c7-8c34-3d487167358f)

 