### PR TITLE
Keep vertex attributes when copying `TextureVisuals`.

### DIFF
--- a/trimesh/visual/texture.py
+++ b/trimesh/visual/texture.py
@@ -135,6 +135,7 @@ class TextureVisuals(Visuals):
             material=self.material.copy(),
             face_materials=copy.copy(self.face_materials),
         )
+        copied.vertex_attributes.data = copy.deepcopy(self.vertex_attributes.data)
 
         return copied
 


### PR DESCRIPTION
When I load a GLTF files with multiple objects with vertex colors, the color attribute will be dropped at `Scene.dump()` due to its calling `TriMesh.copy` which calls `visual.copy` that does not copy the attributes.

I propose to deep-copy the vertex attributes like the mesh geometry data in `TextureVisuals.copy`.