### PR TITLE
Modified to skip processing when the vertex attribute of primitive is None

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -191,6 +191,8 @@ def _parse_node(
                 primitive = primitive.triangleset()
             if isinstance(primitive, collada.triangleset.TriangleSet):
                 vertex = primitive.vertex
+                if vertex is None:
+                    continue
                 vertex_index = primitive.vertex_index
                 vertices = vertex[vertex_index].reshape(len(vertex_index) * 3, 3)
 


### PR DESCRIPTION
This PR avoids errors when loading collada (dae) files that do not have vertices by skipping the process if the vertex is None.
