### PR TITLE
Fix wrong depth range

### DIFF
--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -391,9 +391,6 @@ class SceneViewer(pyglet.window.Window):
         Enable depth test in OpenGL using distances
         from `scene.camera`.
         """
-        # set the culling depth from our camera object
-        gl.glDepthRange(camera.z_near, camera.z_far)
-
         gl.glClearDepth(1.0)
         gl.glEnable(gl.GL_DEPTH_TEST)
         gl.glDepthFunc(gl.GL_LEQUAL)


### PR DESCRIPTION
I was having trouble with some inexplicable z-fighting and found an unnecessary use of `glDepthRange`.

`glDepthRange` is not about clipping, but about mapping the z range [-1, 1] in NDC space to the z buffer value range [0, 1].

The default values [0, 1] are fine for normal use, so this line can be removed entirely :)