### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Further information is available in the [advanced installation documentation](ht
 ## Quick Start
 
 Here is an example of loading a mesh from file and colorizing its faces. Here is a nicely formatted
-[ipython notebook version](https://trimesh.org/examples/quick_start.html) of this example. Also check out the [cross section example](https://trimesh.org/examples/section.html).
+[ipython notebook version](https://trimesh.org/quick_start.html) of this example. Also check out the [cross section example](https://trimesh.org/section.html).
 
 ```python
 import numpy as np


### PR DESCRIPTION
Fix broken links in the Quick Start section. 

During my first contact with the library, when trying to access the links in the quick start section of the README.md, I noticed that some of them were broken. More specifically those that refer to the ipython notebook version and cross section example.

This PR fix these links.