### PR TITLE
Specular/Glossiness to Metallic/Roughness pbr material conversion

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -300,6 +300,37 @@ class GLTFTest(g.unittest.TestCase):
     def test_specular_glossiness(self):
         s = g.get_mesh('pyramid.zip')
         assert len(s.geometry) > 0
+        assert 'GLTF' in s.geometry
+
+        mat = s.geometry['GLTF'].visual.material
+        assert isinstance(mat, g.trimesh.visual.material.PBRMaterial)
+
+        color = g.np.array(mat.baseColorTexture)[:, :, :3]
+        assert color.shape[0] == 84 and color.shape[1] == 71
+
+        # reference values generated with: https://kcoley.github.io/glTF/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness/examples/convert-between-workflows-bjs/
+        assert g.np.allclose(color[0, 0], [253, 234, 208], atol=1)
+        assert g.np.allclose(color[30, 30], [253, 235, 211], atol=1)
+        assert g.np.allclose(color[60, 10], [255, 238, 214], atol=1)
+        assert all(mat.baseColorFactor == [1.0, 1.0, 1.0, 1.0])
+
+        metallic_roughness = g.np.array(mat.metallicRoughnessTexture, dtype=g.np.float32) / 255.0
+        assert metallic_roughness.shape[0] == 84 and metallic_roughness.shape[1] == 71
+
+        metallic = metallic_roughness[:, :, 0]
+        roughness = metallic_roughness[:, :, 1]
+
+        assert g.np.allclose(metallic[0, 0], 0.514, atol=0.01)
+        assert g.np.allclose(metallic[30, 30], 0.49, atol=0.01)
+        assert g.np.allclose(metallic[60, 10], 0.42, atol=0.01)
+
+        assert g.np.allclose(roughness[0, 0], 0.898, atol=0.01)
+        assert g.np.allclose(roughness[30, 30], 0.898, atol=0.01)
+        assert g.np.allclose(roughness[60, 10], 0.898, atol=0.01)
+
+        assert mat.metallicFactor == 1.0
+        assert mat.roughnessFactor == 1.0
+        assert all(mat.emissiveFactor == [0.0, 0.0, 0.0])
 
     def test_write_dir(self):
         # try loading from a file name

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -11,6 +11,7 @@ import base64
 import collections
 
 import numpy as np
+import PIL
 
 from .. import util
 from .. import visual
