### PR TITLE
Set gmsh options before opening the file

### DIFF
--- a/trimesh/interfaces/gmsh.py
+++ b/trimesh/interfaces/gmsh.py
@@ -67,6 +67,10 @@ def load_gmsh(file_name, gmsh_args=None):
         gmsh.initialize()
     gmsh.option.setNumber("General.Terminal", 1)
     gmsh.model.add('Surface_Mesh_Generation')
+    # loop through our numbered args which do things, stuff
+    for arg in args:
+        gmsh.option.setNumber(*arg)
+    
     gmsh.open(file_name)
 
     # create a temporary file for the results
@@ -78,9 +82,6 @@ def load_gmsh(file_name, gmsh_args=None):
     if any(file_name.lower().endswith(e)
            for e in ['.brep', '.stp', '.step', '.igs', '.iges']):
         gmsh.model.geo.synchronize()
-        # loop through our numbered args which do things, stuff
-        for arg in args:
-            gmsh.option.setNumber(*arg)
         # generate the mesh
         gmsh.model.mesh.generate(2)
         # write to the temporary file


### PR DESCRIPTION
I wanted to hide all terminal output when converting step files to meshes but I couldn't. 

**How it was:**
General.Terminal is set to 1, then the file is opened, and only after that the gmsh options (args in load_gmsh) are set.
This results in output such as this during opening: 
_Info    : Reading '..\test_files\my_models\my_file.stp'...
Info    :  - Label 'SomeLabel' (3D)
Info    :  - Color (0.74902, 0.74902, 0.74902) (3D & Surfaces)
Info    :  - Color (0.996078, 0.996078, 1) (Surface)
Info    :  - Color (0.996078, 0.996078, 1) (Surface)
Info    :  - Color (0.996078, 0.996078, 1) (Surface)
..._

**Now:**
gmsh options are set before opening the step file. 
This allows to hide the terminal output during opening by passing arg _("General.Terminal", 0)_. 

This works well for me. Please enlighten me if I missed any drawbacks.

Thanks for the great work on trimesh!