### PR TITLE
Fixting Stitching Bug

### DIFF
--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -435,7 +435,7 @@ def stitch(mesh, faces=None, insert_vertices=False):
         if not valid.any():
             continue
         # take the first valid normal from our new faces
-        check = check[valid][0]
+        check = check[0]
 
         # if our new faces are reversed from the original
         # Adjacent face flip them along their axis


### PR DESCRIPTION
Hi Mike,
Thanks again for sharing trimesh with the community. I noticed a tiny bug in the implementation of "stitch()". More specifically: the implementation of `unitize(...)` https://github.com/mikedh/trimesh/blob/aa3cb56ec733d053401540b00b8ceced6232d1fa/trimesh/util.py#L128-L129

returns the normals after masking with `valid` when `check_valid=True`. However, in the current implementation of stitch https://github.com/mikedh/trimesh/blob/3d5af39b9352ee09b540062ae6340e46ebf0439f/trimesh/repair.py#L438 the mask is applied again on the masked results, causing it the function to break.

This PR contains a quick fix to the problem.

Thanks.
-- Adrish




