### PR TITLE
Fixes #2195

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -307,7 +307,8 @@ class GLTFTest(g.unittest.TestCase):
         )
         assert metallic_roughness.shape[0] == 84 and metallic_roughness.shape[1] == 71
 
-        metallic = metallic_roughness[:, :, 0]
+        # https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#metallic-roughness-material
+        metallic = metallic_roughness[:, :, 2]
         roughness = metallic_roughness[:, :, 1]
 
         assert g.np.allclose(metallic[0, 0], 0.231, atol=0.004)

--- a/trimesh/visual/gloss.py
+++ b/trimesh/visual/gloss.py
@@ -360,7 +360,7 @@ def specular_to_pbr(
         # we need to use RGB textures, because 2 channel textures can cause problems
         result["metallicRoughnessTexture"] = toPIL(
             np.concatenate(
-                [metallic, 1.0 - glossiness, np.zeros_like(metallic)], axis=-1
+                [np.zeros_like(metallic), 1.0 - glossiness, metallic], axis=-1
             ),
             mode="RGB",
         )


### PR DESCRIPTION
Update trimesh.visual.gloss.specular_to_pbr to align with the material definition in gltf 2.0, as specified in https://github.com/mikedh/trimesh/issues/2195