### PR TITLE
Option for closed path polygon sweeping

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -147,6 +147,7 @@ class CreationTest(g.unittest.TestCase):
             vec = g.np.dot(rotmat, vec)
         poly = g.Polygon(perim)
 
+        # --- test open sweep
         # Create 3D path
         angles = g.np.linspace(0, 8 * g.np.pi, 1000)
         x = angles / 10.0
@@ -157,6 +158,21 @@ class CreationTest(g.unittest.TestCase):
         # Extrude
         for engine in self.engines:
             mesh = g.trimesh.creation.sweep_polygon(poly, path, engine=engine)
+            assert mesh.is_volume
+
+        # --- test closed sweep
+        # Create 3D path
+        angles = g.np.linspace(0, 2 * 0.999 * g.np.pi, 1000)
+        x = g.np.zeros((1000,))
+        y = g.np.cos(angles)
+        z = g.np.sin(angles)
+        path_closed = g.np.c_[x, y, z]
+
+        # Extrude
+        for engine in self.engines:
+            mesh = g.trimesh.creation.sweep_polygon(
+                poly, path_closed, closed=True, engine=engine
+            )
             assert mesh.is_volume
 
     def test_annulus(self):


### PR DESCRIPTION
Hello,

thanks for your ongoing awesome work on Trimesh!

For a project I needed closed sweeping of a polygon, so the start and the end of the path are connected. I wanted to use `creation.sweep_polygon()` with a circular path but it always adds caps to the mesh at the end of the path.

I thought sweeping a closed path is actually quite a common use case, so I added an `closed` option to `creation.sweep_polygon()` to close the mesh at the path ends instead of addings caps. 

The results look good as long as the path ends are roughly facing each other:
  
![image](https://github.com/mikedh/trimesh/assets/104222130/31e92a9b-983e-4125-b3d4-2f08069f2d87)
![image](https://github.com/mikedh/trimesh/assets/104222130/ecc157f2-6b90-45e3-a41f-9e981a1ca64b)

Additional note:

One issue is a potential narrowing and twisting when adding angles while sweeping something rotational symmetric like a hexagon because the first and last polygon are rotated against each other without the rotation being visible due to the rotational symmetry (see the example image below).

But I couldn't come up with a trivial way around this, especially without calculating the symmetry angle of the polygon which I didn’t find an existing method for. Is there already a method for this in trimesh or shapely? Otherwise this is maybe something I can look into on another day...

![image](https://github.com/mikedh/trimesh/assets/104222130/e9ab561c-526d-4a8c-8178-6817147fc6de)
