### PR TITLE
prevent division by zero

### DIFF
--- a/trimesh/ray/ray_triangle.py
+++ b/trimesh/ray/ray_triangle.py
@@ -391,6 +391,9 @@ def ray_bounds(ray_origins,
     axis_dir = np.array([ray_directions[i][a]
                          for i, a in enumerate(axis)]).reshape((-1, 1))
 
+    # prevent division by zero
+    axis_dir[axis_dir == 0] = tol.zero
+
     # parametric equation of a line
     # point = direction*t + origin
     # p = dt + o

--- a/trimesh/ray/ray_triangle.py
+++ b/trimesh/ray/ray_triangle.py
@@ -395,9 +395,9 @@ def ray_bounds(ray_origins,
     # point = direction*t + origin
     # p = dt + o
     # t = (p-o)/d
-    t = (axis_bound - axis_ori) / axis_dir
-    # prevent np.inf by division by zero
-    t[axis_dir == 0.0] = 0
+    nonzero = (axis_dir != 0.0).reshape(-1)
+    t = np.zeros_like(axis_bound)
+    t[nonzero] = (axis_bound[nonzero] - axis_ori[nonzero]) / axis_dir[nonzero]
 
     # prevent the bounding box from including triangles
     # behind the ray origin

--- a/trimesh/ray/ray_triangle.py
+++ b/trimesh/ray/ray_triangle.py
@@ -391,14 +391,13 @@ def ray_bounds(ray_origins,
     axis_dir = np.array([ray_directions[i][a]
                          for i, a in enumerate(axis)]).reshape((-1, 1))
 
-    # prevent division by zero
-    axis_dir[axis_dir == 0] = tol.zero
-
     # parametric equation of a line
     # point = direction*t + origin
     # p = dt + o
     # t = (p-o)/d
     t = (axis_bound - axis_ori) / axis_dir
+    # prevent np.inf by division by zero
+    t[axis_dir == 0.0] = 0
 
     # prevent the bounding box from including triangles
     # behind the ray origin


### PR DESCRIPTION
Example (Assets: [ray.zip](https://github.com/mikedh/trimesh/files/12449626/ray.zip)) :
~~~python
import numpy as np
import trimesh
from trimesh.ray import ray_triangle

ray_origins = np.load('ray.origins.npy')
ray_directions = np.load('ray.directions.npy')
mesh = trimesh.load('ray.mesh.obj')
print(mesh.is_watertight) # True

intersector = ray_triangle.RayMeshIntersector(mesh)
intersector.intersects_location(ray_origins,ray_directions)
~~~



Produce Error:
~~~python
.../trimesh/ray/ray_triangle.py:398: RuntimeWarning: divide by zero encountered in true_divide
  t = (axis_bound - axis_ori) / axis_dir
.../trimesh/ray/ray_triangle.py:410: RuntimeWarning: invalid value encountered in multiply
  on_a = (ray_directions * t_a) + ray_origins
~~~
And leading to
~~~python
.../trimesh/ray/ray_triangle.py in intersects_location(self, ray_origins, ray_directions, **kwargs)
    105              ray_directions=ray_directions,
    106              return_locations=True,
--> 107              **kwargs)
    108         return locations, index_ray, index_tri
    109 

.../trimesh/ray/ray_triangle.py in intersects_id(self, ray_origins, ray_directions, return_locations, multiple_hits, **kwargs)
     64              tree=self.mesh.triangles_tree,
     65              multiple_hits=multiple_hits,
---> 66              triangles_normal=self.mesh.face_normals)
     67         if return_locations:
     68             if len(index_tri) == 0:

.../trimesh/ray/ray_triangle.py in ray_triangle_id(triangles, ray_origins, ray_directions, triangles_normal, tree, multiple_hits)
    238         ray_origins=ray_origins,
    239         ray_directions=ray_directions,
--> 240         tree=tree)
    241 
    242     # get subsets which are corresponding rays and triangles

.../trimesh/ray/ray_triangle.py in ray_triangle_candidates(ray_origins, ray_directions, tree)
    347 
    348     for i, bounds in enumerate(ray_bounding):
--> 349         ray_candidates[i] = np.array(list(tree.intersection(bounds)),
    350                                      dtype=np.int64)
    351         ray_id[i] = np.ones(len(ray_candidates[i]), dtype=np.int64) * i

.../rtree/index.py in intersection(self, coordinates, objects)
    819             return self._intersection_obj(coordinates, objects)
    820 
--> 821         p_mins, p_maxs = self.get_coordinate_pointers(coordinates)
    822 
    823         p_num_results = ctypes.c_uint64(0)

.../rtree/index.py in get_coordinate_pointers(self, coordinates)
    368             if not coordinates[i] <= coordinates[i + dimension]:
    369                 raise RTreeError(
--> 370                     "Coordinates must not have minimums more than maximums"
    371                 )
    372 

RTreeError: Coordinates must not have minimums more than maximums
~~~