@@ -1188,9 +1189,9 @@ def specular_to_pbr(
         Specular color values. Ignored if specularGlossinessTexture is present. Defaults to [1.0, 1.0, 1.0].
     glossinessFactor: float
         glossiness factor in range [0,1]. Ignored if specularGlossinessTexture is present. Defaults to 1.0.
-    specularGlossinessTexture: np.ndarray
+    specularGlossinessTexture: PIL image
         Texture with 4 color channels. With [0,1,2] representing specular RGB and 3 glossiness.
-    diffuseTexture: np.ndarray
+    diffuseTexture: PIL image
         Texture with 4 color channels. With [0,1,2] representing diffuse RGB and 3 opacity.
     diffuseFactor: float
         Diffuse RGBA color. Ignored if diffuseTexture is present. Defaults to [1.0, 1.0, 1.0, 1.0].
@@ -1210,34 +1211,121 @@ def specular_to_pbr(
     epsilon = 1e-6
 
     def solve_metallic(diffuse, specular, one_minus_specular_strength):
-        if specular < dielectric_specular[0]:
+        if isinstance(specular, float) and specular < dielectric_specular[0]:
             return 0.0
+
+        if len(diffuse.shape) == 2:
+            diffuse = diffuse[...,None]
+        if len(specular.shape) == 2:
+            specular = specular[...,None]
         
         a = dielectric_specular[0]
         b = diffuse * one_minus_specular_strength / (1.0 - dielectric_specular[0]) + specular - 2.0 * dielectric_specular[0]
         c = dielectric_specular[0] - specular
         D = b * b - 4.0 * a * c
-        return np.clip((-b + np.sqrt(D)) / (2.0 * a), 0.0, 1.0)
+        D = np.clip(D, epsilon, None)
+        metallic = np.clip((-b + np.sqrt(D)) / (2.0 * a), 0.0, 1.0)
+        if isinstance(metallic, np.ndarray):
+            metallic[specular < dielectric_specular[0]] = 0.0
+        return metallic
     
     def get_perceived_brightness(rgb):
         return np.dot(rgb[...,:3], [0.299, 0.587, 0.114])
 
-    if diffuseTexture is not None:
-        diffuse = diffuseTexture
-    else:
-        diffuse = diffuseFactor if diffuseFactor is not None else [1, 1, 1, 1]
-        diffuse = np.array(diffuse, dtype=np.float32)
+    def toPIL(img):
+        if isinstance(img, PIL.Image.Image):
+            return img
+        if img.dtype == np.float32 or img.dtype == np.float64:
+            img = (np.clip(img, 0.0, 1.0) * 255.0).astype(np.uint8)
+        return PIL.Image.fromarray(img)
+    
+    def get_float(val):
+        if isinstance(val, float):
+            return val
+        if isinstance(val, np.ndarray) and len(val.shape) == 1:
+            return val[0]
+        return val.tolist()
+    
+    def get_diffuse(diffuseFactor, diffuseTexture):
+        diffuseFactor = diffuseFactor if diffuseFactor is not None else [1.0, 1.0, 1.0, 1.0]
+        diffuseFactor = np.array(diffuseFactor, dtype=np.float32)
 
-    if specularGlossinessTexture is not None:
-        specular = specularGlossinessTexture[..., :3]
-        glossiness = specularGlossinessTexture[..., 3] if specularGlossinessTexture.shape[-1] == 4 else 1.0
-        one_minus_specular_strength = 1.0 - np.max(specular, dim=-1)
-    else:
-        specular = specularFactor if specularFactor is not None else [1.0, 1.0, 1.0]
-        specular = np.array(specular, dtype=np.float32)
-        glossiness = glossinessFactor if glossinessFactor is not None else 1.0
-        glossiness = np.array(glossiness, dtype=np.float32)
-        one_minus_specular_strength = 1.0 - max(specular[:3])
+        if diffuseTexture is not None:
+            diffuse = np.array(diffuseTexture) / 255.0
+            if diffuse.shape[-1] == 1:
+                diffuse = diffuse * diffuseFactor
+            elif diffuse.shape[-1] == 2:
+                alpha = diffuse[..., 1:2]
+                diffuse = diffuse[..., :1] * diffuseFactor
+                diffuse[...,-1:] *= alpha
+            elif diffuse.shape[-1] == diffuseFactor.shape[-1]: 
+                diffuse = diffuse * diffuseFactor
+            elif diffuse.shape[-1] == 3 and diffuseFactor.shape[-1] == 4:
+                diffuse = np.concatenate([diffuse, np.ones_like(diffuse[..., :1])], axis=-1) * diffuseFactor
+            else:
+                print(f"Warning: diffuseFactor and diffuseTexture have incompatible shapes {diffuseFactor.shape} and {diffuse.shape}.")
+        else:
+            diffuse = diffuseFactor if diffuseFactor is not None else [1, 1, 1, 1]
+            diffuse = np.array(diffuse, dtype=np.float32)
+        return diffuse
+    
+    def get_specular_glossiness(specularFactor, glossinessFactor, specularGlossinessTexture):
+        if specularFactor is None:
+            specularFactor = [1.0, 1.0, 1.0]
+        specularFactor = np.array(specularFactor, dtype=np.float32)
+        if glossinessFactor is None:
+            glossinessFactor = 1.0
+        glossinessFactor = np.array([glossinessFactor], dtype=np.float32)
+
+        # specularGlossinessTexture should be a texture with 4 channels, 3 sRGB channels for specular and 1 linear channel for glossiness. 
+        # in practice, it can also have just 1, 2, or 3 channels which are then to be multiplied with the provided factors
+
+        if specularGlossinessTexture is not None:
+            specularGlossinessTexture = np.array(specularGlossinessTexture)
+            specularTexture, glossinessTexture = None, None
+
+            if len(specularGlossinessTexture.shape) == 2 or specularGlossinessTexture.shape[-1] == 1:
+                # use the one channel as a multiplier for specular and glossiness
+                specularTexture = glossinessTexture = specularGlossinessTexture.reshape((-1,-1,1))
+            elif specularGlossinessTexture.shape[-1] == 3:
+                # all channels are specular, glossiness is only a factor
+                specularTexture = specularGlossinessTexture[..., :3]
+            elif specularGlossinessTexture.shape[-1] == 2:
+                # first channel is specular, last channel is glossiness
+                specularTexture = specularGlossinessTexture[..., :1]
+                glossinessTexture = specularGlossinessTexture[..., 1:2]
+            elif specularGlossinessTexture.shape[-1] == 4:
+                # first 3 channels are specular, last channel is glossiness
+                specularTexture = specularGlossinessTexture[..., :3]
+                glossinessTexture = specularGlossinessTexture[..., 3] if specularGlossinessTexture.shape[-1] == 4 else 1.0
+            
+            if specularTexture is not None:
+                # convert into [0,1] range. Does this require conversion of sRGB values?
+                specular = specularTexture / 255.0
+                specular = specular * specularFactor
+            else:
+                specular = specularFactor
+
+            if glossinessTexture is not None:
+                # convert into [0,1] range. Does this require conversion of sRGB values?
+                glossiness = glossinessTexture / 255.0
+                glossiness = glossiness * glossinessFactor
+            else:
+                glossiness = glossinessFactor
+            
+            one_minus_specular_strength = 1.0 - np.max(specular, axis=-1, keepdims=True)
+        else:
+            specular = specularFactor if specularFactor is not None else [1.0, 1.0, 1.0]
+            specular = np.array(specular, dtype=np.float32)
+            glossiness = glossinessFactor if glossinessFactor is not None else 1.0
+            glossiness = np.array(glossiness, dtype=np.float32)
+            one_minus_specular_strength = 1.0 - max(specular[:3])
+
+        return specular, glossiness, one_minus_specular_strength
+
+
+    diffuse = get_diffuse(diffuseFactor, diffuseTexture)
+    specular, glossiness, one_minus_specular_strength = get_specular_glossiness(specularFactor, glossinessFactor, specularGlossinessTexture)
 
     metallic = solve_metallic(get_perceived_brightness(diffuse), get_perceived_brightness(specular), one_minus_specular_strength)
     if not isinstance(metallic, np.ndarray):
@@ -1251,13 +1339,13 @@ def specular_to_pbr(
     base_color = mm * base_color_from_specular + (1.0 - mm) * base_color_from_diffuse
     base_color = np.clip(base_color, 0.0, 1.0)
 
-    if opacity is not None:
+    if opacity is not None and np.any(opacity < 1.0):
         base_color = np.concatenate([base_color, opacity[..., None]], axis=-1)
 
     result = {}
     if len(base_color.shape) > 1:
-        result['baseColorTexture'] = base_color
-    if diffuseFactor is not None:
+        result['baseColorTexture'] = toPIL(base_color)
+    else:
         result['baseColorFactor'] = base_color.tolist()
 
     if len(metallic.shape) > 1 or len(glossiness.shape) > 1:
@@ -1266,10 +1354,10 @@ def specular_to_pbr(
         if len(metallic.shape) == 1:
             metallic = np.tile(metallic, (glossiness.shape[0], glossiness.shape[1], 1))
         
-        result['metallicRoughnessTexture'] = np.concatenate([metallic, 1.0 - glossiness], axis=-1)
+        result['metallicRoughnessTexture'] = toPIL(np.concatenate([metallic, 1.0 - glossiness], axis=-1))
     else:
-        result['metallicFactor'] = metallic.tolist()
-        result['roughnessFactor'] = (1.0 - glossiness).tolist()
+        result['metallicFactor'] = get_float(metallic)
+        result['roughnessFactor'] = get_float(1.0 - glossiness)
 
     return result
 
@@ -1325,6 +1413,22 @@ def _parse_materials(header, views, resolver=None):
     materials : list
       List of trimesh.visual.texture.Material objects
     """
+    def parse_values_and_textures(input_dict):
+        result = {}
+        for k, v in input_dict.items():
+            if not isinstance(v, dict):
+                result[k] = v
+            elif "index" in v:
+                # get the index of image for texture
+                try:
+                    idx = header["textures"][v["index"]]["source"]
+                    # store the actual image as the value
+                    result[k] = images[idx]
+                except BaseException:
+                    log.debug('unable to store texture',
+                                exc_info=True)
+        return result
+
     images = _parse_textures(header, views, resolver)
 
     # store materials which reference images
@@ -1341,22 +1445,11 @@ def _parse_materials(header, views, resolver=None):
             ext = mat.get('extensions', {}).get(
                 'KHR_materials_pbrSpecularGlossiness', None)
             if isinstance(ext, dict):
-                loopable.update(specular_to_pbr(**ext))
+                ext_params = parse_values_and_textures(ext)
+                loopable.update(specular_to_pbr(**ext_params))
 
             # save flattened keys we can use for kwargs
-            pbr = {}
-            for k, v in loopable.items():
-                if not isinstance(v, dict):
-                    pbr[k] = v
-                elif "index" in v:
-                    # get the index of image for texture
-                    try:
-                        idx = header["textures"][v["index"]]["source"]
-                        # store the actual image as the value
-                        pbr[k] = images[idx]
-                    except BaseException:
-                        log.debug('unable to store texture',
-                                  exc_info=True)
+            pbr = parse_values_and_textures(loopable)
             # create a PBR material object for the GLTF material
             materials.append(visual.material.PBRMaterial(**pbr))
 

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -11,7 +11,6 @@ import base64
 import collections
 
 import numpy as np
-import PIL
 
 from .. import util
 from .. import visual
@@ -1206,6 +1205,17 @@ def specular_to_pbr(
     """
     # based on: https://github.com/KhronosGroup/glTF/blob/89427b26fcac884385a2e6d5803d917ab5d1b04f/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/examples/convert-between-workflows-bjs/js/babylon.pbrUtilities.js#L33-L64
 
+    
+    try:
+        import PIL.Image
+    except ImportError:
+        log.debug('unable to convert material without pillow!')
+        result = {}
+        if isinstance(diffuseTexture, dict):
+            result['baseColorTexture'] = diffuseTexture
+        if diffuseFactor is not None:
+            result['baseColorFactor'] = diffuseFactor
+        return result
 
     dielectric_specular = np.array([0.04, 0.04, 0.04], dtype=np.float32)
     epsilon = 1e-6

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1262,6 +1262,8 @@ def specular_to_pbr(
 
         if diffuseTexture is not None:
             diffuse = np.array(diffuseTexture) / 255.0
+            if len(diffuse.shape) == 2:
+                diffuse = diffuse[...,None]
             if diffuse.shape[-1] == 1:
                 diffuse = diffuse * diffuseFactor
             elif diffuse.shape[-1] == 2:

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1297,7 +1297,7 @@ def specular_to_pbr(
             elif specularGlossinessTexture.shape[-1] == 4:
                 # first 3 channels are specular, last channel is glossiness
                 specularTexture = specularGlossinessTexture[..., :3]
-                glossinessTexture = specularGlossinessTexture[..., 3] if specularGlossinessTexture.shape[-1] == 4 else 1.0
+                glossinessTexture = specularGlossinessTexture[..., 3:]
             
             if specularTexture is not None:
                 # convert into [0,1] range. Does this require conversion of sRGB values?
@@ -1322,7 +1322,14 @@ def specular_to_pbr(
             one_minus_specular_strength = 1.0 - max(specular[:3])
 
         return specular, glossiness, one_minus_specular_strength
-
+    
+    if diffuseTexture is not None and specularGlossinessTexture is not None:
+        # reshape to the size of the largest texture
+        max_shape = [max(diffuseTexture.size[i], specularGlossinessTexture.size[i]) for i in range(2)]
+        if diffuseTexture.size[0] != max_shape[0] or diffuseTexture.size[1] != max_shape[1]:
+            diffuseTexture = diffuseTexture.resize(max_shape)
+        if specularGlossinessTexture.size[0] != max_shape[0] or specularGlossinessTexture.size[1] != max_shape[1]:
+            specularGlossinessTexture = specularGlossinessTexture.resize(max_shape)
 
     diffuse = get_diffuse(diffuseFactor, diffuseTexture)
     specular, glossiness, one_minus_specular_strength = get_specular_glossiness(specularFactor, glossinessFactor, specularGlossinessTexture)


### PR DESCRIPTION
Hi!
I implemented a conversion from specular glossiness PBR materials to metallic roughness.

After trying out on two different GLB files, the code got a little more messy than I hoped for.
But this is mostly caused by non-standard textures being used in those models. 

I followed the information from [here](https://kcoley.github.io/glTF/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness/) as a reference, but most of the time, the actual textures are a bit different, e.g. using 1, 2, or 3 channels for specularGlossinessTexture instead of 4 as defined in this reference document. Because of that, I am not really sure if I always read every file correctly, but it did work fine for me in these examples.

Still, I would like to ask you for a review, because I think that this PR might come in quite handy for a lot of us people who use trimesh to parse 3d scenes.