### PR TITLE
Fix typing for lights in Scene.__init__

### DIFF
--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -27,7 +27,7 @@ class Scene(Geometry3D):
         metadata: Optional[Dict] = None,
         graph: Optional[SceneGraph] = None,
         camera: Optional[cameras.Camera] = None,
-        lights: Optional[lighting.Light] = None,
+        lights: Optional[List[lighting.Light]] = None,
         camera_transform: Optional[NDArray] = None,
     ):
         """


### PR DESCRIPTION
`lights` should be `Optional[List[lighting.Light]]` instead of `Optional[lighting.Light]`