### PR TITLE
Add density, center_mass, and metadata during primitive copy

### DIFF
--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -333,6 +333,17 @@ class PrimitiveTest(g.unittest.TestCase):
         except ValueError:
             pass
 
+    def test_copy(self):
+        start = [20, 10, 100]
+        box = g.trimesh.primitives.Box(extents=start)
+        box.density = 0.3
+        box.center_mass = g.np.array([0.1, -0.6, 11.3])
+
+        box_copy = box.copy()
+
+        assert box.density == box_copy.density
+
+        assert g.np.allclose(box.center_mass, box_copy.center_mass)
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -338,12 +338,15 @@ class PrimitiveTest(g.unittest.TestCase):
         box = g.trimesh.primitives.Box(extents=start)
         box.density = 0.3
         box.center_mass = g.np.array([0.1, -0.6, 11.3])
+        box.metadata["foo"] = "bar"
 
         box_copy = box.copy()
 
         assert box.density == box_copy.density
 
         assert g.np.allclose(box.center_mass, box_copy.center_mass)
+
+        assert box.metadata == box_copy.metadata
 
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -184,7 +184,11 @@ class _Primitive(Trimesh):
         # remove the type indicator, i.e. `Cylinder`
         kwargs.pop('kind')
         # create a new object with kwargs
-        return type(self)(**kwargs)
+        primitive_copy = type(self)(**kwargs)
+        # copy metadata
+        primitive_copy.metadata = self.metadata.copy()
+
+        return primitive_copy
 
     def to_mesh(self, **kwargs):
         """

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -110,6 +110,59 @@ class _Primitive(Trimesh):
         """
         return self.primitive.transform
 
+    @property
+    def center_mass(self):
+        """
+        The point in space which is the center of mass/volume.
+
+        Returns
+        -----------
+        center_mass : (3, ) float
+           Volumetric center of mass of the primitive
+        """
+        center_mass = self.mass_properties["center_mass"]
+        return center_mass
+
+    @center_mass.setter
+    def center_mass(self, cm):
+        """
+        Set the point in space which is the center of mass/volume.
+
+        Parameters
+        -----------
+        center_mass : (3, ) float
+           Volumetric center of mass of the primitive
+        """
+        self._data["center_mass"] = cm
+        self._cache.delete("mass_properties")
+
+    @property
+    def density(self):
+        """
+        The density of the primitive.
+
+        Returns
+        -----------
+        density : float
+          The density of the primitive.
+        """
+        density = self.mass_properties["density"]
+        return density
+
+    @density.setter
+    def density(self, value):
+        """
+        Set the density of the primitive.
+
+        Parameters
+        -------------
+        density : float
+          Specify the density of the primitive to be
+          used in inertia calculations.
+        """
+        self._data["density"] = float(value)
+        self._cache.delete("mass_properties")
+
     @abc.abstractmethod
     def to_dict(self):
         """


### PR DESCRIPTION
Addresses #1989 

* New test for `Primitive.copy()` that includes `density`, `center_mass`, and `metadata`
* New setter for `density` and `center_mass` to add to `_data`
* `metadata` is copied in `Primitive.copy()`  (shallow)