### PR TITLE
Release: fix deprecation warning for has_module

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Keeping `trimesh` easy to install is a core goal, thus the *only* hard dependenc
 pip install trimesh
 ```
 
-The minimal install can load many supported formats (STL, PLY, GLTF/GLB) into numpy arrays. More functionality is available when soft dependencies are installed. This includes things like convex hulls (`scipy`), graph operations (`networkx`), faster ray queries (`pyembree`), vector path handling (`shapely` and `rtree`), XML formats like 3DXML/XAML/3MF (`lxml`), preview windows (`pyglet`), faster cache checks (`xxhash`), etc. To install `trimesh` with the soft dependencies that generally install cleanly on Linux, OSX, and Windows using `pip`:
+The minimal install can load many supported formats (STL, PLY, GLTF/GLB) into numpy arrays. More functionality is available when soft dependencies are installed. This includes things like convex hulls (`scipy`), graph operations (`networkx`), faster ray queries (`embreex`), vector path handling (`shapely` and `rtree`), XML formats like 3DXML/XAML/3MF (`lxml`), preview windows (`pyglet`), faster cache checks (`xxhash`), etc. To install `trimesh` with the soft dependencies that generally install cleanly on Linux, OSX, and Windows using `pip`:
 ```bash
 pip install trimesh[easy]
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.7"
-version = "4.1.1"
+version = "4.1.2"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -351,7 +351,7 @@ def get_meshes(
                 loaded = trimesh.load(os.path.join(dir_models, file_name))
             except BaseException as E:
                 if raise_error:
-                    log.error(f'failed to load {file_name}')
+                    log.error(f"failed to load {file_name}")
                     raise E
                 continue
 

--- a/tests/test_arc.py
+++ b/tests/test_arc.py
@@ -21,7 +21,7 @@ class ArcTests(g.unittest.TestCase):
         )
 
         assert abs(R - res_radius) < g.tol_path.zero
-        assert g.trimesh.util.euclidean(C, res_center) < g.tol_path.zero
+        assert g.np.linalg.norm(C - res_center) < g.tol_path.zero
         # large magnitude arc failed some coplanar tests
         c = g.trimesh.path.arc.arc_center(
             [

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -16,7 +16,7 @@ class ExportTest(g.unittest.TestCase):
             if not isinstance(v, ExceptionWrapper)
         }
 
-        meshes = list(g.get_meshes(8))
+        meshes = list(g.get_meshes(10))
         # make sure we've got something with texture
         meshes.append(g.get_mesh("fuze.obj"))
 
@@ -35,6 +35,11 @@ class ExportTest(g.unittest.TestCase):
                     raise ValueError(
                         "No data exported %s to %s", mesh.metadata["file_name"], file_type
                     )
+
+                if mesh.visual.kind == "texture":
+                    c = mesh.copy()
+                    c.visual.uv = None
+                    c.export(file_type=file_type)
 
                 if file_type in [
                     "dae",  # collada, no native importers

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -54,7 +54,7 @@ class VectorTests(g.unittest.TestCase):
                         "{} had zero distance in discrete!", d.metadata["file_name"]
                     )
 
-                circuit_dist = g.trimesh.util.euclidean(verts[0], verts[-1])
+                circuit_dist = g.np.linalg.norm(verts[0] - verts[-1])
                 circuit_test = circuit_dist < g.tol_path.merge
                 if not circuit_test:
                     g.log.error(

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -266,7 +266,11 @@ def export_ply(
     if include_attributes:
         if hasattr(mesh, "vertex_attributes"):
             # make sure to export texture coordinates as well
-            if hasattr(mesh, "visual") and hasattr(mesh.visual, "uv"):
+            if (
+                hasattr(mesh, "visual")
+                and hasattr(mesh.visual, "uv")
+                and np.shape(mesh.visual.uv) == (len(mesh.vertices), 2)
+            ):
                 mesh.vertex_attributes["s"] = mesh.visual.uv[:, 0]
                 mesh.vertex_attributes["t"] = mesh.visual.uv[:, 1]
             _assert_attributes_valid(mesh.vertex_attributes)

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -20,6 +20,7 @@ import shutil
 import sys
 import time
 import uuid
+import warnings
 import zipfile
 
 # for type checking
@@ -131,20 +132,16 @@ def unitize(vectors, check_valid=False, threshold=None):
 
 def euclidean(a, b) -> float:
     """
-    Euclidean distance between vectors a and b.
-
-    Parameters
-    ------------
-    a : (n,) float
-       First vector
-    b : (n,) float
-       Second vector
-
-    Returns
-    ------------
-    distance : float
-        Euclidean distance between A and B
+    DEPRECATED: use `np.linalg.norm(a - b)` instead of this.
     """
+    warnings.warn(
+        "`trimesh.util.euclidean` is deprecated "
+        + "and will be removed in January 2025. "
+        + "replace with `np.linalg.norm(a - b)`",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     a = np.asanyarray(a, dtype=np.float64)
     b = np.asanyarray(b, dtype=np.float64)
     return np.sqrt(((a - b) ** 2).sum())


### PR DESCRIPTION
- fix deprecation warning for `trimesh.util.has_module` on Python 3.12
- test and fix #2137 
- deprecate and warn `trimesh.util.euclidean(a, b)` for January 2025 as there is no reason for this function to exist over `np.linalg.norm(a - b)`