### PR TITLE
PLY and GLB parameters for skipping texture loading

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -102,6 +102,21 @@ class GLTFTest(g.unittest.TestCase):
         a = g.json.loads(scene.export(file_type="gltf")["model.gltf"].decode("utf-8"))
         assert len(a["buffers"]) <= 3
 
+    def test_skip_materials(self):
+        # load textured PLY
+        mesh = g.get_mesh('fuze.ply')
+        g.check_fuze(mesh)
+
+        # load as GLB
+        export = mesh.export(file_type='glb', unitize_normals=True)
+        validate_glb(export)
+        mesh_glb = g.trimesh.load(
+            g.trimesh.util.wrap_as_stream(export),
+            file_type="glb", force="mesh", skip_materials=True)
+
+        # visuals should not be present
+        assert not mesh_glb.visual.defined
+
     def test_tex_export(self):
         # load textured PLY
         mesh = g.get_mesh("fuze.ply")

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -175,6 +175,16 @@ class OBJTest(g.unittest.TestCase):
             r = g.trimesh.load(file_path)
             g.check_fuze(r)
 
+    def test_skip_mtl(self):
+        # not loading materials should produce a trivial texture
+        m_tex = g.get_mesh("fuze.obj")
+        m_tex_size = m_tex.visual.material.image.size
+
+        m_notex = g.get_mesh('fuze.obj', skip_materials=True)
+        m_notex_size = m_notex.visual.material.image.size
+
+        assert m_tex_size != m_notex_size
+
     def test_mtl(self):
         # get a mesh with texture
         m = g.get_mesh("fuze.obj")

--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -232,6 +232,16 @@ class PlyTest(g.unittest.TestCase):
         # correct number of vertices and has texture loaded
         g.check_fuze(m)
 
+    def test_skip_texturefile(self):
+        # not loading the texture should produce a trivial texture
+        m_tex = g.get_mesh("fuze.ply")
+        m_tex_size = m_tex.visual.material.image.size
+
+        m_notex = g.get_mesh('fuze.ply', skip_texture=True)
+        m_notex_size = m_notex.visual.material.image.size
+
+        assert m_tex_size != m_notex_size
+
     def test_metadata(self):
         mesh = g.get_mesh("metadata.ply")
 

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -64,7 +64,13 @@ def _numpy_type_to_ply_type(_numpy_type):
 
 
 def load_ply(
-    file_obj, resolver=None, fix_texture=True, prefer_color=None, *args, **kwargs
+    file_obj,
+    resolver=None,
+    fix_texture=True,
+    prefer_color=None,
+    skip_texture=False,
+    *args,
+    **kwargs
 ):
     """
     Load a PLY file from an open file object.
@@ -79,6 +85,8 @@ def load_ply(
       If True, will re- index vertices and faces
       so vertices with different UV coordinates
       are disconnected.
+    skip_texture : bool
+      If True, will not load texture (if present).
     prefer_color : None, 'vertex', or 'face'
       Which kind of color to prefer if both defined
 
@@ -100,18 +108,19 @@ def load_ply(
 
     # try to load the referenced image
     image = None
-    try:
-        # soft dependency
-        import PIL.Image
+    if not skip_texture:
+        try:
+            # soft dependency
+            import PIL.Image
 
-        # if an image name is passed try to load it
-        if image_name is not None:
-            data = resolver.get(image_name)
-            image = PIL.Image.open(util.wrap_as_stream(data))
-    except ImportError:
-        log.debug("textures require `pip install pillow`")
-    except BaseException:
-        log.warning("unable to load image!", exc_info=True)
+            # if an image name is passed try to load it
+            if image_name is not None:
+                data = resolver.get(image_name)
+                image = PIL.Image.open(util.wrap_as_stream(data))
+        except ImportError:
+            log.debug("textures require `pip install pillow`")
+        except BaseException:
+            log.warning("unable to load image!", exc_info=True)
 
     # translate loaded PLY elements to kwargs
     kwargs = _elements_to_kwargs(


### PR DESCRIPTION
Relates to #2093.

Since `obj` already implemented this via `skip_materials`, I implemented the same parameter for `glb` and similar parameter (`skip_texture`) for `ply`.