### PR TITLE
fixed gltf export when using paths instead of only file name

### DIFF
--- a/trimesh/exchange/export.py
+++ b/trimesh/exchange/export.py
@@ -90,7 +90,7 @@ def export_mesh(mesh,
     if isinstance(export, dict):
         # if we have a filename rename the default GLTF
         if file_name is not None and 'model.gltf' in export:
-            export[file_name] = export.pop('model.gltf')
+            export[os.path.basename(file_name)] = export.pop('model.gltf')
 
         # write the files if a resolver has been passed
         if resolver is not None:


### PR DESCRIPTION
When you store a GLTF file using a path instead of only a file name, this line effectively duplicated the path.

E.g., instead of writing all files into `out` when using `scene.export("out/scene.gltf")`, it saved all files in `out` except for the `gltf` file which is stored in `out/out/mesh.gltf` - raising an exception doing so.