### PR TITLE
Fix reshape in `get_specular_glossiness`.

### DIFF
--- a/trimesh/visual/gloss.py
+++ b/trimesh/visual/gloss.py
@@ -180,9 +180,9 @@ def specular_to_pbr(
                 or specularGlossinessTexture.shape[-1]
             ) == 1:
                 # use the one channel as a multiplier for specular and glossiness
-                specularTexture = glossinessTexture = specularGlossinessTexture[
-                    ..., np.newaxis
-                ]
+                specularTexture = glossinessTexture = specularGlossinessTexture.reshape(
+                    specularGlossinessTexture.shape[0], specularGlossinessTexture.shape[1], 1
+                )
             elif specularGlossinessTexture.shape[-1] == 3:
                 # all channels are specular, glossiness is only a factor
                 specularTexture = specularGlossinessTexture[..., :3]


### PR DESCRIPTION
The current code is wrong when the array has a singleton dimension as channel dimension already.