### PR TITLE
Fix broken solid name in ASCII STL mesh export

### DIFF
--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -72,6 +72,11 @@ class STLTests(g.unittest.TestCase):
         assert len(s.geometry) == 2
         assert set(s.geometry.keys()) == {"bodyA", "bodyB"}
 
+    def test_ascii_solid_name(self):
+        mesh = g.trimesh.creation.icosphere(subdivisions=1, radius=1.0)
+        mesh.metadata = {"name": "solid_A"}
+        assert g.trimesh.exchange.stl.export_stl_ascii(mesh).splitlines()[0] == "solid solid_A"
+
     def test_empty(self):
         # demo files to check
         empty_files = ["stl_empty_ascii.stl", "stl_empty_bin.stl"]

--- a/trimesh/exchange/stl.py
+++ b/trimesh/exchange/stl.py
@@ -309,7 +309,7 @@ def export_stl_ascii(mesh) -> str:
         name = ""
 
     # concatenate the header, data, and footer, and a new line
-    return "\n".join(["solid {name}", formatter.format(*blob.reshape(-1)), "endsolid\n"])
+    return "\n".join([f"solid {name}", formatter.format(*blob.reshape(-1)), "endsolid\n"])
 
 
 _stl_loaders = {"stl": load_stl, "stl_ascii": load_stl}


### PR DESCRIPTION
Exporting a mesh in ASCII STL format results in the placeholder `{name}` to be printed as solid name instead of the `name` metadata, due to a typo. This PR fixes the typo and introduces a simple unit test.