### PR TITLE
Fix pbr export no uv

### DIFF
--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -206,6 +206,32 @@ class TextureTest(g.unittest.TestCase):
         c = m.copy()
         assert c.visual.uv is None
 
+    def test_pbr_nouv_export(self):
+        # Test that we can properly save and load a pbr material without uv and texture image.
+        material = g.trimesh.visual.material.PBRMaterial(
+            metallicFactor=0.3,
+            roughnessFactor=0.5,
+            baseColorFactor=(0, 255, 0, 255),
+            name="abc"
+        )
+        mesh = g.trimesh.Trimesh(
+            vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 1]], faces=[[0, 1, 2]], process=False,
+            visual=g.trimesh.visual.TextureVisuals(material=material)
+        )
+        scene = g.trimesh.Scene()
+        scene.add_geometry(mesh, geom_name="geom")
+        with g.TemporaryDirectory() as d:
+            # exports by path allow files to be written
+            path = g.os.path.join(d, "tmp.glb")
+            scene.export(path)
+
+            # try reloading
+            r = g.trimesh.load(path)
+            # make sure material survived
+            assert r.geometry["geom"].visual.material.metallicFactor == 0.3
+            assert r.geometry["geom"].visual.material.roughnessFactor == 0.5
+            assert (r.geometry["geom"].visual.material.baseColorFactor == [0, 255, 0, 255]).all()
+
     def test_pbr_export(self):
         # try loading a textured box
         m = next(iter(g.get_mesh("BoxTextured.glb").geometry.values()))

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -920,8 +920,8 @@ def _append_mesh(
             # add the reference for UV coordinates
             current["primitives"][0]["attributes"]["TEXCOORD_0"] = acc_uv
 
-            # only reference the material if we had UV coordinates
-            current["primitives"][0]["material"] = current_material
+        # reference the material
+        current["primitives"][0]["material"] = current_material
 
     if include_normals or (
         include_normals is None and "vertex_normals" in mesh._cache.cache


### PR DESCRIPTION
Thanks for the great work!

In this PR, we introduce a fix for properly exporting pbr materials to gltf when there's no UV mapping.

* GLTF allows PBR materials without texture image, with only the `Factors` be defined.
* Within trimesh, `TextureVisual` may not have a uv map associated, and annotated as optional.
* Currently, since version 4.0.0, exporting to gltf would avoid adding a reference from the mesh to the material if `uv` does not exist. Therefore the loaded `.gltf/glb` would load with default colors.

This is the same issue raised in https://github.com/mikedh/trimesh/issues/2111