### PR TITLE
fix error when specular-glossiness only has one channel

### DIFF
--- a/trimesh/visual/gloss.py
+++ b/trimesh/visual/gloss.py
@@ -180,9 +180,7 @@ def specular_to_pbr(
                 or specularGlossinessTexture.shape[-1]
             ) == 1:
                 # use the one channel as a multiplier for specular and glossiness
-                specularTexture = glossinessTexture = specularGlossinessTexture.reshape(
-                    (-1, -1, 1)
-                )
+                specularTexture = glossinessTexture = specularGlossinessTexture[..., np.newaxis]
             elif specularGlossinessTexture.shape[-1] == 3:
                 # all channels are specular, glossiness is only a factor
                 specularTexture = specularGlossinessTexture[..., :3]


### PR DESCRIPTION
Otherwise would rase error "ValueError: can only specify one unknown dimension"