### PR TITLE
Pass through registration kwargs to icp, e.g. to dissallow reflection

### DIFF
--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -148,7 +148,12 @@ def mesh_other(
 
         # run first pass ICP
         matrix, _junk, cost = icp(
-            a=points, b=search, initial=a_to_b, max_iterations=int(icp_first), scale=scale
+            a=points,
+            b=search,
+            initial=a_to_b,
+            max_iterations=int(icp_first),
+            scale=scale,
+            **kwargs,
         )
 
         # save transform and costs from ICP
@@ -162,6 +167,7 @@ def mesh_other(
         initial=transforms[np.argmin(costs)],
         max_iterations=int(icp_final),
         scale=scale,
+        **kwargs,
     )
 
     # convert to per- point distance average


### PR DESCRIPTION
In the documentation it says that kwargs given to `.register` are passed through to `icp` and further down to `procrustes`. This can, for example, be used to disallow reflection.
However, these kwargs are currently not passed through. This PR corrects that.

Note, that the `scale` flag could be removed (as it is part of kwargs), but I left it in to not change the order of the arguments for backward compatibility.