### PR TITLE
New `torus` function in `creation` module

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -326,12 +326,16 @@ def check_triangulation(v, f, true_area):
     assert g.np.isclose(area, true_area)
 
 
-def test_torus(self):
+def test_torus():
     torus = g.trimesh.creation.torus
 
-    m = torus(major_radius=1.0, minor_radius=0.2)
+    major_radius = 1.0
+    minor_radius = 0.2
+    m = torus(major_radius=major_radius, minor_radius=minor_radius)
     
-    extents = g.np.array([1.4, 1.4, 0.4])
+    extents = g.np.array([2 * major_radius + 2 * minor_radius,
+                          2 * major_radius + 2 * minor_radius,
+                          2 * minor_radius])
     assert g.np.allclose(m.extents, extents)
     assert g.np.allclose(m.bounds, [-extents / 2.0, extents / 2.0])
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -326,6 +326,15 @@ def check_triangulation(v, f, true_area):
     assert g.np.isclose(area, true_area)
 
 
+def test_torus(self):
+    torus = g.trimesh.creation.torus
+
+    m = torus(major_radius=1.0, minor_radius=0.2)
+    
+    extents = g.np.array([1.4, 1.4, 0.4])
+    assert g.np.allclose(m.extents, extents)
+    assert g.np.allclose(m.bounds, [-extents / 2.0, extents / 2.0])
+
 if __name__ == '__main__':
     g.trimesh.util.attach_to_log()
     g.unittest.main()

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -1272,3 +1272,67 @@ def truncated_prisms(tris, origin=None, normal=None):
     mesh = Trimesh(vertices=vertices, faces=faces, process=False)
 
     return mesh
