### PR TITLE
fix export user expansion and default unitize_normals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.7"
-version = "4.0.3"
+version = "4.0.4"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -70,14 +70,14 @@ class BooleanTest(g.unittest.TestCase):
         """
         Make sure boolean operations work on multiple meshes.
         """
-        for _engine, exists in engines:
+        for engine, exists in engines:
             if not exists:
                 continue
             a = g.trimesh.primitives.Sphere(center=[0, 0, 0])
             b = g.trimesh.primitives.Sphere(center=[0, 0, 0.75])
             c = g.trimesh.primitives.Sphere(center=[0, 0, 1.5])
 
-            r = g.trimesh.boolean.union([a, b, c])
+            r = g.trimesh.boolean.union([a, b, c], engine=engine)
 
             assert r.is_volume
             assert r.body_count == 1

--- a/trimesh/exchange/export.py
+++ b/trimesh/exchange/export.py
@@ -308,7 +308,7 @@ def export_scene(scene, file_obj, file_type=None, resolver=None, **kwargs):
         return util.write_encoded(file_obj, data)
     elif util.is_string(file_obj):
         # assume strings are file paths
-        file_path = os.path.expanduser(os.path.abspath(file_obj))
+        file_path = os.path.abspath(os.path.expanduser(file_obj))
         with open(file_path, "wb") as f:
             util.write_encoded(f, data)
 

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -66,7 +66,7 @@ def export_gltf(
     scene,
     include_normals=None,
     merge_buffers=False,
-    unitize_normals=False,
+    unitize_normals=True,
     tree_postprocessor=None,
     embed_buffers=False,
     extension_webp=False,
@@ -85,6 +85,9 @@ def export_gltf(
       Include vertex normals
     merge_buffers : bool
       Merge buffers into one blob.
+    unitize_normals
+      GLTF requires unit normals, however sometimes people
+      want to include non-unit normals for shading reasons.
     resolver : trimesh.resolvers.Resolver
       If passed will use to write each file.
     tree_postprocesser : None or callable
@@ -160,7 +163,7 @@ def export_gltf(
 def export_glb(
     scene,
     include_normals=None,
-    unitize_normals=False,
+    unitize_normals=True,
     tree_postprocessor=None,
     buffer_postprocessor=None,
     extension_webp=False,


### PR DESCRIPTION
- fix `mesh.export('~/thing.glb')` as apparently expanduser always has to be called before abspath
- Make `unitize_normals` the default behavior for GLTF/GLB exports as otherwise no-arguments calls can output files that don't pass the GLTF validator. 
- release #2068 