### PR TITLE
Fix passing read only vertex color buffer when loading GLTF

### DIFF
--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1560,11 +1560,11 @@ def _read_buffers(
                             if len(colors) == len(kwargs["vertices"]):
                                 if visuals is None:
                                     # just pass to mesh as vertex color
-                                    kwargs["vertex_colors"] = colors
+                                    kwargs["vertex_colors"] = colors.copy()
                                 else:
                                     # we ALSO have texture so save as vertex
                                     # attribute
-                                    visuals.vertex_attributes["color"] = colors
+                                    visuals.vertex_attributes["color"] = colors.copy()
                         except BaseException:
                             # survive failed colors
                             log.debug("failed to load colors", exc_info=True)


### PR DESCRIPTION
Without the fix GLTF loading will fail assigning vertex color properly down the line when colors are converted to RGBA which attempts to modify the buffer contents directly, as a result raising exception.

https://github.com/mikedh/trimesh/blob/7853a5ebae3b35275f4d8d65cbc48bcd3a3c8a40/trimesh/visual/color.py#L583