### PR TITLE
fix: add fallback if PATH is not set

### DIFF
--- a/trimesh/interfaces/blender.py
+++ b/trimesh/interfaces/blender.py
@@ -7,7 +7,7 @@ from ..constants import log
 import os
 import platform
 
-_search_path = os.environ['PATH']
+_search_path = os.environ.get('PATH', '')
 if platform.system() == 'Windows':
     # try to find Blender install on Windows
     # split existing path by delimiter

--- a/trimesh/interfaces/scad.py
+++ b/trimesh/interfaces/scad.py
@@ -7,7 +7,7 @@ from .generic import MeshScript
 from ..constants import log
 
 # start the search with the user's PATH
-_search_path = os.environ['PATH']
+_search_path = os.environ.get('PATH', '')
 # add additional search locations on windows
 if platform.system() == 'Windows':
     # split existing path by delimiter

--- a/trimesh/interfaces/vhacd.py
+++ b/trimesh/interfaces/vhacd.py
@@ -5,7 +5,7 @@ from .generic import MeshScript
 from ..constants import log
 from ..util import which
 
-_search_path = os.environ["PATH"]
+_search_path = os.environ.get("PATH", "")
 
 if platform.system() == 'Windows':
     # split existing path by delimiter


### PR DESCRIPTION
Hey @mikedh,

we encountered a problem regarding the PATH variable: In the `interfaces` module, the content of the PATH environment variable is used as a base for the search path for executables (as it should be). However, on systems where the variable is not set, this behavior leads to a `KeyError` when loading the module.

I replaced `os.environ["PATH"]` with `os.environ.get("PATH", "")` to fix this.  