### PR TITLE
Fix load cam gltf

### DIFF
--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -116,6 +116,10 @@ class SceneTests(g.unittest.TestCase):
             path = g.os.path.join(d, "tmp.glb")
             scene.export(path)
             r = g.trimesh.load(path, force="scene")
+
+            # ensure no added nodes
+            assert set(r.graph.nodes) == set(["world", "geometry_0", "cam1"])
+            # ensure same camera parameters and extrinsics
             assert (r.camera_transform == scene.camera_transform).all()
             assert r.camera.name == cam.name
             assert (r.camera.fov == cam.fov).all()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -102,6 +102,25 @@ class SceneTests(g.unittest.TestCase):
                 # make sure explode doesn't crash
                 s.explode()
 
+    def test_cam_gltf(self):
+        # Test that the camera is stored and loaded successfully into a Scene from a gltf.
+        cam = g.trimesh.scene.cameras.Camera(fov=[60, 90], name="cam1")
+        box = g.trimesh.creation.box(extents=[1, 2, 3])
+        scene = g.trimesh.Scene(
+                geometry=[box],
+                camera=cam,
+                camera_transform=[[0, 1, 0, -1], [1, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
+                )
+        with g.TemporaryDirectory() as d:
+            # exports by path allow files to be written
+            path = g.os.path.join(d, "tmp.glb")
+            scene.export(path)
+            r = g.trimesh.load(path, force="scene")
+            assert (r.camera_transform == scene.camera_transform).all()
+            assert r.camera.name == cam.name
+            assert (r.camera.fov == cam.fov).all()
+            assert r.camera.z_near == cam.z_near
+
     def test_scaling(self):
         # Test the scaling of scenes including unit conversion.
 

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -413,6 +413,10 @@ def load_kwargs(*args, **kwargs) -> Geometry:
         else:
             scene = Scene(geometry)
 
+        # camera, if it exists
+        scene.camera = kwargs.get('camera')
+        scene.camera_transform = kwargs.get('camera_transform')
+
         if "base_frame" in kwargs:
             scene.graph.base_frame = kwargs["base_frame"]
         metadata = kwargs.get("metadata")


### PR DESCRIPTION
* Loading a `.gltf/.glb` with a camera, will currently not load the camera object to the scene, and instead contain an empty "dangling" node that was originally the camera node.
* This is shown with the unit test; previously the loaded camera would have default values different than the original
* In this PR, we suggest loading the camera into the `Scene` object if it exists in the gltf, populating the gltf-compatible fields (`fov`, `name`, `z_near`) and the `camera_transform`