+
+
+def torus(major_radius,
+          minor_radius,
+          major_sections=32,
+          minor_sections=32,
+          transform=None,
+          **kwargs):
+    """Create a mesh of a torus around Z centered at the origin.
+
+    Parameters
+    ------------
+    major_radius: (float)
+      Radius from the center of the torus to the center of the tube.
+    minor_radius: (float)
+      Radius of the tube. 
+    major_sections: int
+      Number of sections around major radius result should have
+      If not specified default is 32 per revolution
+    minor_sections: int
+      Number of sections around minor radius result should have
+      If not specified default is 32 per revolution
+    transform: (4, 4) float
+      Transformation matrix
+    **kwargs:
+      passed to Trimesh to create torus
+    
+    Returns
+    ------------
+    geometry : trimesh.Trimesh
+      Mesh of a torus
+    """
+    vertices = []
+    faces = []
+    
+    for i in range(major_sections):
+        theta = 2 * np.pi * i / major_sections
+        for j in range(minor_sections):
+            phi = 2 * np.pi * j / minor_sections
+
+            x = (major_radius + minor_radius * np.cos(phi)) * np.cos(theta)
+            y = (major_radius + minor_radius * np.cos(phi)) * np.sin(theta)
+            z = minor_radius * np.sin(phi)
+
+            vertices.append([x, y, z])
+
+            # Create faces
+            a = i * minor_sections + j
+            b = ((i + 1) % major_sections) * minor_sections + j
+            c = ((i + 1) % major_sections) * minor_sections + (j + 1) % minor_sections
+            d = i * minor_sections + (j + 1) % minor_sections
+
+            faces.append([a, b, c])
+            faces.append([a, c, d])
+
+    torus = Trimesh(vertices=vertices,
+                    faces=faces,
+                    process=False,
+                    **kwargs)
+    
+    if transform is not None:
+        torus.apply_transform(transform)
+    
+    return torus

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -1304,38 +1304,20 @@ def torus(major_radius,
     geometry : trimesh.Trimesh
       Mesh of a torus
     """
-    # Calculate vertex coordinates
-    theta = np.linspace(0, 2 * np.pi, major_sections,
-                        endpoint=False).repeat(minor_sections)
-    phi = np.tile(np.linspace(0, 2 * np.pi, minor_sections,
-                              endpoint=False), major_sections)
+    phi = np.linspace(0, 2 * np.pi, minor_sections, endpoint=False)
+    linestring = np.column_stack((minor_radius * np.cos(phi),
+                                  minor_radius * np.sin(phi))) \
+        + [major_radius, 0]
 
-    x = (major_radius + minor_radius * np.cos(phi)) * np.cos(theta)
-    y = (major_radius + minor_radius * np.cos(phi)) * np.sin(theta)
-    z = minor_radius * np.sin(phi)
+    if 'metadata' not in kwargs:
+        kwargs['metadata'] = dict()
+    kwargs['metadata'].update(
+        {'shape': 'torus',
+         'major_radius': major_radius,
+         'minor_radius': minor_radius})
 
-    vertices = np.stack((x, y, z), axis=-1).reshape(-1, 3)
-
-    # Calculate faces
-    i_range = np.arange(minor_sections)
-    j_range = np.arange(major_sections)
-
-    i_grid, j_grid = np.meshgrid(i_range, j_range, indexing='ij')
-
-    a = (i_grid * minor_sections + j_grid).ravel()
-    b = (((i_grid + 1) % major_sections) * minor_sections + j_grid).ravel()
-    c = (((i_grid + 1) % major_sections) * minor_sections + (j_grid + 1)
-         % minor_sections).ravel()
-    d = (i_grid * minor_sections + (j_grid + 1) % minor_sections).ravel()
-
-    faces = np.column_stack((a, b, c, a, c, d)).reshape(-1, 3)
-
-    torus = Trimesh(vertices=vertices,
-                    faces=faces,
-                    process=False,
-                    **kwargs)
-
-    if transform is not None:
-        torus.apply_transform(transform)
-
-    return torus
+    # generate torus through simple revolution
+    return revolve(linestring=linestring,
+                   sections=major_sections,
+                   transform=transform,
+                   **kwargs)

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -1305,9 +1305,11 @@ def torus(major_radius,
       Mesh of a torus
     """
     # Calculate vertex coordinates
-    theta = np.linspace(0, 2 * np.pi, major_sections, endpoint=False).repeat(minor_sections)
-    phi = np.tile(np.linspace(0, 2 * np.pi, minor_sections, endpoint=False), major_sections)
-    
+    theta = np.linspace(0, 2 * np.pi, major_sections,
+                        endpoint=False).repeat(minor_sections)
+    phi = np.tile(np.linspace(0, 2 * np.pi, minor_sections,
+                              endpoint=False), major_sections)
+
     x = (major_radius + minor_radius * np.cos(phi)) * np.cos(theta)
     y = (major_radius + minor_radius * np.cos(phi)) * np.sin(theta)
     z = minor_radius * np.sin(phi)
@@ -1322,7 +1324,8 @@ def torus(major_radius,
 
     a = (i_grid * minor_sections + j_grid).ravel()
     b = (((i_grid + 1) % major_sections) * minor_sections + j_grid).ravel()
-    c = (((i_grid + 1) % major_sections) * minor_sections + (j_grid + 1) % minor_sections).ravel()
+    c = (((i_grid + 1) % major_sections) * minor_sections + (j_grid + 1)
+         % minor_sections).ravel()
     d = (i_grid * minor_sections + (j_grid + 1) % minor_sections).ravel()
 
     faces = np.column_stack((a, b, c, a, c, d)).reshape(-1, 3)


### PR DESCRIPTION
A vectorized function to create the mesh of a torus (saw here https://github.com/mikedh/trimesh/issues/1490#issuecomment-1046328566 that PRs are welcome).
Parameterized by two radii and the number of sections.

Example:
```
import trimesh
trimesh.creation.torus(1.0, 0.2).show()
```

Looks like this:
![Screenshot from 2023-08-31 19-48-33](https://github.com/mikedh/trimesh/assets/1800546/a6f6d35f-bbe0-4e80-9e4b-ce277875a26c)
