### PR TITLE
Set main_color for vertex and face visual kind

### DIFF
--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -117,6 +117,9 @@ def export_collada(mesh, **kwargs):
                 uv = m.visual.uv
             elif m.visual.kind == "vertex":
                 colors = (m.visual.vertex_colors / 255.0)[:, :3]
+                mat.effect.diffuse = np.array(m.visual.main_color) / 255.0
+            elif m.visual.kind == "face":
+                mat.effect.diffuse = np.array(m.visual.main_color) / 255.0
         c.effects.append(mat.effect)
         c.materials.append(mat)
 


### PR DESCRIPTION
When loading the attached mesh and exporting it to Collada format, the resulting output does not include colors as shown in the first image.

![Screenshot from 2024-01-04 02-24-44](https://github.com/mikedh/trimesh/assets/4690682/e249666c-3ce1-4cc8-90fb-33b7907668f6)

I have made the necessary modifications to address this issue. Now, when you load and export the mesh, you can specify the 'main_color' parameter, and it will result in the desired coloration as shown in the second image.
![Screenshot from 2024-01-04 02-24-20](https://github.com/mikedh/trimesh/assets/4690682/4c1b41ac-bf21-4d60-833a-137966d632aa)

Please review the changes and let me know if you have any feedback or further improvements. Thank you!

### sample mesh

https://drive.google.com/file/d/1JmPVdZdXF85ngItWRbbFaKmBmiDqRoin/view?usp=sharing

### sample code

```
import trimesh

mesh = trimesh.load('./link5.3dxml')
mesh.show()
dae_data = trimesh.exchange.dae.export_collada(mesh.dump())
with open('/tmp/hoge.dae', 'wb') as f:
    f.write(dae_data)
trimesh.load('/tmp/hoge.dae').show()
```
