### PR TITLE
mesh.smooth cache logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,6 @@ RUN pip install -e .[all]
 
 # check formatting
 RUN ruff trimesh
-RUN black --check trimesh
 
 # run pytest wrapped with xvfb for simple viewer tests
 RUN xvfb-run pytest --cov=trimesh \

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -71,9 +71,10 @@ if __name__ == '__main__':
 When you remove the embed and see the profile result you can then tweak the lines that are slow before finishing the function.
 
 ### Automatic Formatting
-The only check in that's required to pass in CI is `ruff`, which I usually run with:
+Trimesh uses `ruff` and `black` configured in `pyproject.toml`, you can run with:
 ```
 ruff . --fix
+black .
 ```
 It can fix a lot of formatting issues automatically. We also periodically run `black` to autoformat the codebase.
 
@@ -81,6 +82,7 @@ It can fix a lot of formatting issues automatically. We also periodically run `b
 ## Docstrings
 
 Trimesh uses the [Sphinx Numpy-style](https://www.sphinx-doc.org/en/master/usage/extensions/example_numpy.html#example-numpy) docstrings which get parsed into the API reference page. 
+
 
 ## General Tips
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -24,8 +24,7 @@ pip install trimesh[all]
 ```
 
 
-Conda Packages
---------------
+## Conda Packages
 
 If you prefer a `conda` environment, `trimesh` is available on `conda-forge` ([trimesh-feedstock repo](https://github.com/conda-forge/trimesh-feedstock))
 
@@ -34,20 +33,11 @@ If you install [Miniconda](https://docs.conda.io/projects/miniconda/en/latest/) 
 ```
 conda install -c conda-forge trimesh
 ```
-      
-Ubuntu-Debian Notes
--------------------
 
-Blender and openSCAD are soft dependencies used for boolean operations with subprocess, you can get them with `apt`:
-
-```
-sudo apt-get install blender
-```
-
-Dependency Overview
+## Dependency Overview
 --------------------
 
-Trimesh has a lot of soft-required upstream packages. We try to make sure they're active and big-ish. Here's a quick summary of what they're used for.
+Trimesh has a lot of soft-required upstream packages, and we try to make sure they're actively maintained. Here's a quick summary of what they're used for:
 
  
 | Package | Description | Alternatives | Level |
@@ -81,3 +71,16 @@ Trimesh has a lot of soft-required upstream packages. We try to make sure they'r
 |`pytest-cov`| A plugin to calculate test coverage. | | `test`|
 |`pyinstrument`| A sampling based profiler for performance tweaking. | | `test`|
 |`vhacdx`| A binding for VHACD which provides convex decompositions | | `recommend`|
+
+## Adding A Dependency
+
+If there's no way to implement something reasonably in vectorized Python or there is a mature minimal C++ or Rust implementation of something useful and complicated we may add a dependency. If it's a major, active project with few dependencies (i.e. `jinja2`) that's probably fine. Otherwise it's a lot more of a commitment than just implementing the function in Python however. An example of this is `embree`, Intel's ray check engine: it is a super complicated thing to do well and 50-100x faster than Python ray checks.
+
+There are a few projects that we've forked into the [`trimesh`](https://github.com/trimesh/) GitHub organization which you can take a look at. The general idea of the requirements for a new compiled dependency are:
+
+- is actively maintained and has an MIT/BSD compatible license.
+- has all source code in the repository or as a submodule, i.e. no mysterious binary blobs.
+- binding preferably uses [pybind11](https://pybind11.readthedocs.io/en/stable/index.html), [nanobind](https://github.com/wjakob/nanobind) or [maturin/py03](https://github.com/PyO3/maturin) for Rust projects. Cython is also OK but other options are preferable if possible. 
+- uses `cibuildwheel` to publish releases configured in `pyproject.toml`.
+- has unit tests which run in CI
+- has minimal dependencies: ideally only `numpy`.

--- a/examples/offscreen_render.py
+++ b/examples/offscreen_render.py
@@ -17,11 +17,11 @@ if __name__ == "__main__":
     # a 45 degree homogeneous rotation matrix around
     # the Y axis at the scene centroid
     rotate = trimesh.transformations.rotation_matrix(
-        angle=np.radians(10.0), direction=[0, 1, 0], point=scene.centroid
+        angle=np.radians(30.0), direction=[1, 0, 0], point=scene.centroid
     )
 
-    for i in range(4):
-        trimesh.constants.log.info("Saving image %d", i)
+    for i in range(10):
+        trimesh.constants.log.info(f"Saving image {i}")
 
         # rotate the camera view transform
         camera_old, _geometry = scene.graph[scene.camera.name]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.7"
-version = "4.0.0"
+version = "4.0.1"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -31,7 +31,7 @@ def typical_application():
 
         faces = mesh.facets[mesh.facets_area.argmax()]
         outline = mesh.outline(faces)  # NOQA
-        smoothed = mesh.smoothed()  # NOQA
+        smoothed = mesh.smooth_shaded  # NOQA
 
         assert mesh.volume > 0.0
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -356,6 +356,24 @@ class CacheTest(g.unittest.TestCase):
         m.process(validate=True)
         assert m.triangles.shape == (1, 3, 3)
 
+    def test_smooth_shade(self, count=10):
+        # test to make sure the smooth shaded copy is cached correctly
+        mesh = g.trimesh.creation.cylinder(radius=1, height=10)
+        scene = g.trimesh.Scene({"mesh": mesh})
+
+        initial = scene.camera_transform.copy()
+
+        hashes = set()
+        for n in range(count):
+            angle = g.np.pi * n / count
+            matrix = g.trimesh.transformations.rotation_matrix(angle, [1, 0, 0])
+            scene.geometry["mesh"].apply_transform(matrix)
+            hashes.add(scene.geometry["mesh"].smooth_shaded)
+            scene.camera_transform = initial
+
+        # the smooth shade should be unique for every transform
+        assert len(hashes) == count
+
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -368,7 +368,7 @@ class CacheTest(g.unittest.TestCase):
             angle = g.np.pi * n / count
             matrix = g.trimesh.transformations.rotation_matrix(angle, [1, 0, 0])
             scene.geometry["mesh"].apply_transform(matrix)
-            hashes.add(scene.geometry["mesh"].smooth_shaded)
+            hashes.add(hash(scene.geometry["mesh"].smooth_shaded))
             scene.camera_transform = initial
 
         # the smooth shade should be unique for every transform

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -123,7 +123,7 @@ class VisualTest(g.unittest.TestCase):
         m = g.get_mesh("featuretype.STL")
 
         # will put smoothed mesh into visuals cache
-        s = m.smoothed()
+        s = m.smooth_shaded
         # every color should be default color
         assert s.visual.face_colors.ptp(axis=0).max() == 0
 
@@ -131,16 +131,16 @@ class VisualTest(g.unittest.TestCase):
         m.visual.face_colors[0] = [255, 0, 0, 255]
 
         # cache should be dumped yo
-        s1 = m.smoothed()
+        s1 = m.smooth_shaded
         assert s1.visual.face_colors.ptp(axis=0).max() != 0
 
         # do the same check on vertex color
         m = g.get_mesh("featuretype.STL")
-        s = m.smoothed()
+        s = m.smooth_shaded
         # every color should be default color
         assert s.visual.vertex_colors.ptp(axis=0).max() == 0
         m.visual.vertex_colors[g.np.arange(10)] = [255, 0, 0, 255]
-        s1 = m.smoothed()
+        s1 = m.smooth_shaded
         assert s1.visual.face_colors.ptp(axis=0).max() != 0
 
     def test_vertex(self):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -113,7 +113,7 @@ class GraphTest(g.unittest.TestCase):
 
         for name in ["ADIS16480.STL", "featuretype.STL"]:
             mesh = g.get_mesh(name)
-            assert len(mesh.faces) == len(mesh.smoothed().faces)
+            assert len(mesh.faces) == len(mesh.smooth_shaded.faces)
 
     def test_engines(self):
         edges = g.np.arange(10).reshape((-1, 2))

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -78,6 +78,22 @@ class GroupTests(g.unittest.TestCase):
         assert set(result[0]) == {1}
         assert all(a[i].all() for i in result)
 
+        # make sure wrapping works if all values are True
+        arr = g.np.ones(10, dtype=bool)
+        result = blocks(arr, min_len=1, wrap=True, only_nonzero=True)
+        assert len(result) == 1
+        assert set(result[0]) == set(range(10))
+
+        # and all false
+        arr = g.np.zeros(10, dtype=bool)
+        result = blocks(arr, min_len=1, wrap=True, only_nonzero=True)
+        assert len(result) == 0
+
+        arr = g.np.zeros(10, dtype=bool)
+        result = blocks(arr, min_len=1, wrap=True, only_nonzero=False)
+        assert len(result) == 1
+        assert set(result[0]) == set(range(10))
+
     def test_block_wrap(self):
         """
         Test blocks with wrapping

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -15,25 +15,42 @@ class IntervalTest(g.unittest.TestCase):
                 [[5, 15], [7, 10]],
                 [[5, 10], [10, 9]],
                 [[0, 1], [0.9, 10]],
-            ]
-        )
-        tru_hit = [False, False, False, True, True, True, True]
-        tru_int = g.np.array(
-            [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [10, 20], [7, 10], [9, 10], [0.9, 1.0]]
+                [[1000, 1001], [2000, 2001]],
+            ],
+            dtype=g.np.float64,
         )
 
-        func = g.trimesh.interval.intersection
+        # true intersection ranges
+        truth = g.np.array(
+            [
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [10, 20],
+                [7, 10],
+                [9, 10],
+                [0.9, 1.0],
+                [0, 0],
+            ],
+            dtype=g.np.float64,
+        )
+
+        intersection = g.trimesh.interval.intersection
+        union = g.trimesh.interval.union
 
         # check the single- interval results
-        for ab, h, i in zip(pairs, tru_hit, tru_int):
-            r_h, r_i = func(*ab)
-            assert g.np.allclose(r_i, i)
-            assert r_h == h
+        for ab, tru in zip(pairs, truth):
+            result = intersection(*ab)
+            assert g.np.allclose(result, tru)
 
         # check the vectorized multiple interval results
-        r_h, r_i = func(pairs[:, 0, :], pairs[:, 1, :])
-        assert g.np.allclose(r_h, tru_hit)
-        assert g.np.allclose(r_i, tru_int)
+        inter = intersection(pairs[:, 0, :], pairs[:, 1, :])
+
+        assert g.np.allclose(truth, inter)
+
+        # now just run a union on these for the fun of it
+        u = union(pairs.reshape((-1, 2)))
+        assert g.np.allclose(u, [[0.0, 21.0], [1000.0, 1001.0], [2000.0, 2001.0]])
 
 
 if __name__ == "__main__":

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -78,7 +78,7 @@ class MeshTests(g.unittest.TestCase):
                 # on a Path3D object
                 test = outline.paths  # NOQA
 
-            smoothed = mesh.smoothed()  # NOQA
+            smoothed = mesh.smooth_shaded  # NOQA
 
             assert abs(mesh.volume) > 0.0
 

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -113,6 +113,31 @@ class SegmentsTest(g.unittest.TestCase):
         # make sure overall length hasn't changed
         assert g.np.isclose(length(res), length(seg))
 
+    def test_clean(self):
+        from trimesh.path.segments import clean, resample
+
+        seg = g.np.array(
+            [[[0, 0], [1, 0]], [[1, 0], [1, 1]], [[1, 1], [0, 1]], [[0, 1], [0, 0]]],
+            dtype=g.np.float64,
+        )
+
+        c = clean(seg)
+        assert len(seg) == len(c)
+        # bounding box should be the same
+        assert g.np.allclose(
+            c.reshape((-1, 2)).min(axis=0), seg.reshape((-1, 2)).min(axis=0)
+        )
+        assert g.np.allclose(
+            c.reshape((-1, 2)).max(axis=0), seg.reshape((-1, 2)).max(axis=0)
+        )
+
+        # resample to shorten
+        r = resample(seg, maxlen=0.3)
+        assert r.shape == (16, 2, 2)
+        # after cleaning should be back to 4 segments
+        rc = clean(r)
+        assert rc.shape == (4, 2, 2)
+
     def test_svg(self):
         from trimesh.path.segments import to_svg
 

--- a/tests/test_smooth.py
+++ b/tests/test_smooth.py
@@ -7,7 +7,7 @@ except BaseException:
 class SmoothTest(g.unittest.TestCase):
     def test_smooth(self):
         m = g.get_mesh("chair_model.obj", force="mesh")
-        s = m.smoothed()
+        s = m.smooth_shaded
 
         ori = g.np.hstack((m.visual.uv, m.vertices))
         check = g.np.hstack((s.visual.uv, s.vertices))

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2125,7 +2125,7 @@ class Trimesh(Geometry3D):
         # run smoothing
         return self.smooth_shaded
 
-    @caching.cache_decorator
+    @property
     def smooth_shaded(self):
         """
         Smooth shading in OpenGL relies on which vertices are shared,
@@ -2140,7 +2140,16 @@ class Trimesh(Geometry3D):
         smooth_shaded : trimesh.Trimesh
           Non watertight version of current mesh.
         """
-        return graph.smooth_shade(self)
+        # key this also by the visual properties
+        # but store it in the mesh cache
+        key = f"smooth_shaded_{hash(self.visual)}"
+        if key in self._cache:
+            return self._cache[key]
+        smooth = graph.smooth_shade(self)
+
+        # store it in the mesh cache which dumps when vertices change
+        self._cache[key] = smooth
+        return smooth
 
     @property
     def visual(self):

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2149,7 +2149,8 @@ class Trimesh(Geometry3D):
         self.visual._verify_hash()
 
         cache = self.visual._cache
-        key = f"smooth_shaded_{hash(self.visual)}"
+        # needs to be dumped whenever visual or mesh changes
+        key = f"smooth_shaded_{hash(self.visual)}_{hash(self)}"
         if key in cache:
             return cache[key]
         smooth = graph.smooth_shade(self)

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2146,13 +2146,16 @@ class Trimesh(Geometry3D):
         """
         # key this also by the visual properties
         # but store it in the mesh cache
+        self.visual._verify_hash()
+
+        cache = self.visual._cache
         key = f"smooth_shaded_{hash(self.visual)}"
-        if key in self._cache:
-            return self._cache[key]
+        if key in cache:
+            return cache[key]
         smooth = graph.smooth_shade(self)
 
         # store it in the mesh cache which dumps when vertices change
-        self._cache[key] = smooth
+        cache[key] = smooth
         return smooth
 
     @property

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2121,7 +2121,7 @@ class Trimesh(Geometry3D):
         DEPRECATED: use `mesh.smooth_shaded` or `trimesh.graph.smooth_shade(mesh)`
         """
         warnings.warn(
-            "`mesh.smooth_shaded` is deprected and will be removed in March 2024: "
+            "`mesh.smoothed()` is deprected and will be removed in March 2024: "
             + "use `mesh.smooth_shaded` or `trimesh.graph.smooth_shade(mesh)`",
             category=DeprecationWarning,
             stacklevel=2,

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2114,25 +2114,14 @@ class Trimesh(Geometry3D):
 
     def smoothed(self, **kwargs):
         """
-        Return a version of the current mesh which will render
-        nicely, without changing source mesh.
-
-        Parameters
-        -------------
-        angle : float or None
-          Angle in radians face pairs with angles
-          smaller than this will appear smoothed
-        facet_minarea : float or None
-          Minimum area fraction to consider
-          IE for `facets_minarea=25` only facets larger
-          than `mesh.area / 25` will be considered.
-
-        Returns
-        ---------
-        smoothed : trimesh.Trimesh
-          Non watertight version of current mesh
-          which will render nicely with smooth shading
+        DEPRECATED: use `mesh.smooth_shaded` or `trimesh.graph.smooth_shade(mesh)`
         """
+        warnings.warn(
+            "`mesh.smooth_shaded` is deprected and will be removed in March 2024: "
+            + "use `mesh.smooth_shaded` or `trimesh.graph.smooth_shade(mesh)`",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         # run smoothing
         return self.smooth_shaded
 

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -277,7 +277,7 @@ class Trimesh(Geometry3D):
         return self._data.mutable
 
     @mutable.setter
-    def mutable(self, value: bool):
+    def mutable(self, value: bool) -> None:
         """
         Set the mutability of the current mesh.
 
@@ -342,7 +342,7 @@ class Trimesh(Geometry3D):
         return sparse
 
     @property
-    def face_normals(self):
+    def face_normals(self) -> NDArray[float64]:
         """
         Return the unit normal vector for each face.
 
@@ -394,7 +394,7 @@ class Trimesh(Geometry3D):
         return padded
 
     @face_normals.setter
-    def face_normals(self, values):
+    def face_normals(self, values: NDArray[float64]) -> None:
         """
         Assign values to face normals.
 
@@ -434,7 +434,7 @@ class Trimesh(Geometry3D):
         self._cache["face_normals"] = values
 
     @property
-    def vertices(self):
+    def vertices(self) -> NDArray[float64]:
         """
         The vertices of the mesh.
 
@@ -451,7 +451,7 @@ class Trimesh(Geometry3D):
         return self._data.get("vertices", np.empty(shape=(0, 3), dtype=float64))
 
     @vertices.setter
-    def vertices(self, values):
+    def vertices(self, values: NDArray[float64]):
         """
         Assign vertex values to the mesh.
 
@@ -465,7 +465,7 @@ class Trimesh(Geometry3D):
         self._data["vertices"] = np.asanyarray(values, order="C", dtype=float64)
 
     @caching.cache_decorator
-    def vertex_normals(self):
+    def vertex_normals(self) -> NDArray[float64]:
         """
         The vertex normals of the mesh. If the normals were loaded
         we check to make sure we have the same number of vertex
@@ -491,7 +491,7 @@ class Trimesh(Geometry3D):
         return vertex_normals
 
     @vertex_normals.setter
-    def vertex_normals(self, values: NDArray[float64]):
+    def vertex_normals(self, values: NDArray[float64]) -> None:
         """
         Assign values to vertex normals.
 
@@ -608,7 +608,7 @@ class Trimesh(Geometry3D):
         return centroid
 
     @property
-    def center_mass(self):
+    def center_mass(self) -> NDArray[float64]:
         """
         The point in space which is the center of mass/volume.
 
@@ -620,7 +620,7 @@ class Trimesh(Geometry3D):
         return self.mass_properties.center_mass
 
     @center_mass.setter
-    def center_mass(self, value):
+    def center_mass(self, value: NDArray[float64]) -> None:
         """
         Override the point in space which is the center of mass and volume.
 
@@ -648,7 +648,7 @@ class Trimesh(Geometry3D):
         return self.mass_properties.density
 
     @density.setter
-    def density(self, value: float):
+    def density(self, value: float) -> None:
         """
         Set the density of the primitive.
 
@@ -1138,9 +1138,9 @@ class Trimesh(Geometry3D):
         self,
         merge_tex: Optional[bool] = None,
         merge_norm: Optional[bool] = None,
-        digits_vertex: None = None,
-        digits_norm: None = None,
-        digits_uv: None = None,
+        digits_vertex: Optional[bool] = None,
+        digits_norm: Optional[bool] = None,
+        digits_uv: Optional[bool] = None,
     ) -> None:
         """
         Removes duplicate vertices grouped by position and
@@ -1336,7 +1336,7 @@ class Trimesh(Geometry3D):
         )
         self.update_faces(self.unique_faces())
 
-    def rezero(self):
+    def rezero(self) -> None:
         """
         Translate the mesh so that all vertex vertices are positive.
 
@@ -1709,7 +1709,7 @@ class Trimesh(Geometry3D):
         )
         self.update_faces(self.nondegenerate_faces(height=height))
 
-    def nondegenerate_faces(self, height=tol.merge) -> NDArray[bool]:
+    def nondegenerate_faces(self, height: float = tol.merge) -> NDArray[bool]:
         """
         Remove degenerate faces (faces without 3 unique vertex indices)
         from the current mesh.
@@ -1855,7 +1855,7 @@ class Trimesh(Geometry3D):
 
         return on_hull
 
-    def fix_normals(self, multibody: Optional[bool] = None):
+    def fix_normals(self, multibody: Optional[bool] = None) -> None:
         """
         Find and fix problems with self.face_normals and self.faces
         winding direction.
@@ -1885,7 +1885,7 @@ class Trimesh(Geometry3D):
         """
         return repair.fill_holes(self)
 
-    def register(self, other, **kwargs):
+    def register(self, other: Geometry3D, **kwargs):
         """
         Align a mesh with another mesh or a PointCloud using
         the principal axes of inertia as a starting point which
@@ -1917,7 +1917,11 @@ class Trimesh(Geometry3D):
         return mesh_to_other, cost
 
     def compute_stable_poses(
-        self, center_mass=None, sigma=0.0, n_samples=1, threshold=0.0
+        self,
+        center_mass: Optional[NDArray[float64]] = None,
+        sigma: float = 0.0,
+        n_samples: int = 1,
+        threshold: float = 0.0,
     ):
         """
         Computes stable orientations of a mesh and their quasi-static probabilities.
@@ -2222,7 +2226,12 @@ class Trimesh(Geometry3D):
 
         return path
 
-    def section_multiplane(self, plane_origin, plane_normal, heights):
+    def section_multiplane(
+        self,
+        plane_origin: NDArray[float64],
+        plane_normal: NDArray[float64],
+        heights: NDArray[float64],
+    ):
         """
         Return multiple parallel cross sections of the current
         mesh in 2D.

--- a/trimesh/graph.py
+++ b/trimesh/graph.py
@@ -748,7 +748,7 @@ def smoothed(*args, **kwargs):
     DEPRECATED: use `trimesh.graph.smooth_shade(mesh, ...)`
     """
     warnings.warn(
-        "`trimesh.graph.smooth_shaded` is deprected and will be removed in March 2024: "
+        "`trimesh.graph.smoothed` is deprected and will be removed in March 2024: "
         + "use `trimesh.graph.smooth_shade(mesh, ...)`",
         category=DeprecationWarning,
         stacklevel=2,

--- a/trimesh/graph.py
+++ b/trimesh/graph.py
@@ -15,6 +15,7 @@ import numpy as np
 from . import exceptions, grouping, util
 from .constants import log, tol
 from .geometry import faces_to_edges
+from .typed import Optional
 
 try:
     from scipy.sparse import coo_matrix, csgraph
@@ -741,9 +742,15 @@ def neighbors(edges, max_index=None, directed=False):
     return array
 
 
-def smoothed(mesh, angle=None, facet_minarea=10):
+def smoothed(*args, **kwargs):
+    return smooth_shade(*args, **kwargs)
+
+
+def smooth_shade(
+    mesh, angle: Optional[float] = None, facet_minarea: Optional[float] = 10.0
+):
     """
-    Return a non- watertight version of the mesh which
+    Return a non-watertight version of the mesh which
     will render nicely with smooth shading by
     disconnecting faces at sharp angles to each other.
 

--- a/trimesh/graph.py
+++ b/trimesh/graph.py
@@ -9,6 +9,7 @@ Currently uses networkx or scipy.sparse.csgraph backend.
 """
 
 import collections
+import warnings
 
 import numpy as np
 
@@ -743,6 +744,15 @@ def neighbors(edges, max_index=None, directed=False):
 
 
 def smoothed(*args, **kwargs):
+    """
+    DEPRECATED: use `trimesh.graph.smooth_shade(mesh, ...)`
+    """
+    warnings.warn(
+        "`trimesh.graph.smooth_shaded` is deprected and will be removed in March 2024: "
+        + "use `trimesh.graph.smooth_shade(mesh, ...)`",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     return smooth_shade(*args, **kwargs)
 
 

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -781,6 +781,10 @@ def blocks(data, min_len=2, max_len=np.inf, wrap=False, digits=None, only_nonzer
         if only_nonzero and not bool(data[0]):
             return blocks
 
+        # if all values are True or False we can exit
+        if len(blocks) == 1 and len(blocks[0]) == len(data):
+            return blocks
+
         # so now first point equals last point, so the cases are:
         # - first and last point are in a block: combine two blocks
         # - first OR last point are in block: add other point to block

--- a/trimesh/interval.py
+++ b/trimesh/interval.py
@@ -13,8 +13,8 @@ from .typed import NDArray, float64
 
 def intersection(a: NDArray[float64], b: NDArray[float64]) -> NDArray[float64]:
     """
-    Given a pair of ranges, merge them in to
-    one range if they overlap at all
+    Given pairs of ranges merge them in to
+    one range if they overlap.
 
     Parameters
     --------------
@@ -27,7 +27,7 @@ def intersection(a: NDArray[float64], b: NDArray[float64]) -> NDArray[float64]:
     --------------
     inter : (2, ) or (2, 2) float
       The unioned range from the two inputs,
-      if not overlapping ptp will be zero.
+      if not `inter.ptp(axis=1)` will be zero.
     """
     a = np.array(a, dtype=np.float64)
     b = np.array(b, dtype=np.float64)

--- a/trimesh/interval.py
+++ b/trimesh/interval.py
@@ -11,121 +11,63 @@ import numpy as np
 from .typed import NDArray, float64
 
 
-def check(a, b, digits):
-    """
-    Check input ranges, convert them to vector form,
-    and get a fixed precision integer version of them.
-
-    Parameters
-    --------------
-    a : (2, ) or (2, n) float
-      Start and end of a 1D interval
-    b : (2, ) or (2, n) float
-      Start and end of a 1D interval
-    digits : int
-      How many digits to consider
-
-    Returns
-    --------------
-    a : (2, n) float
-      Ranges as vector
-    b : (2, n) float
-      Ranges as vector
-    a_int : (2, n) int64
-      Ranges rounded to digits, as vector
-    b_int : (2, n) int64
-      Ranges rounded to digits, as vector
-    is_1D : bool
-      If True, input was single pair of ranges
-    """
-    a = np.array(a, dtype=np.float64)
-    b = np.array(b, dtype=np.float64)
-
-    if a.shape != b.shape or a.shape[-1] != 2:
-        raise ValueError("ranges must be identical and (2,)!")
-
-    # if input was single interval reshape it here
-    is_1D = False
-    if len(a.shape) == 1:
-        a = a.reshape((-1, 2))
-        b = b.reshape((-1, 2))
-        is_1D = True
-
-    # make sure ranges are sorted
-    a.sort(axis=1)
-    b.sort(axis=1)
-
-    # compare in fixed point as integers
-    a_int = (a * 10**digits).round().astype(np.int64)
-    b_int = (b * 10**digits).round().astype(np.int64)
-
-    return a, b, a_int, b_int, is_1D
-
-
-def intersection(a, b, digits=8):
+def intersection(a: NDArray[float64], b: NDArray[float64]) -> NDArray[float64]:
     """
     Given a pair of ranges, merge them in to
     one range if they overlap at all
 
     Parameters
     --------------
-    a : (2, ) float
+    a : (2, ) or (n, 2)
       Start and end of a 1D interval
     b : (2, ) float
       Start and end of a 1D interval
-    digits : int
-      How many digits to consider
 
     Returns
     --------------
-    intersects : bool or (n,) bool
-      Indicates if the ranges overlap at all
-    new_range : (2, ) or (2, 2) float
+    inter : (2, ) or (2, 2) float
       The unioned range from the two inputs,
-      or both of the original ranges if not overlapping
+      if not overlapping ptp will be zero.
     """
-    # check shape and convert
-    a, b, a_int, b_int, is_1D = check(a, b, digits)
+    a = np.array(a, dtype=np.float64)
+    b = np.array(b, dtype=np.float64)
 
-    # what are the starting and ending points of the overlap
+    # convert to vectorized form
+    is_1D = a.shape == (2,)
+    a = a.reshape((-1, 2))
+    b = b.reshape((-1, 2))
+    
+    # make sure they're min-max
+    a.sort(axis=1)
+    b.sort(axis=1)
+    a_low, a_high = a.T
+    b_low, b_high = b.T
+
+    # do the checks
+    check = np.logical_not(np.logical_or(b_low >= a_high, a_low >= b_high))
     overlap = np.zeros(a.shape, dtype=np.float64)
-
-    # A fully overlaps B
-    current = np.logical_and(a_int[:, 0] <= b_int[:, 0], a_int[:, 1] >= b_int[:, 1])
-    overlap[current] = b[current]
-
-    # B fully overlaps A
-    current = np.logical_and(a_int[:, 0] >= b_int[:, 0], a_int[:, 1] <= b_int[:, 1])
-    overlap[current] = a[current]
-
-    # A starts B ends
-    # A:, 0   B:, 0     A:, 1        B:, 1
-    current = np.logical_and(
-        np.logical_and(a_int[:, 0] <= b_int[:, 0], b_int[:, 0] < a_int[:, 1]),
-        a_int[:, 1] < b_int[:, 1],
+    overlap[check] = np.column_stack(
+        (
+            np.array([a_low[check], b_low[check]]).max(axis=0),
+            np.array([a_high[check], b_high[check]]).min(axis=0),
+        )
     )
-    overlap[current] = np.column_stack([b[current][:, 0], a[current][:, 1]])
-
-    # B starts A ends
-    # B:, 0  A:, 0    B:, 1  A:, 1
-    current = np.logical_and(
-        np.logical_and(b_int[:, 0] <= a_int[:, 0], a_int[:, 0] < b_int[:, 1]),
-        b_int[:, 1] < a_int[:, 1],
-    )
-    overlap[current] = np.column_stack([a[current][:, 0], b[current][:, 1]])
-
-    # is range overlapping at all
-    intersects = overlap.ptp(axis=1) > 10**-digits
 
     if is_1D:
-        return intersects[0], overlap[0]
+        return overlap[0]
 
-    return intersects, overlap
+    return overlap
 
 
 def union(intervals: NDArray[float64], sort: bool = True) -> NDArray[float64]:
     """
-    For an array of intervals union them into just the subset of intervals.
+    For array of multiple intervals union them all into
+    the subset of intervals.
+
+    For example:
+    `intervals = [[1,2], [2,3]] -> [[1, 3]]`
+    `intervals = [[1,2], [2.5,3]] -> [[1, 2], [2.5, 3]]`
+
 
     Parameters
     ------------
@@ -162,4 +104,4 @@ def union(intervals: NDArray[float64], sort: bool = True) -> NDArray[float64]:
         else:
             unions.append([begin, end])
 
-    return unions
+    return np.array(unions)

--- a/trimesh/interval.py
+++ b/trimesh/interval.py
@@ -8,6 +8,8 @@ Deal with 1D intervals which are defined by:
 
 import numpy as np
 
+from .typed import NDArray, float64
+
 
 def check(a, b, digits):
     """
@@ -119,3 +121,45 @@ def intersection(a, b, digits=8):
         return intersects[0], overlap[0]
 
     return intersects, overlap
+
+
+def union(intervals: NDArray[float64], sort: bool = True) -> NDArray[float64]:
+    """
+    For an array of intervals union them into just the subset of intervals.
+
+    Parameters
+    ------------
+    intervals : (n, 2)
+      Pairs of `(min, max)` values.
+    sort
+      If the array is already ordered into (min, max) pairs
+      and then pairs sorted by minimum value you can skip the
+      sorting in this function.
+
+    Returns
+    ----------
+    unioned : (m, 2)
+      New intervals where `m <= n`
+    """
+    if len(intervals) == 0:
+        return np.empty(0)
+
+    # if the intervals have not been pre-sorted we should apply our sorting logic
+    # you would only skip this if you are subsetting a larger list elsewhere.
+    if sort:
+        # copy inputs and make sure they are (min, max) pairs
+        intervals = np.sort(intervals, axis=1)
+        # order them by lowest starting point
+        intervals = intervals[intervals[:, 0].argsort()]
+
+    # we know we will have at least one interval
+    unions = [intervals[0]]
+
+    for begin, end in intervals[1:]:
+        if unions[-1][1] >= begin:
+            #
+            unions[-1][1] = max(unions[-1][1], end)
+        else:
+            unions.append([begin, end])
+
+    return unions

--- a/trimesh/interval.py
+++ b/trimesh/interval.py
@@ -36,7 +36,7 @@ def intersection(a: NDArray[float64], b: NDArray[float64]) -> NDArray[float64]:
     is_1D = a.shape == (2,)
     a = a.reshape((-1, 2))
     b = b.reshape((-1, 2))
-    
+
     # make sure they're min-max
     a.sort(axis=1)
     b.sort(axis=1)

--- a/trimesh/path/segments.py
+++ b/trimesh/path/segments.py
@@ -177,9 +177,11 @@ def clean(segments: NDArray[float64], digits: int = 10) -> NDArray[float64]:
     # collect new unified paramameters
     p, o, v = [], [], []
     for g in group_rows(np.column_stack((origins, vectors)), digits=digits):
+        # union the intervals sorting ourselves to skip the `sort(axis=1)` we did above
         group = param[g]
         u = interval.union(group[group[:, 0].argsort()], sort=False)
         p.extend(u)
+        # use the origins for the subsetted union
         o.extend(origins[g[: len(u)]])
         v.extend(vectors[g[: len(u)]])
 

--- a/trimesh/path/segments.py
+++ b/trimesh/path/segments.py
@@ -9,9 +9,10 @@ import numpy as np
 
 from .. import geometry, grouping, interval, transformations, util
 from ..constants import tol
+from ..typed import NDArray, float64
 
 
-def segments_to_parameters(segments):
+def segments_to_parameters(segments: NDArray[float64]):
     """
     For 3D line segments defined by two points, turn
     them in to an origin defined as the closest point along
@@ -144,6 +145,27 @@ def colinear_pairs(segments, radius=0.01, angle=0.01, length=None):
         colinear = colinear[identical]
 
     return colinear
+
+
+def clean(segments, digits=10):
+    """
+    Clean
+    """
+    # convert segments to parameterized origins
+    # which are the closest point on the line to
+    # the actual zero- origin
+    origins, vectors, param = segments_to_parameters(segments)
+
+    # collect new unified paramameters
+    p, o, v = [], [], []
+    for g in grouping.group_rows(np.column_stack((origins, vectors)), digits=digits):
+        # union the ranges
+        u = interval.union(param[g])
+        p.extend(u)
+        o.extend(origins[g[: len(u)]])
+        v.extend(vectors[g[: len(u)]])
+
+    return parameters_to_segments(o, v, p)
 
 
 def split(segments, points, atol=1e-5):

--- a/trimesh/rendering.py
+++ b/trimesh/rendering.py
@@ -136,7 +136,6 @@ def mesh_to_vertexlist(mesh, group=None, smooth=True, smooth_threshold=60000):
         color_gl,
     )
 
-    print("renda", hash(mesh), np.array(vertices).reshape((-1, 3)).ptp(axis=0))
     return args
 
 

--- a/trimesh/rendering.py
+++ b/trimesh/rendering.py
@@ -69,6 +69,7 @@ def mesh_to_vertexlist(mesh, group=None, smooth=True, smooth_threshold=60000):
     --------------
     args : (7,) tuple
       Args for vertex list constructor
+
     """
 
     if hasattr(mesh.visual, "uv"):
@@ -107,7 +108,7 @@ def mesh_to_vertexlist(mesh, group=None, smooth=True, smooth_threshold=60000):
         # if we have a small number of faces and colors defined
         # smooth the  mesh by merging vertices of faces below
         # the threshold angle
-        mesh = mesh.smoothed()
+        mesh = mesh.smooth_shaded
         vertex_count = len(mesh.vertices)
         normals = mesh.vertex_normals.reshape(-1).tolist()
         faces = mesh.faces.reshape(-1).tolist()
@@ -134,6 +135,8 @@ def mesh_to_vertexlist(mesh, group=None, smooth=True, smooth_threshold=60000):
         ("n3f/static", normals),
         color_gl,
     )
+
+    print("renda", hash(mesh), np.array(vertices).reshape((-1, 3)).ptp(axis=0))
     return args
 
 

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -253,9 +253,11 @@ class Scene(Geometry3D):
         # avoid accessing attribute in tight loop
         geometry = self.geometry
         # hash of geometry and transforms
-        return hash(
-            (hash(self.graph.transforms), hash((k, hash(v)) for k, v in geometry.items()))
-        )
+        # start with the last modified time of the scene graph
+        hashable = [hex(self.graph.transforms.__hash__())]
+        # take the re-hex string of the hash
+        hashable.extend(hex(geometry[k].__hash__()) for k in geometry.keys())
+        return caching.hash_fast("".join(hashable).encode("utf-8"))
 
     @property
     def is_empty(self):

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -252,11 +252,10 @@ class Scene(Geometry3D):
         """
         # avoid accessing attribute in tight loop
         geometry = self.geometry
-        # start with the last modified time of the scene graph
-        hashable = [hex(self.graph.transforms.__hash__())]
-        # take the re-hex string of the hash
-        hashable.extend(hex(geometry[k].__hash__()) for k in geometry.keys())
-        return caching.hash_fast("".join(hashable).encode("utf-8"))
+        # hash of geometry and transforms
+        return hash(
+            (hash(self.graph.transforms), hash((k, hash(v)) for k, v in geometry.items()))
+        )
 
     @property
     def is_empty(self):

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -229,9 +229,11 @@ class SceneViewer(pyglet.window.Window):
         for name, geom in self.scene.geometry.items():
             if geom.is_empty:
                 continue
-            if geometry_hash(geom) == self.vertex_list_hash.get(name):
-                continue
+            # if geometry_hash(geom) == self.vertex_list_hash.get(name):
+            #    continue
+            i = hash(geom)
             self.add_geometry(name=name, geometry=geom, smooth=bool(self._smooth))
+            assert hash(geom) == i
 
     def _update_meshes(self):
         # call the callback if specified
@@ -263,7 +265,7 @@ class SceneViewer(pyglet.window.Window):
         # create the indexed vertex list
         self.vertex_list[name] = self.batch.add_indexed(*args)
         # save the hash of the geometry
-        self.vertex_list_hash[name] = geometry_hash(geometry)
+        self.vertex_list_hash[name] = hash(geometry)
         # save the rendering mode from the constructor args
         self.vertex_list_mode[name] = args[1]
 
@@ -731,7 +733,6 @@ class SceneViewer(pyglet.window.Window):
 
             # get the transform from world to geometry and mesh name
             transform, geometry_name = graph.get(current_node)
-
             # if no geometry at this frame continue without rendering
             if geometry_name is None or geometry_name not in self.vertex_list_mode:
                 continue
@@ -749,7 +750,6 @@ class SceneViewer(pyglet.window.Window):
             mesh = geometry[geometry_name]
             if mesh.is_empty:
                 continue
-
             # get the GL mode of the current geometry
             mode = self.vertex_list_mode[geometry_name]
 

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -229,11 +229,9 @@ class SceneViewer(pyglet.window.Window):
         for name, geom in self.scene.geometry.items():
             if geom.is_empty:
                 continue
-            # if geometry_hash(geom) == self.vertex_list_hash.get(name):
-            #    continue
-            i = hash(geom)
+            if _geometry_hash(geom) == self.vertex_list_hash.get(name):
+                continue
             self.add_geometry(name=name, geometry=geom, smooth=bool(self._smooth))
-            assert hash(geom) == i
 
     def _update_meshes(self):
         # call the callback if specified
@@ -265,7 +263,7 @@ class SceneViewer(pyglet.window.Window):
         # create the indexed vertex list
         self.vertex_list[name] = self.batch.add_indexed(*args)
         # save the hash of the geometry
-        self.vertex_list_hash[name] = hash(geometry)
+        self.vertex_list_hash[name] = _geometry_hash(geometry)
         # save the rendering mode from the constructor args
         self.vertex_list_mode[name] = args[1]
 
@@ -842,7 +840,7 @@ class SceneViewer(pyglet.window.Window):
         return file_obj
 
 
-def geometry_hash(geometry):
+def _geometry_hash(geometry):
     """
     Get a hash for a geometry object
 


### PR DESCRIPTION
- fix #1378 
  - renames confusing `mesh.smoothed` to a cached `mesh.smooth_shaded` and will add deprecation warnings.  
- adds a fix and test for `trimesh.grouping.blocks(..., wrap=True)` for arrays with every value true. 
- add some type annotations