### PR TITLE
fix: copy visual data when copying points

### DIFF
--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -62,6 +62,7 @@ class PointsTest(g.unittest.TestCase):
 
         # check to see if copy works
         assert g.np.allclose(cloud.vertices, cloud.copy().vertices)
+        assert hash(cloud.visual) == hash(cloud.copy().visual)
 
     def test_empty(self):
         p = g.trimesh.PointCloud(None)

--- a/trimesh/points.py
+++ b/trimesh/points.py
@@ -475,6 +475,10 @@ class PointCloud(Geometry3D):
 
         # copy vertex and face data
         copied._data.data = copy.deepcopy(self._data.data)
+
+        # copy visual data
+        copied.visual = copy.deepcopy(self.visual)
+
         # get metadata
         copied.metadata = copy.deepcopy(self.metadata)
 


### PR DESCRIPTION
As the failure of unit test in 59b9403 shows, PointCloud's copy operation does not copy the visual data in the current implementation. This PR fixes this problem. 