### PR TITLE
keep vertex normals when fusing meshes

### DIFF
--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1503,6 +1503,10 @@ def concatenate(a, b=None):
     if all('face_normals' in m._cache for m in is_mesh):
         face_normals = np.vstack(
             [m.face_normals for m in is_mesh])
+        
+    # always save vertex normals
+    vertex_normals = vstack_empty(
+        [m.vertex_normals.copy() for m in is_mesh])
 
     try:
         # concatenate visuals
@@ -1516,6 +1520,7 @@ def concatenate(a, b=None):
     return trimesh_type(vertices=vertices,
                         faces=faces,
                         face_normals=face_normals,
+                        vertex_normals=vertex_normals,
                         visual=visual,
                         process=False)
 


### PR DESCRIPTION
Hi!

I am not sure if there are any potential failure cases for this. 
But I am surprised that vertex normals (and other vertex attributes as well actually) are discarded when fusing meshes.

Anyways, it does do the trick for my use case. But let me know if there are some corner cases that could make issues!