### PR TITLE
Release: Refactor Load Types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
   pypi:
     name: Release To PyPi
-    needs: [tests, containers]
+    needs: [tests, containers, corpus]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -118,13 +118,13 @@ jobs:
     - name: Install Trimesh
       run: pip install .[easy,test]
     - name: Run Corpus Check
-      run: python tests/corpus.py
+      run: python tests/corpus.py -run
 
   release:
     permissions:
       contents: write  # for actions/create-release
     name: Create GitHub Release
-    needs: [tests, containers]
+    needs: [tests, containers, corpus]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,5 +68,5 @@ jobs:
     - name: Install Trimesh
       run: pip install .[easy,test]
     - name: Run Corpus Check
-      run: python tests/corpus.py
+      run: python tests/corpus.py -run
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,13 +1,13 @@
-pypandoc==1.13
+pypandoc==1.14
 recommonmark==0.7.1
-jupyter==1.0.0
+jupyter==1.1.1
 
 # get sphinx version range from furo install
-furo==2024.5.6
-myst-parser==3.0.1
-pyopenssl==24.1.0
-autodocsumm==0.2.12
-jinja2==3.1.4
-matplotlib==3.8.4
-nbconvert==7.16.4
+furo==2024.8.6
+myst-parser==4.0.0
+pyopenssl==24.3.0
+autodocsumm==0.2.14
+jinja2==3.1.5
+matplotlib==3.10.0
+nbconvert==7.16.5
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.8"
-version = "4.5.3"
+version = "4.6.0"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ test_more = [
     "matplotlib",
     "pymeshlab",
     "triangle",
+    "ipython",
 ]
 
 # interfaces.gmsh will be dropped Jan 2025

--- a/tests/corpus.py
+++ b/tests/corpus.py
@@ -221,11 +221,9 @@ if __name__ == "__main__":
             if v in (trimesh.exchange.misc.load_meshio,)
         ]
     )
-    """
-    # remove loaders we don't care about
-    available.difference_update({"json", "dae", "zae"})
-    available.update({"dxf", "svg"})
-    """
+
+    # TODO : waiting on a release containing pycollada/pycollada/147
+    available.difference_update({"dae"})
 
     with Profiler() as P:
         # check against the small trimesh corpus

--- a/tests/corpus.py
+++ b/tests/corpus.py
@@ -258,7 +258,7 @@ def run(save: bool = False):
     )
 
     # TODO : waiting on a release containing pycollada/pycollada/147
-    # available.difference_update({"dae"})
+    available.difference_update({"dae"})
 
     with Profiler() as P:
         # check against the small trimesh corpus

--- a/tests/corpus.py
+++ b/tests/corpus.py
@@ -58,11 +58,11 @@ class Report:
         Compare this load report to another.
         """
         # what files were loaded by both versions
-        ot = {o.file_name: o.type_load for o in self.load}
-        nt = {n.file_name: n.type_load for n in other.load}
+        self_type = {o.file_name: o.type_load for o in self.load}
+        other_type = {n.file_name: n.type_load for n in other.load}
 
-        both = set(ot.keys()).intersection(nt.keys())
-        matches = np.array([ot[k] == nt[k] for k in both])
+        both = set(self_type.keys()).intersection(other_type.keys())
+        matches = np.array([self_type[k] == other_type[k] for k in both])
         percent = matches.sum() / len(matches)
 
         print(f"Comparing `{self.version}` against `{other.version}`")

--- a/tests/corpus.py
+++ b/tests/corpus.py
@@ -6,10 +6,13 @@ Test loaders against large corpuses of test data from github:
 will download more than a gigabyte to your home directory!
 """
 
-from dataclasses import dataclass
+import json
+import time
+from dataclasses import asdict, dataclass
 
 import numpy as np
 from pyinstrument import Profiler
+from pyinstrument.renderers.jsonrenderer import JSONRenderer
 
 import trimesh
 from trimesh.typed import List, Optional, Tuple
@@ -35,6 +38,19 @@ class LoadReport:
 
     # if there was an exception save it here
     exception: Optional[str] = None
+
+
+@dataclass
+class Report:
+    # what did we load
+    load: list[LoadReport]
+
+    # what version of trimesh was this produced on
+    version: str
+
+    # what was the profiler output for this run
+    # a pyinstrument.renderers.JSONRenderer output
+    profile: str
 
 
 def on_repo(
@@ -74,16 +90,14 @@ def on_repo(
         resolver = repo.namespaced(namespace)
 
         check = path.lower()
-        broke = (
-            "malformed empty outofmemory "
-            + "bad incorrect missing "
-            + "failures pond.0.ply"
-        ).split()
+        broke = "malformed outofmemory bad incorrect missing invalid failures".split()
         should_raise = any(b in check for b in broke)
         raised = False
 
         # start collecting data about the current load attempt
         current = LoadReport(file_name=name, file_type=trimesh.util.split_extension(name))
+
+        print(f"Attempting: {name}")
 
         try:
             m = trimesh.load(
@@ -143,8 +157,7 @@ def on_repo(
 
         # if it worked when it didn't have to add a label
         if should_raise and not raised:
-            # raise ValueError(name)
-            current.exception = "SHOULD HAVE RAISED BUT DIDN'T!"
+            current.exception = "PROBABLY SHOULD HAVE RAISED BUT DIDN'T!"
         report.append(current)
 
     return report
@@ -200,8 +213,7 @@ if __name__ == "__main__":
     # get a set with available extension
     available = trimesh.available_formats()
 
-    """
-    # remove loaders that are thin wrappers
+    # remove meshio loaders because we're not testing meshio
     available.difference_update(
         [
             k
@@ -209,40 +221,55 @@ if __name__ == "__main__":
             if v in (trimesh.exchange.misc.load_meshio,)
         ]
     )
+    """
     # remove loaders we don't care about
     available.difference_update({"json", "dae", "zae"})
     available.update({"dxf", "svg"})
     """
 
     with Profiler() as P:
-        # check the assimp corpus, about 50mb
-
-        report = on_repo(
+        # check against the small trimesh corpus
+        loads = on_repo(
             repo="mikedh/trimesh",
             commit="2fcb2b2ea8085d253e692ecd4f71b8f450890d51",
             available=available,
             root="models",
         )
 
-        """
-        report.extend(on_repo(
-            repo="assimp/assimp", commit="c2967cf79acdc4cd48ecb0729e2733bf45b38a6f", available=available
-        ))
+        # check the assimp corpus, about 50mb
+        loads.extend(
+            on_repo(
+                repo="assimp/assimp",
+                commit="1e44036c363f64d57e9f799beb9f06d4d3389a87",
+                available=available,
+                root="test",
+            )
+        )
         # check the gltf-sample-models, about 1gb
-        report.extend(
+        loads.extend(
             on_repo(
                 repo="KhronosGroup/glTF-Sample-Models",
-                commit="8e9a5a6ad1a2790e2333e3eb48a1ee39f9e0e31b"
-                , available=available
+                commit="8e9a5a6ad1a2790e2333e3eb48a1ee39f9e0e31b",
+                available=available,
             )
         )
-        report.extend(
+        # try on the universal robot models
+        loads.extend(
             on_repo(
                 repo="ros-industrial/universal_robot",
-                commit="8f01aa1934079e5a2c859ccaa9dd6623d4cfa2fe", available=available
+                commit="8f01aa1934079e5a2c859ccaa9dd6623d4cfa2fe",
+                available=available,
             )
         )
-        """
 
     # show all profiler lines
     log.info(P.output_text(show_all=True))
+
+    # save the profile for comparison loader
+    profile = P.output(JSONRenderer())
+
+    # compose the overall report
+    report = Report(load=loads, version=trimesh.__version__, profile=profile)
+
+    with open(f"trimesh.{trimesh.__version__}.{int(time.time())}.json", "w") as F:
+        json.dump(asdict(report), F)

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -366,7 +366,6 @@ def get_meshes(
                 batched.append(loaded)
 
             for mesh in batched:
-                mesh.metadata["file_name"] = file_name
                 # only return our limit
                 if returned[0] >= count:
                     return

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -12,7 +12,7 @@ def typical_application():
     meshes = g.get_meshes(raise_error=True)
 
     for mesh in meshes:
-        g.log.info("Testing %s", mesh.metadata["file_name"])
+        g.log.info("Testing %s", mesh.source.file_name)
         assert len(mesh.faces) > 0
         assert len(mesh.vertices) > 0
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -87,11 +87,12 @@ class MeshTests(g.unittest.TestCase):
 
         # check methods in scene objects
         scene = mesh.scene()
-        # camera will be None unless set
-        blacklist = ["camera"]
+
+        # these properties can be None
+        allowed_to_be_none = ["camera", "source"]
         for method in dir(scene):
             # ignore private- ish methods
-            if method.startswith("_") or method in blacklist:
+            if method.startswith("_") or method in allowed_to_be_none:
                 continue
             # a string expression to evaluate
             expr = f"scene.{method}"

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -11,8 +11,7 @@ engines = g.trimesh.boolean.engines_available
 if g.all_dependencies:
     engines = g.trimesh.boolean._engines.keys()
 
-# TODO : fix blender booleans?
-engines.difference_update({"blender"})
+engines = set(engines)
 
 
 def test_boolean():

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -9,18 +9,20 @@ class BoundsTest(g.unittest.TestCase):
         meshes = [g.get_mesh(i) for i in ["large_block.STL", "featuretype.STL"]]
         self.meshes = g.np.append(meshes, list(g.get_meshes(5)))
 
-
     def test_obb_mesh_large(self):
         """Test the OBB functionality on really large sets of vertices."""
 
-        torus_mesh = g.trimesh.creation.torus(major_radius=5, minor_radius=1, major_sections=512, minor_sections=256)
+        torus_mesh = g.trimesh.creation.torus(
+            major_radius=5, minor_radius=1, major_sections=512, minor_sections=256
+        )
         start = g.timeit.default_timer()
         g.trimesh.bounds.oriented_bounds(torus_mesh.vertices)
         stop = g.timeit.default_timer()
 
         # Make sure oriented bound estimation runs within 30 seconds.
-        assert stop - start < 30, f"Took {stop - start} seconds to estimate the oriented bounding box."
-
+        assert (
+            stop - start < 30
+        ), f"Took {stop - start} seconds to estimate the oriented bounding box."
 
     def test_obb_mesh(self):
         """

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -14,7 +14,7 @@ class BoundsTest(g.unittest.TestCase):
         Test the OBB functionality in attributes of Trimesh objects
         """
         for m in self.meshes:
-            g.log.info("Testing OBB of %s", m.metadata["file_name"])
+            g.log.info("Testing OBB of %s", m.source.file_name)
             for i in range(6):
                 # on the first run through don't transform the points to see
                 # if we succeed in the meshes original orientation

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -56,7 +56,7 @@ class VisualTest(g.unittest.TestCase):
         truth = g.np.array([hsv_to_rgb(*v) for v in hsv])
 
         # they should match
-        assert g.np.allclose(ours[:, :3], truth, atol=0.0001), ours[:,:3] - truth
+        assert g.np.allclose(ours[:, :3], truth, atol=0.0001), ours[:, :3] - truth
 
     def test_concatenate_empty_mesh(self):
         box = g.get_mesh("box.STL")

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -28,6 +28,36 @@ class VisualTest(g.unittest.TestCase):
         r = a + b
         assert any(g.np.ptp(r.visual.face_colors, axis=0) > 1)
 
+    def test_random_color(self):
+        from trimesh.visual.color import random_color
+
+        c = random_color()
+        assert c.shape == (4,)
+        assert c.dtype == g.np.uint8
+
+        c = random_color(count=10)
+        assert c.shape == (10, 4)
+        assert c.dtype == g.np.uint8
+
+    def test_hsv_rgba(self):
+        # our HSV -> RGBA function
+        # the non-vectorized stdlib HSV -> RGB function
+        from colorsys import hsv_to_rgb
+
+        from trimesh.visual.color import hsv_to_rgba
+
+        # create some random HSV values in the 0.0 - 1.0 range
+        hsv = g.random((100, 3))
+
+        # run our conversion
+        ours = hsv_to_rgba(hsv, dtype=g.np.float64)
+
+        # check the result from the standard library
+        truth = g.np.array([hsv_to_rgb(*v) for v in hsv])
+
+        # they should match
+        assert g.np.allclose(ours[:, :3], truth, atol=0.0001)
+
     def test_concatenate_empty_mesh(self):
         box = g.get_mesh("box.STL")
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -229,6 +229,10 @@ class VisualTest(g.unittest.TestCase):
         # every color should differ
         assert (colors[:-1] != colors[1:]).any(axis=1).all()
 
+        # make sure it handles zero range
+        colors = g.trimesh.visual.interpolate(g.np.zeros(100))
+        assert g.np.allclose(colors, [255, 0, 0, 255])
+
     def test_uv_to_color(self):
         try:
             import PIL.Image

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -40,10 +40,10 @@ class VisualTest(g.unittest.TestCase):
         assert c.dtype == g.np.uint8
 
     def test_hsv_rgba(self):
-        # our HSV -> RGBA function
         # the non-vectorized stdlib HSV -> RGB function
         from colorsys import hsv_to_rgb
 
+        # our HSV -> RGBA function
         from trimesh.visual.color import hsv_to_rgba
 
         # create some random HSV values in the 0.0 - 1.0 range

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -56,7 +56,7 @@ class VisualTest(g.unittest.TestCase):
         truth = g.np.array([hsv_to_rgb(*v) for v in hsv])
 
         # they should match
-        assert g.np.allclose(ours[:, :3], truth, atol=0.0001)
+        assert g.np.allclose(ours[:, :3], truth, atol=0.0001), ours[:,:3] - truth
 
     def test_concatenate_empty_mesh(self):
         box = g.get_mesh("box.STL")

--- a/tests/test_convex.py
+++ b/tests/test_convex.py
@@ -61,20 +61,18 @@ class ConvexTest(g.unittest.TestCase):
 
             if not close_ok:
                 g.log.error(f"volume inconsistent: {volume}")
-                raise ValueError(
-                    "volume is inconsistent on {}".format(mesh.metadata["file_name"])
-                )
+                raise ValueError(f"volume is inconsistent on {mesh.source.file_name}")
             assert min(volume) > 0.0
 
             if not all(i.is_winding_consistent for i in hulls):
                 raise ValueError(
                     "mesh %s reported bad winding on convex hull!",
-                    mesh.metadata["file_name"],
+                    mesh.source.file_name,
                 )
 
             if not all(i.is_convex for i in hulls):
                 raise ValueError(
-                    "mesh %s reported non-convex convex hull!", mesh.metadata["file_name"]
+                    "mesh %s reported non-convex convex hull!", mesh.source.file_name
                 )
 
     def test_primitives(self):

--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -68,7 +68,7 @@ class FileTests(g.unittest.TestCase):
             g.trimesh.load(f.name)
             # shouldn't make it to here
             raise AssertionError()
-        except ValueError:
+        except NotImplementedError:
             # should be raised
             pass
         # file shouldn't be open
@@ -78,7 +78,7 @@ class FileTests(g.unittest.TestCase):
             g.trimesh.load_mesh(f.name)
             # shouldn't make it to here
             raise AssertionError()
-        except KeyError:
+        except NotImplementedError:
             # should be raised
             pass
         not_open(f.name, proc)

--- a/tests/test_dxf.py
+++ b/tests/test_dxf.py
@@ -114,7 +114,7 @@ class DXFTest(g.unittest.TestCase):
             ff = g.os.path.join(dir_versions, f)
             try:
                 paths[f] = g.trimesh.load(ff)
-            except ValueError as E:
+            except NotImplementedError as E:
                 # something like 'r14a' for ascii
                 # and 'r14b' for binary
                 version = f.split(".")[-2]

--- a/tests/test_dxf.py
+++ b/tests/test_dxf.py
@@ -65,16 +65,14 @@ class DXFTest(g.unittest.TestCase):
             if ratio > 0.01:
                 g.log.error(
                     "perimeter ratio on export %s wrong! %f %f %f",
-                    p.metadata["file_name"],
+                    p.source.file_name,
                     p.length,
                     r.length,
                     ratio,
                 )
 
                 raise ValueError(
-                    "perimeter ratio too large ({}) on {}".format(
-                        ratio, p.metadata["file_name"]
-                    )
+                    f"perimeter ratio too large ({ratio}) on {p.source.file_name}"
                 )
 
     def test_spline(self):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -222,7 +222,8 @@ class ExportTest(g.unittest.TestCase):
         assert mesh.visual.kind == "vertex"
 
         as_dict = mesh.to_dict()
-        back = g.trimesh.Trimesh(**as_dict)  # NOQA
+        back = g.trimesh.Trimesh(**as_dict, process=False)
+        assert g.np.allclose(back.vertices, mesh.vertices)
 
     def test_scene(self):
         # get a multi- mesh scene with a transform tree

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -336,8 +336,6 @@ class ExportTest(g.unittest.TestCase):
         # it's wordy
         f = g.trimesh.exchange.load._parse_file_args
 
-        RET_COUNT = 5
-
         # a path that doesn't exist
         nonexists = f"/banana{g.random()}"
         assert not g.os.path.exists(nonexists)
@@ -348,13 +346,11 @@ class ExportTest(g.unittest.TestCase):
 
         # should be able to extract type from passed filename
         args = f(file_obj=exists, file_type=None)
-        assert len(args) == RET_COUNT
-        assert args[1] == "obj"
+        assert args.file_type == "obj"
 
         # should be able to extract correct type from longer name
         args = f(file_obj=exists, file_type="YOYOMA.oBj")
-        assert len(args) == RET_COUNT
-        assert args[1] == "obj"
+        assert args.file_type == "obj"
 
         # with a nonexistent file and no extension it should raise
         try:
@@ -367,15 +363,13 @@ class ExportTest(g.unittest.TestCase):
         # nonexistent file with extension passed should return
         # file name anyway, maybe something else can handle it
         args = f(file_obj=nonexists, file_type=".ObJ")
-        assert len(args) == RET_COUNT
         # should have cleaned up case
-        assert args[1] == "obj"
+        assert args.file_type == "obj"
 
         # make sure overriding type works for string filenames
         args = f(file_obj=exists, file_type="STL")
-        assert len(args) == RET_COUNT
         # should have used manually passed type over .obj
-        assert args[1] == "stl"
+        assert args.file_type == "stl"
 
     def test_buffered_random(self):
         """Test writing to non-standard file"""

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -33,7 +33,7 @@ class ExportTest(g.unittest.TestCase):
                 # if nothing returned log the message
                 if export is None or len(export) == 0:
                     raise ValueError(
-                        "No data exported %s to %s", mesh.metadata["file_name"], file_type
+                        "No data exported %s to %s", mesh.source.file_name, file_type
                     )
 
                 if mesh.visual.kind == "texture":
@@ -50,7 +50,7 @@ class ExportTest(g.unittest.TestCase):
                     g.log.warning("no native loaders implemented for collada!")
                     continue
 
-                g.log.info("Export/import testing on %s", mesh.metadata["file_name"])
+                g.log.info("Export/import testing on %s", mesh.source.file_name)
 
                 if isinstance(export, str):
                     assert export.endswith("\n"), f"{file_type} doesn't end with newline"
@@ -84,34 +84,24 @@ class ExportTest(g.unittest.TestCase):
                     g.log.error(
                         "Export -> import for %s on %s wrong shape!",
                         file_type,
-                        mesh.metadata["file_name"],
+                        mesh.source.file_name,
                     )
 
                 if loaded.vertices is None:
                     g.log.error(
                         "Export -> import for %s on %s gave None for vertices!",
                         file_type,
-                        mesh.metadata["file_name"],
+                        mesh.source.file_name,
                     )
 
                 if loaded.faces.shape != mesh.faces.shape:
                     raise ValueError(
-                        "export cycle {} on {} gave faces {}->{}!".format(
-                            file_type,
-                            mesh.metadata["file_name"],
-                            str(mesh.faces.shape),
-                            str(loaded.faces.shape),
-                        )
+                        f"export cycle {file_type} on {mesh.source.file_name} gave faces {mesh.faces.shape!s}->{loaded.faces.shape!s}!"
                     )
 
                 if loaded.vertices.shape != mesh.vertices.shape:
                     raise ValueError(
-                        "export cycle {} on {} gave vertices {}->{}!".format(
-                            file_type,
-                            mesh.metadata["file_name"],
-                            mesh.vertices.shape,
-                            loaded.vertices.shape,
-                        )
+                        f"export cycle {file_type} on {mesh.source.file_name} gave vertices {mesh.vertices.shape}->{loaded.vertices.shape}!"
                     )
 
                 # try exporting/importing certain file types by name

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -53,6 +53,9 @@ def validate_glb(data, name=None):
         raise ValueError("gltf_validator failed")
 
 
+load_kwargs = g.trimesh.exchange.load._load_kwargs
+
+
 class GLTFTest(g.unittest.TestCase):
     def test_duck(self):
         scene = g.get_mesh("Duck.glb", process=False)
@@ -196,7 +199,7 @@ class GLTFTest(g.unittest.TestCase):
 
         kwargs = g.trimesh.exchange.gltf.load_glb(g.trimesh.util.wrap_as_stream(export))
         # roundtrip it
-        reloaded = g.trimesh.exchange.load.load_kwargs(kwargs)
+        reloaded = load_kwargs(kwargs)
         # make basic assertions
         g.scene_equal(original, reloaded)
 
@@ -264,7 +267,7 @@ class GLTFTest(g.unittest.TestCase):
         assert len(export.keys()) == 2
 
         # reload the export
-        reloaded = g.trimesh.exchange.load.load_kwargs(
+        reloaded = load_kwargs(
             g.trimesh.exchange.gltf.load_gltf(
                 file_obj=None, resolver=g.trimesh.visual.resolvers.ZipResolver(export)
             )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -102,7 +102,7 @@ class GraphTest(g.unittest.TestCase):
 
             g.log.info(
                 "graph engine on %s (scale %f sec):\n%s",
-                mesh.metadata["file_name"],
+                mesh.source.file_name,
                 diff.min(),
                 str(g.np.column_stack((self.engines, diff))),
             )

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -24,8 +24,11 @@ class ViewTest(g.unittest.TestCase):
         children = list(h.body.iterchildren())
         assert len(children) >= 2
 
-        # make sure this is returning anything
-        assert js.scene_to_notebook(s) is not None
+        try:
+            # make sure this is returning anything
+            assert js.scene_to_notebook(s) is not None
+        except ImportError:
+            g.log.debug("Probably no IPython to test", exc_info=True)
 
     def test_inNB(self):
         import trimesh.viewer.notebook as js

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -24,6 +24,9 @@ class ViewTest(g.unittest.TestCase):
         children = list(h.body.iterchildren())
         assert len(children) >= 2
 
+        # make sure this is returning anything
+        assert js.scene_to_notebook(s) is not None
+
     def test_inNB(self):
         import trimesh.viewer.notebook as js
 

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -12,7 +12,7 @@ class IdentifierTest(g.unittest.TestCase):
         )
         for mesh in meshes:
             if not mesh.is_volume or mesh.body_count != 1:
-                g.log.warning("Mesh %s is not watertight!", mesh.metadata["file_name"])
+                g.log.warning("Mesh %s is not watertight!", mesh.source.file_name)
                 continue
 
             g.log.info("Trying hash at %d random transforms", count)
@@ -30,7 +30,7 @@ class IdentifierTest(g.unittest.TestCase):
                 ptp = g.np.ptp(identifier, axis=0)
                 g.log.error(
                     "Hashes on %s differ after transform:\n %s\n",
-                    mesh.metadata["file_name"],
+                    mesh.source.file_name,
                     str(ptp),
                 )
                 raise ValueError("values differ after transform!")
@@ -40,7 +40,7 @@ class IdentifierTest(g.unittest.TestCase):
             if hashed[-1] == stretched.identifier_hash:
                 raise ValueError(
                     "Hashes on %s didn't change after stretching",
-                    mesh.metadata["file_name"],
+                    mesh.source.file_name,
                 )
 
     def test_scene_id(self):

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -12,7 +12,9 @@ class IdentifierTest(g.unittest.TestCase):
         )
         for mesh in meshes:
             if not mesh.is_volume or mesh.body_count != 1:
-                g.log.warning("Mesh %s is not watertight!", mesh.source.file_name)
+                g.log.warning(
+                    f"Mesh {getattr(mesh.source, "file_name", None)} is not watertight!"
+                )
                 continue
 
             g.log.info("Trying hash at %d random transforms", count)

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -13,7 +13,7 @@ class IdentifierTest(g.unittest.TestCase):
         for mesh in meshes:
             if not mesh.is_volume or mesh.body_count != 1:
                 g.log.warning(
-                    f"Mesh {getattr(mesh.source, "file_name", None)} is not watertight!"
+                    f"Mesh {getattr(mesh.source, 'file_name', None)} is not watertight!"
                 )
                 continue
 

--- a/tests/test_loaded.py
+++ b/tests/test_loaded.py
@@ -11,8 +11,9 @@ class LoaderTest(g.unittest.TestCase):
         """
         # get a unit cube from localhost
         with g.serve_meshes() as address:
-            mesh = g.trimesh.exchange.load.load_remote(url=address + "/unit_cube.STL")
+            scene = g.trimesh.exchange.load.load_remote(url=address + "/unit_cube.STL")
 
+        mesh = scene.to_mesh()
         assert g.np.isclose(mesh.volume, 1.0)
         assert isinstance(mesh, g.trimesh.Trimesh)
 

--- a/tests/test_loaded.py
+++ b/tests/test_loaded.py
@@ -36,7 +36,7 @@ class LoaderTest(g.unittest.TestCase):
         # check load_mesh
         file_obj = open(g.os.path.join(g.dir_models, "featuretype.STL"), "rb")
         assert not file_obj.closed
-        mesh = g.trimesh.load(file_obj=file_obj, file_type="stl")
+        mesh = g.trimesh.load_mesh(file_obj=file_obj, file_type="stl")
         # should have actually loaded the mesh
         assert len(mesh.faces) == 3476
         # should not close the file object

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -18,7 +18,7 @@ class MeshTests(g.unittest.TestCase):
 
         for mesh in g.get_meshes(raise_error=True):
             # log file name for debugging
-            file_name = mesh.metadata["file_name"]
+            file_name = mesh.source.file_name
 
             # ply files can return PointCloud objects
             if file_name.startswith("points_"):

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -28,6 +28,18 @@ class OBJTest(g.unittest.TestCase):
         rec = g.roundtrip(m.export(file_type="obj"), file_type="obj")
         assert g.np.isclose(m.area, rec.area)
 
+    def test_keep_unreferenced(self):
+        # try loading a short mesh with 2 vertices, one of which is referenced
+        m = g.trimesh.load(
+            g.trimesh.util.wrap_as_stream("o mesh\nv 1 1 1\nv 1 1 2\nf 1 1 1"),
+            file_type="obj",
+            process=False,
+            maintain_order=True,
+        )
+
+        assert g.np.allclose(m.faces[0], [0, 0, 0])
+        assert g.np.allclose(m.vertices, [[1, 1, 1], [1, 1, 2]])
+
     def test_trailing(self):
         # test files with texture and trailing slashes
         m = g.get_mesh("jacked.obj")
@@ -335,6 +347,9 @@ class OBJTest(g.unittest.TestCase):
 
     def test_scene_export_material_name(self):
         s = g.get_mesh("fuze.obj", force="scene")
+
+        g.log.warning(s.geometry)
+
         dummy = "fuxx"
         s.geometry["fuze.obj"].visual.material.name = dummy
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -42,7 +42,7 @@ class VectorTests(g.unittest.TestCase):
 
             # file_name should be populated, and if we have a DXF file
             # the layer field should be populated with layer names
-            if d.metadata["file_name"][-3:] == "dxf":
+            if d.source.file_name[-3:] == "dxf":
                 assert len(d.layers) == len(d.entities)
 
             for path, verts in zip(d.paths, d.discrete):
@@ -51,7 +51,7 @@ class VectorTests(g.unittest.TestCase):
 
                 if not g.np.all(dists > g.tol_path.zero):
                     raise ValueError(
-                        "{} had zero distance in discrete!", d.metadata["file_name"]
+                        "{} had zero distance in discrete!", d.source.file_name
                     )
 
                 circuit_dist = g.np.linalg.norm(verts[0] - verts[-1])
@@ -59,14 +59,14 @@ class VectorTests(g.unittest.TestCase):
                 if not circuit_test:
                     g.log.error(
                         "On file %s First and last vertex distance %f",
-                        d.metadata["file_name"],
+                        d.source.file_name,
                         circuit_dist,
                     )
                 assert circuit_test
 
                 is_ccw = g.trimesh.path.util.is_ccw(verts)
                 if not is_ccw:
-                    g.log.error("discrete %s not ccw!", d.metadata["file_name"])
+                    g.log.error("discrete %s not ccw!", d.source.file_name)
 
             for i in range(len(d.paths)):
                 assert d.polygons_closed[i].is_valid
@@ -82,7 +82,7 @@ class VectorTests(g.unittest.TestCase):
             split = d.split()
             g.log.info(
                 "Split %s into %d bodies, checking identifiers",
-                d.metadata["file_name"],
+                d.source.file_name,
                 len(split),
             )
             for body in split:
@@ -101,7 +101,7 @@ class VectorTests(g.unittest.TestCase):
             assert g.np.allclose(d.bounds[:, 1], ori[:, 1])
 
             if len(d.polygons_full) > 0 and len(d.vertices) < 150:
-                g.log.info("Checking medial axis on %s", d.metadata["file_name"])
+                g.log.info("Checking medial axis on %s", d.source.file_name)
                 m = d.medial_axis()
                 assert len(m.entities) > 0
 

--- a/tests/test_permutate.py
+++ b/tests/test_permutate.py
@@ -25,7 +25,7 @@ class PermutateTest(g.unittest.TestCase):
                 g.log.error(f"face_adjacency unchanged: {test.face_adjacency!s}")
                 raise ValueError(
                     "face adjacency of %s the same after permutation!",
-                    mesh.metadata["file_name"],
+                    mesh.source.file_name,
                 )
 
             if (
@@ -37,7 +37,7 @@ class PermutateTest(g.unittest.TestCase):
                 )
                 raise ValueError(
                     "face adjacency edges of %s the same after permutation!",
-                    mesh.metadata["file_name"],
+                    mesh.source.file_name,
                 )
 
             assert not close(test.faces, mesh.faces)

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -8,13 +8,13 @@ class RayTests(g.unittest.TestCase):
     def test_rays(self):
         meshes = [g.get_mesh(**k) for k in g.data["ray_data"]["load_kwargs"]]
         rays = g.data["ray_data"]["rays"]
-        names = [m.metadata["file_name"] for m in meshes]
+        names = [m.source.file_name for m in meshes]
 
         hit_id = []
         hit_loc = []
         hit_any = []
         for m in meshes:
-            name = m.metadata["file_name"]
+            name = m.source.file_name
             hit_any.append(m.ray.intersects_any(**rays[name]))
             hit_loc.append(m.ray.intersects_location(**rays[name])[0])
             hit_id.append(m.ray.intersects_id(**rays[name]))

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -36,7 +36,7 @@ class RegistrationTest(g.unittest.TestCase):
             # weight points or not
             if weight:
                 weights = g.np.zeros(len(points_a))
-                weights[:10] = 1.0
+                weights[::3] = 1.0
             else:
                 weights = None
 
@@ -59,11 +59,7 @@ class RegistrationTest(g.unittest.TestCase):
                 scale=scale,
                 weights=g.np.ones(len(points_a)),
             )
-            if weight:
-                # weights should have changed the matrix
-                # todo : check something less silly here?
-                assert not g.np.allclose(matrixN, matrixN_C)
-            else:
+            if not weight:
                 # no weights so everything should be identical
                 assert g.np.allclose(matrixN, matrixN_C)
                 assert g.np.allclose(transformed_C, transformed)
@@ -107,10 +103,12 @@ class RegistrationTest(g.unittest.TestCase):
             if a_flip and reflection and not scale:
                 assert g.np.isclose(det, -1.0), det
 
-    def test_procrustes_float_weights():
+    def test_procrustes_float_weights(self):
+        from trimesh.registration import procrustes
+
         # create two meshes that are a box and some arbitrary other stuff
-        a = g.trimesh.creation.box() + g.trimesh.load_mesh("models/featuretype.STL")
-        b = g.trimesh.creation.box() + g.trimesh.load_mesh("models/rabbit.obj")
+        a = g.trimesh.creation.box() + g.get_mesh("featuretype.STL")
+        b = g.trimesh.creation.box() + g.get_mesh("rabbit.obj")
 
         # mangle the larger mesh to have the same number of vertices
         a.vertices = a.vertices[: len(b.vertices)]

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -96,7 +96,7 @@ class RepairTests(g.unittest.TestCase):
             assert mesh.is_winding_consistent == winding
 
             # save timings
-            timing[mesh.metadata["file_name"]] = g.time.time() - tic
+            timing[mesh.source.file_name] = g.time.time() - tic
         # print timings as a warning
         g.log.warning(g.json.dumps(timing, indent=4))
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -91,7 +91,7 @@ class SceneTests(g.unittest.TestCase):
                     # then make sure json can serialize it
                     e = g.json.dumps(s.export(file_type=export_format))
                     # reconstitute the dict into a scene
-                    r = g.trimesh.load(g.json.loads(e), file_type="dict")
+                    r = g.trimesh.load(g.json.loads(e))
 
                     # make sure the extents are similar before and after
                     assert g.np.allclose(g.np.prod(s.extents), g.np.prod(r.extents))

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -91,7 +91,7 @@ class SceneTests(g.unittest.TestCase):
                     # then make sure json can serialize it
                     e = g.json.dumps(s.export(file_type=export_format))
                     # reconstitute the dict into a scene
-                    r = g.trimesh.load(g.json.loads(e))
+                    r = g.trimesh.load(g.json.loads(e), file_type="dict")
 
                     # make sure the extents are similar before and after
                     assert g.np.allclose(g.np.prod(s.extents), g.np.prod(r.extents))

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -289,25 +289,6 @@ class SceneTests(g.unittest.TestCase):
         assert len(u.duplicate_nodes) == 1
         assert len(u.duplicate_nodes[0]) == 1
 
-    def test_dedupe(self):
-        # create a scene with two identical meshes
-        a = g.trimesh.creation.box()
-        b = g.trimesh.creation.box().apply_translation([2, 2, 2])
-        s = g.trimesh.Scene([a, b])
-
-        # should have 2 geometries
-        assert len(s.geometry) == 2
-        assert len(s.graph.nodes_geometry) == 2
-
-        # get a de-duplicated scene
-        d = s.deduplicated()
-        # should not have mutated original
-        assert len(s.geometry) == 2
-        assert len(s.graph.nodes_geometry) == 2
-        # should only have one geometry
-        assert len(d.geometry) == 1
-        assert len(d.graph.nodes_geometry) == 1
-
     def test_3DXML(self):
         s = g.get_mesh("rod.3DXML")
         assert len(s.geometry) == 3

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -126,7 +126,6 @@ class ExportTest(g.unittest.TestCase):
                 assert g.np.isclose(a.area, b.area)
                 assert a.body_count == b.body_count
 
-
             # assert r.metadata["file_path"].endswith(fn[3:])
 
 

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -126,7 +126,8 @@ class ExportTest(g.unittest.TestCase):
                 assert g.np.isclose(a.area, b.area)
                 assert a.body_count == b.body_count
 
-            assert r.metadata["file_path"].endswith(fn[3:])
+
+            # assert r.metadata["file_path"].endswith(fn[3:])
 
 
 if __name__ == "__main__":

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -25,7 +25,7 @@ class TextureTest(g.unittest.TestCase):
         m = g.get_mesh("fuze.obj", force="mesh")
 
         # check that we saved the original file path
-        assert m.visual.material.image.info["file_path"].endswith("fuze uv.obj")
+        assert m.visual.material.image.info["file_path"].endswith("fuze uv.jpg")
 
         # add malformed UV coordinates
         m.visual.uv = m.visual.uv[:100]

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -23,6 +23,10 @@ class TextureTest(g.unittest.TestCase):
     def test_bad_uv(self):
         # get a textured OBJ
         m = g.get_mesh("fuze.obj", force="mesh")
+
+        # check that we saved the original file path
+        assert m.visual.material.image.info["file_path"].endswith("fuze uv.obj")
+
         # add malformed UV coordinates
         m.visual.uv = m.visual.uv[:100]
         m.merge_vertices()

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -55,7 +55,7 @@ class TextureTest(g.unittest.TestCase):
             # see if web resolvers work
             tex = g.trimesh.exchange.load.load_remote(
                 url=address + "/fuze.obj", process=False
-            )
+            ).geometry["fuze.obj"]
             g.check_fuze(tex)
 
             # see if web + zip resolvers work

--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -10,12 +10,16 @@ class VoxelGridTest(g.unittest.TestCase):
         Test that voxels work at all
         """
         for m in [
-            g.get_mesh("featuretype.STL"),
+            g.get_mesh("featuretype.STL", force="mesh"),
             g.trimesh.primitives.Box(),
             g.trimesh.primitives.Sphere(),
         ]:
             for pitch in [0.1, 0.1 - g.tol.merge]:
                 surface = m.voxelized(pitch=pitch)
+
+                scene = g.trimesh.Scene(surface)
+                assert len(scene.geometry) == 1
+                assert g.np.allclose(scene.bounds, surface.bounds)
 
                 # make sure the voxelized pitch is similar to passed
                 assert g.np.allclose(surface.pitch, pitch)

--- a/trimesh/__init__.py
+++ b/trimesh/__init__.py
@@ -54,6 +54,7 @@ from .exchange.load import (
     load_mesh,
     load_path,
     load_remote,
+    load_scene,
 )
 
 # geometry objects
@@ -108,6 +109,7 @@ __all__ = [
     "load_mesh",
     "load_path",
     "load_remote",
+    "load_scene",
     "nsphere",
     "path",
     "permutate",

--- a/trimesh/__main__.py
+++ b/trimesh/__main__.py
@@ -30,7 +30,8 @@ def main():
     args = parser.parse_args()
 
     if args.file_name is None:
-        scene = None
+        parser.print_help()
+        return
     else:
         scene = load(args.file_name)
 

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -39,7 +39,7 @@ from .caching import Cache, DataStore, TrackedArray, cache_decorator
 from .constants import log, tol
 from .exceptions import ExceptionWrapper
 from .exchange.export import export_mesh
-from .parent import Geometry3D
+from .parent import Geometry3D, LoadSource
 from .scene import Scene
 from .triangles import MassProperties
 from .typed import (
@@ -99,6 +99,7 @@ class Trimesh(Geometry3D):
         use_embree: bool = True,
         initial_cache: Optional[Dict[str, ndarray]] = None,
         visual: Optional[Union[ColorVisuals, TextureVisuals]] = None,
+        source: Optional[LoadSource] = None,
         **kwargs,
     ) -> None:
         """
@@ -201,6 +202,9 @@ class Trimesh(Geometry3D):
             self.metadata.update(metadata)
         elif metadata is not None:
             raise ValueError(f"metadata should be a dict or None, got {metadata!s}")
+
+        # where was this loaded from
+        self.source = source
 
         # store per-face and per-vertex attributes which will
         # be updated when an update_faces call is made

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -39,7 +39,7 @@ from .caching import Cache, DataStore, TrackedArray, cache_decorator
 from .constants import log, tol
 from .exceptions import ExceptionWrapper
 from .exchange.export import export_mesh
-from .parent import Geometry3D, LoadSource
+from .parent import Geometry3D
 from .scene import Scene
 from .triangles import MassProperties
 from .typed import (
@@ -99,7 +99,6 @@ class Trimesh(Geometry3D):
         use_embree: bool = True,
         initial_cache: Optional[Dict[str, ndarray]] = None,
         visual: Optional[Union[ColorVisuals, TextureVisuals]] = None,
-        source: Optional[LoadSource] = None,
         **kwargs,
     ) -> None:
         """
@@ -202,9 +201,6 @@ class Trimesh(Geometry3D):
             self.metadata.update(metadata)
         elif metadata is not None:
             raise ValueError(f"metadata should be a dict or None, got {metadata!s}")
-
-        # where was this loaded from
-        self.source = source
 
         # store per-face and per-vertex attributes which will
         # be updated when an update_faces call is made

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2184,7 +2184,8 @@ class Trimesh(Geometry3D):
           Curve of intersection or None if it was not hit by plane.
         """
         # turn line segments into Path2D/Path3D objects
-        from .exchange.load import load_path
+        from .path.exchange.misc import lines_to_path
+        from .path.path import Path3D
 
         # return a single cross section in 3D
         lines, face_index = intersections.mesh_plane(
@@ -2199,13 +2200,14 @@ class Trimesh(Geometry3D):
         if len(lines) == 0:
             return None
 
-        # otherwise load the line segments into a Path3D object
-        path = load_path(lines)
+        # otherwise load the line segments into the keyword arguments
+        # for a Path3D object.
+        path = lines_to_path(lines)
 
         # add the face index info into metadata
-        path.metadata["face_index"] = face_index
+        # path.metadata["face_index"] = face_index
 
-        return path
+        return Path3D(**path)
 
     def section_multiplane(
         self,

--- a/trimesh/exchange/cascade.py
+++ b/trimesh/exchange/cascade.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 
+from ..exceptions import ExceptionWrapper
 from ..typed import BinaryIO, Dict, Number, Optional
 
 # used as an intermediate format
@@ -68,5 +69,6 @@ try:
     import cascadio
 
     _cascade_loaders = {"stp": load_step, "step": load_step}
-except BaseException:
-    _cascade_loaders = {}
+except BaseException as E:
+    wrapper = ExceptionWrapper(E)
+    _cascade_loaders = {"stp": wrapper, "step": wrapper}

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1256,8 +1256,12 @@ def _parse_textures(header, views, resolver=None):
             if "bufferView" in img:
                 blob = views[img["bufferView"]]
             elif "uri" in img:
-                # will get bytes from filesystem or base64 URI
-                blob = _uri_to_bytes(uri=img["uri"], resolver=resolver)
+                try:
+                    # will get bytes from filesystem or base64 URI
+                    blob = _uri_to_bytes(uri=img["uri"], resolver=resolver)
+                except BaseException:
+                    log.debug(f"unable to load image from: {img.keys()}", exc_info=True)
+                    continue
             else:
                 log.debug(f"unable to load image from: {img.keys()}")
                 continue

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -452,22 +452,22 @@ def load_glb(
     return kwargs
 
 
-def _uri_to_bytes(uri, resolver):
+def _uri_to_bytes(uri: str, resolver: ResolverLike) -> bytes:
     """
     Take a URI string and load it as a
     a filename or as base64.
 
     Parameters
     --------------
-    uri : string
+    uri
       Usually a filename or something like:
       "data:object/stuff,base64,AABA112A..."
-    resolver : trimesh.visual.Resolver
+    resolver
       A resolver to load referenced assets
 
     Returns
     ---------------
-    data : bytes
+    data
       Loaded data from URI
     """
     # see if the URI has base64 data

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1497,8 +1497,11 @@ def _read_buffers(
             for p in m["primitives"]:
                 # if we don't have a triangular mesh continue
                 # if not specified assume it is a mesh
-                kwargs = {"metadata": {}, "process": False}
-                kwargs.update(deepcopy(mesh_kwargs))
+                kwargs = deepcopy(mesh_kwargs)
+                if kwargs.get("metadata", None) is None:
+                    kwargs["metadata"] = {}
+                if "process" not in kwargs:
+                    kwargs["process"] = False
                 kwargs["metadata"].update(metadata)
                 # i.e. GL_LINES, GL_TRIANGLES, etc
                 # specification says the default mode is GL_TRIANGLES

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1252,6 +1252,9 @@ def _parse_textures(header, views, resolver=None):
         images = [None] * len(header["images"])
         # loop through images
         for i, img in enumerate(header["images"]):
+            if img.get("mimeType", "") == "image/ktx2":
+                log.debug("`image/ktx2` textures are unsupported, skipping!")
+                continue
             # get the bytes representing an image
             if "bufferView" in img:
                 blob = views[img["bufferView"]]
@@ -1271,7 +1274,7 @@ def _parse_textures(header, views, resolver=None):
                 # load the buffer into a PIL image
                 images[i] = PIL.Image.open(util.wrap_as_stream(blob))
             except BaseException:
-                log.error("failed to load image!", exc_info=True)
+                log.debug("failed to load image!", exc_info=True)
     return images
 
 
@@ -1314,9 +1317,12 @@ def _parse_materials(header, views, resolver=None):
                     )
                     if webp is not None:
                         idx = webp
-                    else:
+                    elif "source" in texture:
                         # fallback (or primary, if extensions are not present)
                         idx = texture["source"]
+                    else:
+                        # no source available
+                        continue
                     # store the actual image as the value
                     result[k] = images[idx]
                 except BaseException:

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1477,8 +1477,10 @@ def _read_buffers(
     for index, m in enumerate(header.get("meshes", [])):
         try:
             # GLTF spec indicates implicit units are meters
-            metadata = {"units": "meters",
-                        "from_gltf_primitive": len(m["primitives"]) > 1}
+            metadata = {
+                "units": "meters",
+                "from_gltf_primitive": len(m["primitives"]) > 1,
+            }
 
             # try to load all mesh metadata
             if isinstance(m.get("extras"), dict):
@@ -1487,7 +1489,6 @@ def _read_buffers(
             # put any mesh extensions in a field of the metadata
             if "extensions" in m:
                 metadata["gltf_extensions"] = m["extensions"]
-
 
             for p in m["primitives"]:
                 # if we don't have a triangular mesh continue

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -597,6 +597,7 @@ def _parse_file_args(
             if "{" in file_obj:
                 # if a bracket is in the string it's probably straight JSON
                 file_type = "json"
+                file_obj = util.wrap_as_stream(file_obj)
             elif "https://" in file_obj or "http://" in file_obj:
                 if not allow_remote:
                     raise ValueError("unable to load URL with `allow_remote=False`")
@@ -614,6 +615,11 @@ def _parse_file_args(
 
             elif file_type is None:
                 raise ValueError(f"string is not a file: {file_obj}")
+            else:
+                file_obj = None
+    elif isinstance(file_obj, dict):
+        file_obj = util.wrap_as_stream(json.dumps(file_obj))
+        file_type = "dict"
 
     if file_type is None:
         file_type = file_obj.__class__.__name__

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -78,7 +78,6 @@ def load(
     **kwargs,
 ) -> Geometry:
     """
-
     For new code the typed load functions `trimesh.load_scene` or `trimesh.load_mesh`
     are recommended over `trimesh.load` which is a backwards-compatibility wrapper
     that mimics the behavior of the old function and can return any geometry type.
@@ -127,18 +126,11 @@ def load(
         )
         return loaded
 
-    # else:
-    #    log.debug(
-    #        "For new code the typed load functions `trimesh.load_scene` or `trimesh.load_mesh` "
-    #        + "are recommended over `trimesh.load` which is a backwards-compatibility wrapper "
-    #        + "that mimics the behavior of the old function and can return any geometry type."
-    #    )
-
     ###########################################
     # we are matching deprecated behavior here!
     # matching old behavior you should probably use `load_scene`
     if len(loaded.geometry) == 1:
-        kind = loaded.metadata.get("file_type", file_type)
+        kind = loaded._source.file_type
         geom = next(iter(loaded.geometry.values()))
         if (kind not in {"glb", "gltf"} and isinstance(geom, PointCloud)) or kind in {
             "obj",
@@ -247,9 +239,11 @@ def load_scene(
     if not isinstance(loaded, Scene):
         loaded = Scene(loaded)
 
-    # add the "file_path" information to the overall scene metadata
-    if "metadata" not in kwargs:
-        loaded.metadata.update(arg.metadata)
+    loaded._source = arg
+
+    ## add the "file_path" information to the overall scene metadata
+    # if "metadata" not in kwargs:
+    #    loaded.metadata.update(arg.metadata)
     # add the load path metadata to every geometry
     # [g.metadata.update(arg.metadata) for g in loaded.geometry.values()]
 

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -121,7 +121,8 @@ def load(
     # we are matching deprecated behavior here.
     # gltf/glb always return a scene
     # -
-    if len(loaded.geometry) == 1:
+    file_type = loaded.metadata["file_type"]
+    if len(loaded.geometry) == 1 and file_type in {"obj", "stl", "ply", "svg", "binvox"}:
         # matching old behavior, you should probably use `load_scene`
         return next(iter(loaded.geometry.values()))
 
@@ -556,7 +557,6 @@ def _parse_file_args(
     metadata = {}
     opened = False
     file_path = None
-
     if "metadata" in kwargs and isinstance(kwargs["metadata"], dict):
         metadata.update(kwargs["metadata"])
 
@@ -624,9 +624,11 @@ def _parse_file_args(
 
     # all our stored extensions reference in lower case
     file_type = file_type.lower()
+
     if file_path is not None:
         metadata["file_path"] = file_path
         metadata["file_name"] = os.path.basename(file_path)
+    metadata["file_type"] = file_type
 
     # if we still have no resolver try using file_obj name
     if (

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -120,9 +120,16 @@ def load(
 
     # we are matching deprecated behavior here.
     # gltf/glb always return a scene
-    # -
     file_type = loaded.metadata["file_type"]
-    if len(loaded.geometry) == 1 and file_type in {"obj", "stl", "ply", "svg", "binvox"}:
+    if len(loaded.geometry) == 1 and file_type in {
+        "obj",
+        "stl",
+        "ply",
+        "svg",
+        "binvox",
+        "xaml",
+        "dxf",
+    }:
         # matching old behavior, you should probably use `load_scene`
         return next(iter(loaded.geometry.values()))
 

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -129,11 +129,13 @@ def load(
     ###########################################
     # we are matching deprecated behavior here!
     # matching old behavior you should probably use `load_scene`
-    if len(loaded.geometry) == 1:
-        kind = loaded._source.file_type
+    kind = loaded._source.file_type
+    always_scene = {"gltf", "glb", "zip", "3dxml", "tar.gz"}
+    if kind not in always_scene and len(loaded.geometry) == 1:
         geom = next(iter(loaded.geometry.values()))
         geom.metadata.update(loaded.metadata)
-        if (kind not in {"glb", "gltf"} and isinstance(geom, PointCloud)) or kind in {
+
+        if isinstance(geom, PointCloud) or kind in {
             "obj",
             "stl",
             "ply",

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -110,13 +110,6 @@ def load(
         allow_remote=allow_remote,
         **kwargs,
     )
-    arg = _parse_file_args(
-        file_obj=file_obj,
-        file_type=file_type,
-        resolver=resolver,
-        allow_remote=allow_remote,
-        **kwargs,
-    )
 
     # combine a scene into a single mesh
     if force == "mesh":
@@ -129,7 +122,7 @@ def load(
     # we are matching deprecated behavior here!
     # matching old behavior you should probably use `load_scene`
     if len(loaded.geometry) == 1:
-        kind = arg.file_type
+        kind = loaded.metadata.get("file_type", file_type)
         geom = next(iter(loaded.geometry.values()))
         if (kind not in {"glb", "gltf"} and isinstance(geom, PointCloud)) or kind in {
             "obj",
@@ -227,7 +220,7 @@ def load_scene(
                 **kwargs,
             )
         else:
-            raise ValueError(f"File type: {arg.file_type} not supported")
+            raise ValueError(f"file_type: '{arg.file_type}' not supported")
 
     finally:
         # if we opened the file ourselves from a file name

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -129,7 +129,8 @@ def load(
     # we are matching deprecated behavior here!
     # matching old behavior you should probably use `load_scene`
     kind = loaded.source.file_type
-    always_scene = {"gltf", "glb", "zip", "3dxml", "tar.gz"}
+    always_scene = {"glb", "gltf", "zip", "3dxml", "tar.gz"}
+
     if kind not in always_scene and len(loaded.geometry) == 1:
         geom = next(iter(loaded.geometry.values()))
         geom.metadata.update(loaded.metadata)

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -78,8 +78,10 @@ def load(
     **kwargs,
 ) -> Geometry:
     """
-    Load a mesh or vectorized path into objects like
-    Trimesh, Path2D, Path3D, Scene
+
+    For new code the typed load functions `trimesh.load_scene` or `trimesh.load_mesh`
+    are recommended over `trimesh.load` which is a backwards-compatibility wrapper
+    that mimics the behavior of the old function and can return any geometry type.
 
     Parameters
     -----------
@@ -103,6 +105,7 @@ def load(
       Loaded geometry as trimesh classes
     """
 
+    # call the most general loading case into a `Scene`.
     loaded = load_scene(
         file_obj=file_obj,
         file_type=file_type,
@@ -111,12 +114,25 @@ def load(
         **kwargs,
     )
 
-    # combine a scene into a single mesh
     if force == "mesh":
+        # new code should use `load_mesh` for this
         log.debug(
-            "`trimesh.load_mesh` does the same thing as `trimesh.load(force='mesh')`"
+            "`trimesh.load(force='mesh')` is a compatibility wrapper for `trimesh.load_mesh`"
         )
         return loaded.to_mesh()
+    elif force == "scene":
+        # new code should use `load_scene` for this
+        log.debug(
+            "`trimesh.load(force='scene')` is a compatibility wrapper for `trimesh.load_scene`"
+        )
+        return loaded
+
+    # else:
+    #    log.debug(
+    #        "For new code the typed load functions `trimesh.load_scene` or `trimesh.load_mesh` "
+    #        + "are recommended over `trimesh.load` which is a backwards-compatibility wrapper "
+    #        + "that mimics the behavior of the old function and can return any geometry type."
+    #    )
 
     ###########################################
     # we are matching deprecated behavior here!
@@ -232,8 +248,8 @@ def load_scene(
         loaded = Scene(loaded)
 
     # add the "file_path" information to the overall scene metadata
-    # if 'metadata' not in kwargs:
-    #    loaded.metadata.update(arg.metadata)
+    if "metadata" not in kwargs:
+        loaded.metadata.update(arg.metadata)
     # add the load path metadata to every geometry
     # [g.metadata.update(arg.metadata) for g in loaded.geometry.values()]
 

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -118,21 +118,22 @@ def load(
         )
         return loaded.to_mesh()
 
-    # we are matching deprecated behavior here.
-    # gltf/glb always return a scene
-    file_type = loaded.metadata["file_type"]
-    if len(loaded.geometry) == 1 and file_type in {
-        "obj",
-        "stl",
-        "ply",
-        "svg",
-        "binvox",
-        "xaml",
-        "dxf",
-        "off",
-    }:
-        # matching old behavior, you should probably use `load_scene`
-        return next(iter(loaded.geometry.values()))
+    ###########################################
+    # we are matching deprecated behavior here!
+    # matching old behavior you should probably use `load_scene`
+    if len(loaded.geometry) == 1:
+        geom = next(iter(loaded.geometry.values()))
+        if isinstance(geom, PointCloud) or loaded.metadata["file_type"] in {
+            "obj",
+            "stl",
+            "ply",
+            "svg",
+            "binvox",
+            "xaml",
+            "dxf",
+            "off",
+        }:
+            return geom
 
     return loaded
 

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -332,7 +332,7 @@ def _load_compressed(file_obj, file_type=None, resolver=None, mixed=False, **kwa
             elif compressed_type == "json":
                 import json
 
-                meta_archive[file_name] = json.loads(file_obj)
+                meta_archive[file_name] = json.load(file_obj)
                 continue
             elif compressed_type not in available:
                 # don't raise an exception, just try the next one

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -514,7 +514,7 @@ def _load_kwargs(*args, **kwargs) -> Geometry:
 @dataclass
 class _FileArgs:
     # a file-like object that can be accessed
-    file_obj: Stream
+    file_obj: Optional[Stream]
 
     # a cleaned file type string, i.e. "stl"
     file_type: str
@@ -526,7 +526,7 @@ class _FileArgs:
     was_opened: bool
 
     # a resolver for loading assets next to the file
-    resolver: resolvers.ResolverLike
+    resolver: Optional[resolvers.ResolverLike]
 
 
 def _parse_file_args(

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -113,9 +113,14 @@ def load(
 
     # combine a scene into a single mesh
     if force == "mesh":
-        log.debug("hey in the future use `load_mesh` ;)")
+        log.debug(
+            "`trimesh.load_mesh` does the same thing as `trimesh.load(force='mesh')`"
+        )
         return loaded.to_mesh()
 
+    # we are matching deprecated behavior here.
+    # gltf/glb always return a scene
+    # -
     if len(loaded.geometry) == 1:
         # matching old behavior, you should probably use `load_scene`
         return next(iter(loaded.geometry.values()))
@@ -163,6 +168,7 @@ def load_scene(
         file_type=file_type,
         resolver=resolver,
         allow_remote=allow_remote,
+        **kwargs,
     )
 
     try:

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -328,7 +328,7 @@ def _load_compressed(file_obj, file_type=None, resolver=None, mixed=False, **kwa
                 load_scene(
                     file_obj=data,
                     file_type=compressed_type,
-                    resolver=arg.resolver,
+                    resolver=resolver,
                     metadata=metadata,
                     **kwargs,
                 )

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -207,8 +207,8 @@ def load_scene(
             # call the dummy function to raise the import error
             # this prevents the exception from being super opaque
             load_path()
-        elif isinstance(arg.file_obj, dict):
-            loaded = _load_kwargs(arg.file_obj)
+        elif isinstance(file_obj, dict):
+            loaded = _load_kwargs(file_obj)
         elif arg.file_type in mesh_loaders:
             # mesh loaders use mesh loader
 

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -211,8 +211,10 @@ def load_scene(
     if not isinstance(loaded, Scene):
         loaded = Scene(loaded)
 
-    # add any file path metadata
+    # add the "file_path" information to the overall scene metadata
     loaded.metadata.update(arg.metadata)
+    # add the load path metadata to every geometry
+    [g.metadata.update(arg.metadata) for g in loaded.geometry.values()]
 
     return loaded
 

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -129,6 +129,7 @@ def load(
         "binvox",
         "xaml",
         "dxf",
+        "off",
     }:
         # matching old behavior, you should probably use `load_scene`
         return next(iter(loaded.geometry.values()))

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -144,6 +144,7 @@ def load(
             "xaml",
             "dxf",
             "off",
+            "msh",
         }:
             return geom
 
@@ -231,7 +232,7 @@ def load_scene(
                 **kwargs,
             )
         else:
-            raise ValueError(f"file_type: '{arg.file_type}' not supported")
+            raise NotImplementedError(f"file_type '{arg.file_type}' not supported")
 
     finally:
         # if we opened the file ourselves from a file name

--- a/trimesh/exchange/load.py
+++ b/trimesh/exchange/load.py
@@ -132,6 +132,7 @@ def load(
     if len(loaded.geometry) == 1:
         kind = loaded._source.file_type
         geom = next(iter(loaded.geometry.values()))
+        geom.metadata.update(loaded.metadata)
         if (kind not in {"glb", "gltf"} and isinstance(geom, PointCloud)) or kind in {
             "obj",
             "stl",
@@ -242,10 +243,8 @@ def load_scene(
     loaded._source = arg
 
     ## add the "file_path" information to the overall scene metadata
-    # if "metadata" not in kwargs:
-    #    loaded.metadata.update(arg.metadata)
-    # add the load path metadata to every geometry
-    # [g.metadata.update(arg.metadata) for g in loaded.geometry.values()]
+    if "metadata" not in kwargs:
+        loaded.metadata.update(arg.metadata)
 
     return loaded
 

--- a/trimesh/exchange/misc.py
+++ b/trimesh/exchange/misc.py
@@ -54,24 +54,25 @@ def load_dict(file_obj, **kwargs):
 
     # now go through file_obj structure and if anything is encoded as base64
     # pull it back into numpy arrays
-    if isinstance(file_obj, dict):
-        loaded = {}
-        file_obj = util.decode_keys(file_obj, "utf-8")
-        for key, shape in mesh_file_obj.items():
-            if key in file_obj:
-                loaded[key] = util.encoded_to_array(file_obj[key])
-                if not util.is_shape(loaded[key], shape):
-                    raise ValueError(
-                        "Shape of %s is %s, not %s!",
-                        key,
-                        str(loaded[key].shape),
-                        str(shape),
-                    )
-        if len(key) == 0:
-            raise ValueError("Unable to extract any mesh file_obj!")
-        return loaded
-    else:
-        raise ValueError("%s object passed to dict loader!", file_obj.__class__.__name__)
+    if not isinstance(file_obj, dict):
+        raise ValueError(f"`{type(file_obj)}` object passed to dict loader!")
+
+    loaded = {}
+    file_obj = util.decode_keys(file_obj, "utf-8")
+    for key, shape in mesh_file_obj.items():
+        if key in file_obj:
+            loaded[key] = util.encoded_to_array(file_obj[key])
+            if not util.is_shape(loaded[key], shape):
+                raise ValueError(
+                    "Shape of %s is %s, not %s!",
+                    key,
+                    str(loaded[key].shape),
+                    str(shape),
+                )
+    if len(loaded) == 0:
+        raise ValueError("Unable to extract a mesh from the dict!")
+
+    return loaded
 
 
 def load_meshio(file_obj, file_type=None, **kwargs):

--- a/trimesh/exchange/misc.py
+++ b/trimesh/exchange/misc.py
@@ -104,12 +104,17 @@ def load_meshio(file_obj, file_type=None, **kwargs):
         temp.write(file_obj.read())
         temp.flush()
 
-        for file_format in file_formats:
-            try:
-                mesh = meshio.read(temp.name, file_format=file_format)
-                break
-            except BaseException:
-                util.log.debug("failed to load", exc_info=True)
+        if file_type in file_formats:
+            # if we've been passed the file type and don't have to guess
+            mesh = meshio.read(temp.name, file_format=file_type)
+        else:
+            # try the loaders in order
+            for file_format in file_formats:
+                try:
+                    mesh = meshio.read(temp.name, file_format=file_format)
+                    break
+                except BaseException:
+                    util.log.debug("failed to load", exc_info=True)
         if mesh is None:
             raise ValueError("Failed to load file!")
 
@@ -129,7 +134,7 @@ def load_meshio(file_obj, file_type=None, **kwargs):
     return result
 
 
-_misc_loaders = {}
+_misc_loaders = {"dict": load_dict, "dict64": load_dict}
 
 try:
     import meshio

--- a/trimesh/exchange/misc.py
+++ b/trimesh/exchange/misc.py
@@ -1,9 +1,10 @@
 import json
+from tempfile import NamedTemporaryFile
 
 from .. import util
 
 
-def load_dict(data, **kwargs):
+def load_dict(file_obj, **kwargs):
     """
     Load multiple input types into kwargs for a Trimesh constructor.
     Tries to extract keys:
@@ -14,7 +15,7 @@ def load_dict(data, **kwargs):
 
     Parameters
     ----------
-    data : dict
+    file_obj : dict
     accepts multiple forms
           -dict: has keys for vertices and faces as (n,3) numpy arrays
           -dict: has keys for vertices/faces (n,3) arrays encoded as dicts/base64
@@ -30,19 +31,19 @@ def load_dict(data, **kwargs):
             -faces:    (n,3) int
             -face_normals: (n,3) float (optional)
     """
-    if data is None:
-        raise ValueError("data passed to load_dict was None!")
-    if util.is_instance_named(data, "Trimesh"):
-        return data
-    if isinstance(data, str):
-        if "{" not in data:
+    if file_obj is None:
+        raise ValueError("file_obj passed to load_dict was None!")
+    if util.is_instance_named(file_obj, "Trimesh"):
+        return file_obj
+    if isinstance(file_obj, str):
+        if "{" not in file_obj:
             raise ValueError("Object is not a JSON encoded dictionary!")
-        data = json.loads(data.decode("utf-8"))
-    elif util.is_file(data):
-        data = json.load(data)
+        file_obj = json.loads(file_obj.decode("utf-8"))
+    elif util.is_file(file_obj):
+        file_obj = json.load(file_obj)
 
-    # what shape should the data be to be usable
-    mesh_data = {
+    # what shape should the file_obj be to be usable
+    mesh_file_obj = {
         "vertices": (-1, 3),
         "faces": (-1, (3, 4)),
         "face_normals": (-1, 3),
@@ -51,14 +52,14 @@ def load_dict(data, **kwargs):
         "vertex_colors": (-1, (3, 4)),
     }
 
-    # now go through data structure and if anything is encoded as base64
+    # now go through file_obj structure and if anything is encoded as base64
     # pull it back into numpy arrays
-    if isinstance(data, dict):
+    if isinstance(file_obj, dict):
         loaded = {}
-        data = util.decode_keys(data, "utf-8")
-        for key, shape in mesh_data.items():
-            if key in data:
-                loaded[key] = util.encoded_to_array(data[key])
+        file_obj = util.decode_keys(file_obj, "utf-8")
+        for key, shape in mesh_file_obj.items():
+            if key in file_obj:
+                loaded[key] = util.encoded_to_array(file_obj[key])
                 if not util.is_shape(loaded[key], shape):
                     raise ValueError(
                         "Shape of %s is %s, not %s!",
@@ -67,10 +68,10 @@ def load_dict(data, **kwargs):
                         str(shape),
                     )
         if len(key) == 0:
-            raise ValueError("Unable to extract any mesh data!")
+            raise ValueError("Unable to extract any mesh file_obj!")
         return loaded
     else:
-        raise ValueError("%s object passed to dict loader!", data.__class__.__name__)
+        raise ValueError("%s object passed to dict loader!", file_obj.__class__.__name__)
 
 
 def load_meshio(file_obj, file_type=None, **kwargs):
@@ -98,16 +99,21 @@ def load_meshio(file_obj, file_type=None, **kwargs):
     # e.g., the ones that use h5m underneath
     # in that case use the associated file name instead
     mesh = None
-    for file_format in file_formats:
-        try:
-            mesh = meshio.read(file_obj.name, file_format=file_format)
-            break
-        except BaseException:
-            util.log.debug("failed to load", exc_info=True)
-    if mesh is None:
-        raise ValueError("Failed to load file!")
 
-    # save data as kwargs for a trimesh.Trimesh
+    with NamedTemporaryFile(suffix=f".{file_type}") as temp:
+        temp.write(file_obj.read())
+        temp.flush()
+
+        for file_format in file_formats:
+            try:
+                mesh = meshio.read(temp.name, file_format=file_format)
+                break
+            except BaseException:
+                util.log.debug("failed to load", exc_info=True)
+        if mesh is None:
+            raise ValueError("Failed to load file!")
+
+    # save file_obj as kwargs for a trimesh.Trimesh
     result = {}
     # pass kwargs to mesh constructor
     result.update(kwargs)
@@ -123,7 +129,7 @@ def load_meshio(file_obj, file_type=None, **kwargs):
     return result
 
 
-_misc_loaders = {"dict": load_dict, "dict64": load_dict, "json": load_dict}
+_misc_loaders = {}
 
 try:
     import meshio

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -1,3 +1,4 @@
+import os
 import re
 from collections import defaultdict, deque
 
@@ -352,7 +353,10 @@ def parse_mtl(mtl, resolver=None):
                 # an image file name
                 material["image"] = Image.open(util.wrap_as_stream(file_data))
                 # also store the original map_kd file name
-                material[key] = file_name
+                material["image"].info["file_path"] = os.path.abspath(
+                    os.path.join(getattr(resolver, "parent", ""), file_name)
+                )
+
             except BaseException:
                 log.debug("failed to load image", exc_info=True)
 

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -16,17 +16,20 @@ except BaseException as E:
 
 from .. import util
 from ..constants import log, tol
+from ..resolvers import ResolverLike
+from ..typed import Dict, Loadable, Optional
 from ..visual.color import to_float
 from ..visual.material import SimpleMaterial
 from ..visual.texture import TextureVisuals, unmerge_faces
 
 
 def load_obj(
-    file_obj,
-    resolver=None,
-    group_material=True,
-    skip_materials=False,
-    maintain_order=False,
+    file_obj: Loadable,
+    resolver: Optional[ResolverLike] = None,
+    group_material: bool = True,
+    skip_materials: bool = False,
+    maintain_order: bool = False,
+    metadata: Optional[Dict] = None,
     **kwargs,
 ):
     """
@@ -168,7 +171,19 @@ def load_obj(
         elif current_object is not None:
             name = current_object
         else:
-            name = kwargs.get("metadata", {}).get("file_name", "geometry")
+            name = next(
+                i
+                for i in (
+                    getattr(resolver, "_file_name", None),
+                    getattr(file_obj, "name", None),
+                    "geometry",
+                )
+                if i is not None
+            )
+
+            # if name == 'geometry':
+            #    from IPython import embed
+            #    embed()
 
         # ensure the name is always unique
         name = util.unique_name(name, geometry)

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -171,19 +171,17 @@ def load_obj(
         elif current_object is not None:
             name = current_object
         else:
+            # try to use the file name from the resolver
+            # or file object if possible before defaulting
             name = next(
                 i
                 for i in (
-                    getattr(resolver, "_file_name", None),
+                    getattr(resolver, "file_name", None),
                     getattr(file_obj, "name", None),
                     "geometry",
                 )
                 if i is not None
             )
-
-            # if name == 'geometry':
-            #    from IPython import embed
-            #    embed()
 
         # ensure the name is always unique
         name = util.unique_name(name, geometry)

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -597,15 +597,15 @@ def _parse_vertices(text):
             # we have a nice 2D array
             result[k] = array.reshape(shape)
         else:
-            # try to recover with a slightly more expensive loop
-            count = per_row[k]
-            try:
-                # try to get result through reshaping
-                result[k] = np.fromstring(
-                    " ".join(i.split()[:count] for i in value), sep=" ", dtype=np.float64
-                ).reshape(shape)
-            except BaseException:
-                pass
+            # we don't have a nice (n, d) array so fall back to a slow loop
+            # this is where mixed "some of the values but not all have vertex colors"
+            # problem is handled.
+            lines = []
+            [[lines.append(v.strip().split()) for v in str.splitlines(i)] for i in value]
+            # we need to make a 2D array so clip it to the shortest array
+            count = min(len(L) for L in lines)
+            # make a numpy array out of the cleaned up line data
+            result[k] = np.array([L[:count] for L in lines], dtype=np.float64)
 
     # vertices
     v = result["v"]

--- a/trimesh/graph.py
+++ b/trimesh/graph.py
@@ -9,7 +9,6 @@ Currently uses networkx or scipy.sparse.csgraph backend.
 """
 
 import collections
-import warnings
 
 import numpy as np
 
@@ -740,19 +739,6 @@ def neighbors(edges, max_index=None, directed=False):
     array = [list(neighbors[i]) for i in range(max_index)]
 
     return array
-
-
-def smoothed(*args, **kwargs):
-    """
-    DEPRECATED: use `trimesh.graph.smooth_shade(mesh, ...)`
-    """
-    warnings.warn(
-        "`trimesh.graph.smoothed` is deprecated and will be removed in March 2024: "
-        + "use `trimesh.graph.smooth_shade(mesh, ...)`",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    return smooth_shade(*args, **kwargs)
 
 
 def smooth_shade(

--- a/trimesh/interfaces/generic.py
+++ b/trimesh/interfaces/generic.py
@@ -73,11 +73,9 @@ class MeshScript:
             output = check_output(
                 command_run, stderr=subprocess.STDOUT, startupinfo=startupinfo
             )
-        except CalledProcessError as e:
-            # Log output if debug is enabled
-            if self.debug:
-                log.info(e.output.decode())
-            raise
+        except CalledProcessError as E:
+            # raise with the output from the process
+            raise RuntimeError(E.output.decode())
 
         if self.debug:
             log.info(output.decode())

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -17,7 +17,7 @@ from . import transformations as tf
 from .caching import cache_decorator
 from .constants import tol
 from .resolvers import ResolverLike
-from .typed import Any, ArrayLike, Dict, NDArray, Optional, Stream
+from .typed import Any, ArrayLike, Dict, NDArray, Optional, Stream, float64
 from .util import ABC
 
 
@@ -49,15 +49,13 @@ class LoadSource:
             return None
         return os.path.basename(self.file_path)
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict:
         # this overides the `pickle.dump` behavior for this class
         # we cannot pickle a file object so return `file_obj: None` for pickles
         return {k: v if k != "file_obj" else None for k, v in self.__dict__.items()}
 
-    def __deepcopy__(self):
-        copied = deepcopy(self)
-        copied.file_obj = None
-        return copied
+    def __deepcopy__(self, *args):
+        return LoadSource(**self.__getstate__())
 
 
 class Geometry(ABC):
@@ -98,7 +96,7 @@ class Geometry(ABC):
 
         Returns
         ---------
-        hash : int
+        hash
           Hash of current graph and geometry.
         """
         return self._data.__hash__()  # type: ignore
@@ -119,7 +117,7 @@ class Geometry(ABC):
     def export(self, file_obj, file_type=None):
         pass
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Print quick summary of the current geometry without
         computing properties.
@@ -353,7 +351,7 @@ class Geometry3D(Geometry):
         volume_min = np.argmin([i.volume for i in options])
         return options[volume_min]
 
-    def apply_obb(self, **kwargs):
+    def apply_obb(self, **kwargs) -> NDArray[float64]:
         """
         Apply the oriented bounding box transform to the current mesh.
 

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -7,6 +7,7 @@ The base class for Trimesh, PointCloud, and Scene objects
 
 import abc
 import os
+from copy import deepcopy
 from dataclasses import dataclass
 
 import numpy as np
@@ -52,6 +53,11 @@ class LoadSource:
         # this overides the `pickle.dump` behavior for this class
         # we cannot pickle a file object so return `file_obj: None` for pickles
         return {k: v if k != "file_obj" else None for k, v in self.__dict__.items()}
+
+    def __deepcopy__(self):
+        copied = deepcopy(self)
+        copied.file_obj = None
+        return copied
 
 
 class Geometry(ABC):

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -49,7 +49,7 @@ class LoadSource:
         return os.path.basename(self.file_path)
 
     def __getstate__(self) -> Dict:
-        # this overides the `pickle.dump` behavior for this class
+        # this overrides the `pickle.dump` behavior for this class
         # we cannot pickle a file object so return `file_obj: None` for pickles
         return {k: v if k != "file_obj" else None for k, v in self.__dict__.items()}
 

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -16,7 +16,7 @@ from . import transformations as tf
 from .caching import cache_decorator
 from .constants import tol
 from .resolvers import ResolverLike
-from .typed import Any, ArrayLike, Dict, NDArray, Optional, Stream, float64
+from .typed import Any, ArrayLike, Dict, NDArray, Optional, float64
 from .util import ABC
 
 
@@ -27,7 +27,7 @@ class LoadSource:
     """
 
     # a file-like object that can be accessed
-    file_obj: Optional[Stream] = None
+    file_obj: Optional[Any] = None
 
     # a cleaned file type string, i.e. "stl"
     file_type: Optional[str] = None
@@ -44,6 +44,14 @@ class LoadSource:
 
     @property
     def file_name(self) -> Optional[str]:
+        """
+        Get just the file name from the path if available.
+
+        Returns
+        ---------
+        file_name
+          Just the file name, i.e. for file_path="/a/b/c.stl" -> "c.stl"
+        """
         if self.file_path is None:
             return None
         return os.path.basename(self.file_path)

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -6,6 +6,8 @@ The base class for Trimesh, PointCloud, and Scene objects
 """
 
 import abc
+import os
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -13,8 +15,38 @@ from . import bounds, caching
 from . import transformations as tf
 from .caching import cache_decorator
 from .constants import tol
-from .typed import Any, ArrayLike, Dict, NDArray, Optional
+from .resolvers import ResolverLike
+from .typed import Any, ArrayLike, Dict, NDArray, Optional, Stream
 from .util import ABC
+
+
+@dataclass
+class LoadSource:
+    """
+    Save information about where a particular object was loaded from.
+    """
+
+    # a file-like object that can be accessed
+    file_obj: Optional[Stream]
+
+    # a cleaned file type string, i.e. "stl"
+    file_type: str
+
+    # if this was originally loaded from a file path
+    # save it here so we can check it later.
+    file_path: Optional[str]
+
+    # did we open `file_obj` ourselves?
+    was_opened: bool
+
+    # a resolver for loading assets next to the file
+    resolver: Optional[ResolverLike]
+
+    @property
+    def file_name(self) -> Optional[str]:
+        if self.file_path is None:
+            return None
+        return os.path.basename(self.file_path)
 
 
 class Geometry(ABC):
@@ -28,6 +60,7 @@ class Geometry(ABC):
 
     # geometry should have a dict to store loose metadata
     metadata: Dict
+    source: Optional[LoadSource] = None
 
     @property
     @abc.abstractmethod

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -37,7 +37,7 @@ class LoadSource:
     file_path: Optional[str] = None
 
     # did we open `file_obj` ourselves?
-    was_opened: bool = None
+    was_opened: bool = False
 
     # a resolver for loading assets next to the file
     resolver: Optional[ResolverLike] = None

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -27,20 +27,20 @@ class LoadSource:
     """
 
     # a file-like object that can be accessed
-    file_obj: Optional[Stream]
+    file_obj: Optional[Stream] = None
 
     # a cleaned file type string, i.e. "stl"
-    file_type: str
+    file_type: Optional[str] = None
 
     # if this was originally loaded from a file path
     # save it here so we can check it later.
-    file_path: Optional[str]
+    file_path: Optional[str] = None
 
     # did we open `file_obj` ourselves?
-    was_opened: bool
+    was_opened: bool = None
 
     # a resolver for loading assets next to the file
-    resolver: Optional[ResolverLike]
+    resolver: Optional[ResolverLike] = None
 
     @property
     def file_name(self) -> Optional[str]:
@@ -68,7 +68,25 @@ class Geometry(ABC):
 
     # geometry should have a dict to store loose metadata
     metadata: Dict
-    source: Optional[LoadSource] = None
+
+    @property
+    def source(self) -> LoadSource:
+        """
+        Where and what was this current geometry loaded from?
+
+        Returns
+        --------
+        source
+          If loaded from a file, has the path, type, etc.
+        """
+        # this should have been tacked on by the loader
+        # but we want to *always* be able to access
+        # a value like `mesh.source.file_type` so add a default
+        current = getattr(self, "_source", None):
+        if current is not None:
+            return current
+        self._source = LoadSource()
+        return self._source
 
     @property
     @abc.abstractmethod

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -7,7 +7,6 @@ The base class for Trimesh, PointCloud, and Scene objects
 
 import abc
 import os
-from copy import deepcopy
 from dataclasses import dataclass
 
 import numpy as np

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -48,6 +48,11 @@ class LoadSource:
             return None
         return os.path.basename(self.file_path)
 
+    def __getstate__(self):
+        # this overides the `pickle.dump` behavior for this class
+        # we cannot pickle a file object so return `file_obj: None` for pickles
+        return {k: v if k != "file_obj" else None for k, v in self.__dict__.items()}
+
 
 class Geometry(ABC):
     """

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -82,7 +82,7 @@ class Geometry(ABC):
         # this should have been tacked on by the loader
         # but we want to *always* be able to access
         # a value like `mesh.source.file_type` so add a default
-        current = getattr(self, "_source", None):
+        current = getattr(self, "_source", None)
         if current is not None:
             return current
         self._source = LoadSource()

--- a/trimesh/path/exchange/dxf.py
+++ b/trimesh/path/exchange/dxf.py
@@ -76,7 +76,7 @@ def load_dxf(file_obj, **kwargs):
         # do it by encoding sentinel to bytes and subset searching
         if raw[:22].find(b"AutoCAD Binary DXF") != -1:
             # no converter to ASCII DXF available
-            raise NotImplementedError("binary DXF not supported!")
+            raise NotImplementedError("Binary DXF is not supported!")
         else:
             # we've been passed bytes that don't have the
             # header for binary DXF so try decoding as UTF-8
@@ -814,7 +814,7 @@ def export_dxf(path, only_layers=None):
 
 def bulge_to_arcs(lines, bulge, bulge_idx, is_closed=False, metadata=None):
     """
-    Polylines can have "vertex bulge," which means the polyline
+    Polylines can have "vertex bulge" which means the polyline
     has an arc tangent to segments, rather than meeting at a
     vertex.
 

--- a/trimesh/path/exchange/dxf.py
+++ b/trimesh/path/exchange/dxf.py
@@ -76,7 +76,7 @@ def load_dxf(file_obj, **kwargs):
         # do it by encoding sentinel to bytes and subset searching
         if raw[:22].find(b"AutoCAD Binary DXF") != -1:
             # no converter to ASCII DXF available
-            raise ValueError("binary DXF not supported!")
+            raise NotImplementedError("binary DXF not supported!")
         else:
             # we've been passed bytes that don't have the
             # header for binary DXF so try decoding as UTF-8

--- a/trimesh/path/exchange/load.py
+++ b/trimesh/path/exchange/load.py
@@ -1,10 +1,11 @@
 from ... import util
+from ...exceptions import ExceptionWrapper
 from ...exchange.ply import load_ply
-from ...typed import Optional
+from ...typed import Optional, Set
 from ..path import Path
 from . import misc
 from .dxf import _dxf_loaders
-from .svg_io import svg_to_path
+from .svg_io import _svg_loaders
 
 
 def load_path(file_obj, file_type: Optional[str] = None, **kwargs):
@@ -32,38 +33,25 @@ def load_path(file_obj, file_type: Optional[str] = None, **kwargs):
       Data as a native trimesh Path file_object
     """
     # avoid a circular import
-    from ...exchange.load import _load_kwargs
+    from ...exchange.load import _load_kwargs, _parse_file_args
 
-    if isinstance(file_type, str):
-        # we accept full file names here so make sure we
-        file_type = util.split_extension(file_type).lower()
-
-    # record how long we took
-    tic = util.now()
+    arg = _parse_file_args(file_obj=file_obj, file_type=file_type, **kwargs)
 
     if isinstance(file_obj, Path):
         # we have been passed a file object that is already a loaded
         # trimesh.path.Path object so do nothing and return
         return file_obj
-    elif util.is_file(file_obj):
-        # for open file file_objects use loaders
-        if file_type == "ply":
-            # we cannot register this exporter to path_loaders
-            # since this is already reserved for 3D values in `trimesh.load`
-            kwargs.update(load_ply(file_obj, file_type=file_type))
-        else:
-            kwargs.update(path_loaders[file_type](file_obj, file_type=file_type))
-    elif isinstance(file_obj, str):
-        # strings passed are evaluated as file file_objects
-        with open(file_obj, "rb") as f:
-            # get the file type from the extension
-            file_type = util.split_extension(file_obj).lower()
-            if file_type == "ply":
-                # we cannot register this exporter to path_loaders since this is already reserved by TriMesh in ply format in trimesh.load()
-                kwargs.update(load_ply(f, file_type=file_type))
-            else:
-                # call the loader
-                kwargs.update(path_loaders[file_type](f, file_type=file_type))
+    elif util.is_file(arg.file_obj):
+        if arg.file_type in path_loaders:
+            kwargs.update(
+                path_loaders[arg.file_type](
+                    file_obj=arg.file_obj, file_type=arg.file_type
+                )
+            )
+        elif arg.file_type == "ply":
+            # we cannot register this exporter to path_loaders since
+            # this is already reserved by Trimesh in ply format in trimesh.load()
+            kwargs.update(load_ply(file_obj=arg.file_obj, file_type=arg.file_type))
     elif util.is_instance_named(file_obj, ["Polygon", "MultiPolygon"]):
         # convert from shapely polygons to Path2D
         kwargs.update(misc.polygon_to_path(file_obj))
@@ -72,31 +60,33 @@ def load_path(file_obj, file_type: Optional[str] = None, **kwargs):
         kwargs.update(misc.linestrings_to_path(file_obj))
     elif isinstance(file_obj, dict):
         # load as kwargs
-        return _load_kwargs(file_obj)
+        kwargs = file_obj
     elif util.is_sequence(file_obj):
         # load as lines in space
         kwargs.update(misc.lines_to_path(file_obj))
     else:
         raise ValueError("Not a supported object type!")
 
+    # actually load
     result = _load_kwargs(kwargs)
-    util.log.debug(f"loaded {result!s} in {util.now() - tic:0.4f}s")
+    result._source = arg
 
     return result
 
 
-def path_formats():
+def path_formats() -> Set[str]:
     """
     Get a list of supported path formats.
 
     Returns
     ------------
-    loaders : list of str
-        Extensions of loadable formats, ie:
-        ['svg', 'dxf']
+    loaders
+       Extensions of loadable formats, i.e. {'svg', 'dxf'}
     """
-    return set(path_loaders.keys())
+
+    return {k for k, v in path_loaders.items() if not isinstance(v, ExceptionWrapper)}
 
 
-path_loaders = {"svg": svg_to_path}
+path_loaders = {}
+path_loaders.update(_svg_loaders)
 path_loaders.update(_dxf_loaders)

--- a/trimesh/path/exchange/misc.py
+++ b/trimesh/path/exchange/misc.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from ... import graph, grouping, util
 from ...constants import tol_path
-from ...typed import ArrayLike, Dict
+from ...typed import ArrayLike, Dict, NDArray, Optional
 from ..entities import Arc, Line
 
 
@@ -37,7 +37,7 @@ def dict_to_path(as_dict):
     return result
 
 
-def lines_to_path(lines):
+def lines_to_path(lines: ArrayLike, index: Optional[NDArray[np.int64]] = None) -> Dict:
     """
     Turn line segments into a Path2D or Path3D object.
 
@@ -45,6 +45,8 @@ def lines_to_path(lines):
     ------------
     lines : (n, 2, dimension) or (n, dimension) float
       Line segments or connected polyline curve in 2D or 3D
+    index : (n,) int64
+      If passed save an index for each line segment.
 
     Returns
     -----------
@@ -52,6 +54,9 @@ def lines_to_path(lines):
       kwargs for Path constructor
     """
     lines = np.asanyarray(lines, dtype=np.float64)
+
+    if index is not None:
+        index = np.asanyarray(index, dtype=np.int64)
 
     if util.is_shape(lines, (-1, (2, 3))):
         # the case where we have a list of points

--- a/trimesh/path/exchange/svg_io.py
+++ b/trimesh/path/exchange/svg_io.py
@@ -13,21 +13,6 @@ from ...util import jsonify
 from ..arc import arc_center
 from ..entities import Arc, Bezier, Line
 
-try:
-    # pip install svg.path
-    from svg.path import parse_path
-except BaseException as E:
-    # will re-raise the import exception when
-    # someone tries to call `parse_path`
-    parse_path = exceptions.ExceptionWrapper(E)
-
-try:
-    from lxml import etree
-except BaseException as E:
-    # will re-raise the import exception when
-    # someone actually tries to use the module
-    etree = exceptions.ExceptionWrapper(E)
-
 # store any additional properties using a trimesh namespace
 _ns_name = "trimesh"
 _ns_url = "https://github.com/mikedh/trimesh"
@@ -719,3 +704,23 @@ def _decode(bag):
             base64.urlsafe_b64decode(text[7:].encode("utf-8")).decode("utf-8")
         )
     return text
+
+
+_svg_loaders = {"svg": svg_to_path}
+
+try:
+    # pip install svg.path
+    from svg.path import parse_path
+except BaseException as E:
+    # will re-raise the import exception when
+    # someone tries to call `parse_path`
+    parse_path = exceptions.ExceptionWrapper(E)
+    _svg_loaders["svg"] = parse_path
+
+try:
+    from lxml import etree
+except BaseException as E:
+    # will re-raise the import exception when
+    # someone actually tries to use the module
+    etree = exceptions.ExceptionWrapper(E)
+    _svg_loaders["svg"] = etree

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -8,6 +8,7 @@ those stored in a DXF or SVG file.
 
 import collections
 import copy
+import warnings
 from hashlib import sha256
 
 import numpy as np
@@ -18,7 +19,7 @@ from ..constants import log
 from ..constants import tol_path as tol
 from ..geometry import plane_transform
 from ..points import plane_fit
-from ..typed import ArrayLike, Dict, Iterable, List, NDArray, Optional, float64
+from ..typed import ArrayLike, Dict, Iterable, List, NDArray, Optional, Tuple, float64
 from ..visual import to_rgba
 from . import (
     creation,  # NOQA
@@ -773,12 +774,23 @@ class Path3D(Path):
     Hold multiple vector curves (lines, arcs, splines, etc) in 3D.
     """
 
-    def to_planar(
+    def to_planar(self, *args, **kwargs):
+        """
+        DEPRECATED: replace `path.to_planar`->`path.to_2D), removal 1/1/2026
+        """
+        warnings.warn(
+            "DEPRECATED: replace `path.to_planar`->`path.to_2D), removal 1/1/2026",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.to_3D(*args, **kwargs)
+
+    def to_2D(
         self,
         to_2D: Optional[ArrayLike] = None,
         normal: Optional[ArrayLike] = None,
         check: bool = True,
-    ):
+    ) -> Tuple["Path2D", NDArray[float64]]:
         """
         Check to see if current vectors are all coplanar.
 
@@ -791,17 +803,17 @@ class Path3D(Path):
           Homogeneous transformation matrix to apply,
           if not passed a plane will be fitted to vertices.
         normal : (3,) float or None
-           Normal of direction of plane to use.
+          Normal of direction of plane to use.
         check
-         Raise a ValueError if points aren't coplanar
+          Raise a ValueError if points aren't coplanar.
 
         Returns
         -----------
-        planar : trimesh.path.Path2D
-                   Current path transformed onto plane
-        to_3D :  (4,4) float
-                   Homeogenous transformations to move planar
-                   back into 3D space
+        planar
+          Current path transformed onto plane
+        to_3D : (4, 4) float
+          Homeogenous transformations to move planar
+          back into the original 3D frame.
         """
         # which vertices are actually referenced
         referenced = self.referenced_vertices

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -783,7 +783,7 @@ class Path3D(Path):
             category=DeprecationWarning,
             stacklevel=2,
         )
-        return self.to_3D(*args, **kwargs)
+        return self.to_2D(*args, **kwargs)
 
     def to_2D(
         self,

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -261,7 +261,7 @@ def procrustes(
     # All zero entries are removed from further computations.
     # If weights is a binary array, the optimal solution can still be found by
     # simply removing the zero entries.
-    nonzero_weights = w_norm[:, 0] > 0
+    nonzero_weights = w_norm[:, 0] > 0.0
     a_nonzero = a_original[nonzero_weights]
     b_nonzero = b_original[nonzero_weights]
     w_norm = w_norm[nonzero_weights]
@@ -312,8 +312,8 @@ def procrustes(
         # the transformed source points and the target points.
         cost = (((b_nonzero - transformed[nonzero_weights]) ** 2) * w_norm).sum()
         return matrix, transformed, cost
-    else:
-        return matrix
+
+    return matrix
 
 
 def icp(a, b, initial=None, threshold=1e-5, max_iterations=20, **kwargs):

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -335,6 +335,11 @@ class WebResolver(Resolver):
         else:
             # recombine into string ignoring any double slashes
             path = "/".join(split)
+
+        # save the URL we were created with, i.e.
+        # `https://stuff.com/models/thing.glb`
+        self.url = url
+        # save the root url, i.e. `https://stuff.com/models`
         self.base_url = (
             "/".join(
                 i
@@ -380,6 +385,24 @@ class WebResolver(Resolver):
         response.raise_for_status()
 
         # return the bytes of the response
+        return response.content
+
+    def get_base(self) -> bytes:
+        """
+        Fetch the data at the full URL this resolver was
+        instantiated with, i.e. `https://stuff.com/hi.glb`
+        this will return the response.
+
+        Returns
+        --------
+        content
+          The value at `self.url`
+        """
+        import httpx
+
+        # just fetch the url we were created with
+        response = httpx.get(self.url, follow_redirects=True)
+        response.raise_for_status()
         return response.content
 
     def namespaced(self, namespace: str) -> "WebResolver":

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -611,5 +611,5 @@ def nearby_names(name, namespace=None):
         yield "/".join(strip)
 
 
-# most loaders can use a mapping in additon to a resolver
+# most loaders can use a mapping in addition to a resolver
 ResolverLike = Union[Resolver, Mapping]

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -509,8 +509,15 @@ class GithubResolver(Resolver):
         # download the archive or get from disc
         raw = self.cache.get(self.url, fetch)
         # create a zip resolver for the archive
+        # the root directory in the zip is the repo+commit so strip that off
+        # so the keys are usable, i.e. "models" instead of "trimesh-2232323/models"
         self._zip = ZipResolver(
-            util.decompress(util.wrap_as_stream(raw), file_type="zip")
+            {
+                k.split("/", 1)[1]: v
+                for k, v in util.decompress(
+                    util.wrap_as_stream(raw), file_type="zip"
+                ).items()
+            }
         )
 
         return self._zip

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -402,6 +402,9 @@ class WebResolver(Resolver):
     def write(self, key, value):
         raise NotImplementedError("`WebResolver` is read-only!")
 
+    def keys(self):
+        raise NotImplementedError("`WebResolver` can't list keys")
+
 
 class GithubResolver(Resolver):
     def __init__(

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -321,7 +321,6 @@ class WebResolver(Resolver):
 
         # parse string into namedtuple
         parsed = urlparse(url)
-
         # we want a base url
         split = [i for i in parsed.path.split("/") if len(i) > 0]
 
@@ -485,7 +484,6 @@ class GithubResolver(Resolver):
     @property
     def zipped(self) -> ZipResolver:
         """
-
         - opened zip file
         - locally saved zip file
         - retrieve zip file and saved

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -88,8 +88,8 @@ class FilePathResolver(Resolver):
         if not os.path.isdir(self.parent):
             raise ValueError(f"path `{self.parent} `not a directory!")
 
-        self._source = source
-        self._file_name = os.path.basename(source)
+        self.file_path = source
+        self.file_name = os.path.basename(source)
 
     def keys(self):
         """
@@ -355,6 +355,8 @@ class WebResolver(Resolver):
         assert "//" not in self.base_url[len(parsed.scheme) + 3 :]
         # we should always have ended with a single slash
         assert self.base_url.endswith("/")
+
+        self.file_name = url.split("/")[-1]
 
     def get(self, name: str) -> bytes:
         """

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -88,6 +88,9 @@ class FilePathResolver(Resolver):
         if not os.path.isdir(self.parent):
             raise ValueError(f"path `{self.parent} `not a directory!")
 
+        self._source = source
+        self._file_name = os.path.basename(source)
+
     def keys(self):
         """
         List all files available to be loaded.

--- a/trimesh/resources/__init__.py
+++ b/trimesh/resources/__init__.py
@@ -48,6 +48,7 @@ def _get(name: str, decode: bool, decode_json: bool, as_stream: bool):
     resource : str, bytes, or decoded JSON
       File data
     """
+
     # key by name and decode
     cache_key = (name, bool(decode), bool(decode_json), bool(as_stream))
     cached = _cache.get(cache_key)
@@ -57,7 +58,9 @@ def _get(name: str, decode: bool, decode_json: bool, as_stream: bool):
         return cached
 
     # get the resource using relative names
-    with open(os.path.join(_pwd, name), "rb") as f:
+    # all templates are using POSIX relative paths
+    # so fix them to be platform-specific
+    with open(os.path.join(_pwd, *name.split("/")), "rb") as f:
         resource = f.read()
 
     # make sure we return it as a string if asked

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -367,7 +367,7 @@ class Scene(Geometry3D):
             {
                 k: np.column_stack((v, np.zeros(len(v))))
                 for k, v in vertices.items()
-                if v.shape[1] == 2
+                if v is not None and v.shape[1] == 2
             }
         )
 

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -659,30 +659,6 @@ class Scene(Geometry3D):
         # we only care about the values keys are garbage
         return list(duplicates.values())
 
-    def deduplicated(self) -> "Scene":
-        """
-        DEPRECATED: REMOVAL JANUARY 2025, this is one line and not that useful.
-
-        Return a new scene where each unique geometry is only
-        included once and transforms are discarded.
-
-        Returns
-        -------------
-        dedupe : Scene
-          One copy of each unique geometry from scene
-        """
-
-        warnings.warn(
-            "DEPRECATED: REMOVAL JANUARY 2025, this is one line and not that useful.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-
-        # keying by `identifier_hash` will mean every geometry is unique
-        return Scene(
-            list({g.identifier_hash: g for g in self.geometry.values()}.values())
-        )
-
     def reconstruct_instances(self, cost_threshold: Floating = 1e-5) -> "Scene":
         """
         If a scene has been "baked" with meshes it means that

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -186,10 +186,6 @@ class Scene(Geometry3D):
             self.graph.transforms = concat.graph.transforms
             return
 
-        if not hasattr(geometry, "vertices"):
-            util.log.debug(f"unknown type ({type(geometry).__name__}) added to scene!")
-            return
-
         # get or create a name to reference the geometry by
         if geom_name is not None:
             # if name is passed use it
@@ -363,9 +359,8 @@ class Scene(Geometry3D):
         corners = {}
         # collect vertices for every mesh
         vertices = {
-            k: m.vertices
+            k: m.vertices if hasattr(m, "vertices") and len(m.vertices) > 0 else m.bounds
             for k, m in self.geometry.items()
-            if hasattr(m, "vertices") and len(m.vertices) > 0
         }
         # handle 2D geometries
         vertices.update(

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -193,8 +193,8 @@ class Scene(Geometry3D):
         elif "name" in geometry.metadata:
             # if name is in metadata use it
             name = geometry.metadata["name"]
-        elif "file_name" in geometry.metadata:
-            name = geometry.metadata["file_name"]
+        elif geometry.source is not None and geometry.source.file_name is not None:
+            name = geometry.source.file_name
         else:
             # try to create a simple name
             name = "geometry_" + str(len(self.geometry))

--- a/trimesh/typed.py
+++ b/trimesh/typed.py
@@ -13,7 +13,7 @@ from typing import (
 from numpy import float64, floating, int64, integer, unsignedinteger
 
 # requires numpy>=1.20
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike, DTypeLike, NDArray
 
 if version_info >= (3, 9):
     # use PEP585 hints on newer python
@@ -63,6 +63,7 @@ __all__ = [
     "ArrayLike",
     "BinaryIO",
     "Callable",
+    "DTypeLike",
     "Dict",
     "Hashable",
     "Integer",

--- a/trimesh/units.py
+++ b/trimesh/units.py
@@ -100,12 +100,15 @@ def units_from_metadata(obj: Geometry, guess: bool = True) -> str:
      A guess of what the units might be
     """
 
+    hints = [obj.metadata.get("name", None)]
+    if obj.source is not None:
+        hints.append(obj.source.file_name)
+
     # try to guess from metadata
-    for key in ["file_name", "name"]:
-        if key not in obj.metadata:
+    for hint in hints:
+        if hint is None:
             continue
-        # get the string which might contain unit hints
-        hints = obj.metadata[key].lower()
+        hint = hint.lower()
         if "unit" in hints:
             # replace all delimiter options with white space
             for delim in "_-.":

--- a/trimesh/units.py
+++ b/trimesh/units.py
@@ -109,20 +109,20 @@ def units_from_metadata(obj: Geometry, guess: bool = True) -> str:
         if hint is None:
             continue
         hint = hint.lower()
-        if "unit" in hints:
+        if "unit" in hint:
             # replace all delimiter options with white space
             for delim in "_-.":
-                hints = hints.replace(delim, " ")
+                hint = hint.replace(delim, " ")
             # loop through each hint
-            for hint in hints.strip().split():
+            for h in hint.strip().split():
                 # get rid of keyword and whitespace
-                hint = hint.replace("units", "").replace("unit", "").strip()
+                h = h.replace("units", "").replace("unit", "").strip()
                 # if the hint is a valid unit return it
-                if hint in _lookup:
-                    return hint
+                if h in _lookup:
+                    return h
 
     if not guess:
-        raise ValueError("no units and not allowed to guess")
+        raise ValueError("No units and not allowed to guess!")
 
     # we made it to the wild ass guess section
     # if the scale is larger than 100 mystery units

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1469,22 +1469,23 @@ def concatenate(
     except BaseException:
         pass
 
-    try:
-        source = deepcopy(is_mesh[0].source)
-    except BaseException:
-        source = None
-
     # create the mesh object
-    return trimesh_type(
+    result = trimesh_type(
         vertices=vertices,
         faces=faces,
         face_normals=face_normals,
         vertex_normals=vertex_normals,
         visual=visual,
         metadata=metadata,
-        source=source,
         process=False,
     )
+
+    try:
+        result._source = deepcopy(is_mesh[0].source)
+    except BaseException:
+        pass
+
+    return result
 
 
 def submesh(
@@ -1581,9 +1582,9 @@ def submesh(
             face_normals=np.vstack(normals),
             visual=visual,
             metadata=deepcopy(mesh.metadata),
-            source=deepcopy(mesh.source),
             process=False,
         )
+        appended._source = deepcopy(mesh.source)
 
         return appended
 
@@ -1598,11 +1599,12 @@ def submesh(
             face_normals=n,
             visual=c,
             metadata=deepcopy(mesh.metadata),
-            source=deepcopy(mesh.source),
             process=False,
         )
         for v, f, n, c in zip(vertices, faces, normals, visuals)
     ]
+
+    [setattr(r, "_source", deepcopy(mesh.source)) for r in result]
 
     if only_watertight or repair:
         # fill_holes will attempt a repair and returns the

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -23,7 +23,7 @@ import numpy as np
 from .iteration import chain
 
 # use our wrapped types for wider version compatibility
-from .typed import Dict, Iterable, NDArray, Optional, Set, Union
+from .typed import ArrayLike, Dict, Iterable, NDArray, Optional, Set, Union, float64
 
 # create a default logger
 log = logging.getLogger("trimesh")
@@ -441,7 +441,7 @@ def vector_to_spherical(cartesian):
     return spherical
 
 
-def spherical_to_vector(spherical):
+def spherical_to_vector(spherical: ArrayLike) -> NDArray[float64]:
     """
     Convert an array of `(n, 2)` spherical angles to `(n, 3)` unit vectors.
 
@@ -1279,7 +1279,7 @@ def comment_strip(text, starts_with="#", new_line="\n"):
     return result
 
 
-def encoded_to_array(encoded: Dict) -> NDArray:
+def encoded_to_array(encoded: Union[Dict, ArrayLike]) -> NDArray:
     """
     Turn a dictionary with base64 encoded strings back into a numpy array.
 

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1279,13 +1279,13 @@ def comment_strip(text, starts_with="#", new_line="\n"):
     return result
 
 
-def encoded_to_array(encoded):
+def encoded_to_array(encoded: Dict) -> NDArray:
     """
     Turn a dictionary with base64 encoded strings back into a numpy array.
 
     Parameters
     ------------
-    encoded : dict
+    encoded
       Has keys:
         dtype: string of dtype
         shape: int tuple of shape
@@ -1294,7 +1294,7 @@ def encoded_to_array(encoded):
 
     Returns
     ----------
-    array: numpy array
+    array
     """
 
     if not isinstance(encoded, dict):

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1867,7 +1867,9 @@ def decompress(file_obj, file_type):
     if file_type.endswith("bz2"):
         import bz2
 
-        return {file_obj.name[:-4]: wrap_as_stream(bz2.open(file_obj, mode="r").read())}
+        # get the file name if we have one otherwise default to "archive"
+        name = getattr(file_obj, "name", "archive")
+        return {name: wrap_as_stream(bz2.open(file_obj, mode="r").read())}
     if "tar" in file_type[-6:]:
         import tarfile
 

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -23,7 +23,7 @@ import numpy as np
 from .iteration import chain
 
 # use our wrapped types for wider version compatibility
-from .typed import Dict, Iterable, Optional, Set, Union
+from .typed import Dict, Iterable, NDArray, Optional, Set, Union
 
 # create a default logger
 log = logging.getLogger("trimesh")

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -674,7 +674,7 @@ def hsv_to_rgba(hsv: ArrayLike, dtype: DTypeLike = np.uint8) -> NDArray:
     if len(hsv.shape) != 2 or hsv.shape[1] != 3:
         raise ValueError("(n, 3) values of HSV are required")
     # clip values in-place to 0.0-1.0 range
-    np.clip(hsv, a_min=0.0, a_max=0.0, out=hsv)
+    np.clip(hsv, a_min=0.0, a_max=1.0, out=hsv)
 
     # expand into flat arrays for each of
     # hue, saturation, and value

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -29,7 +29,7 @@ import numpy as np
 from .. import caching, util
 from ..constants import tol
 from ..grouping import unique_rows
-from ..typed import ArrayLike, DTypeLike, Integer, NDArray, Optional
+from ..typed import ArrayLike, DTypeLike, Integer, Iterable, NDArray, Optional, Union
 from .base import Visuals
 
 
@@ -455,7 +455,9 @@ class ColorVisuals(Visuals):
         mat, uv = color_to_uv(vertex_colors=self.vertex_colors)
         return TextureVisuals(material=mat, uv=uv)
 
-    def concatenate(self, other: "ColorVisuals", *args) -> "ColorVisuals":
+    def concatenate(
+        self, other: Union[Iterable[Visuals], Visuals], *args
+    ) -> "ColorVisuals":
         """
         Concatenate two or more ColorVisuals objects
         into a single object.
@@ -560,7 +562,7 @@ class VertexColor(Visuals):
         return self._colors.__hash__()
 
 
-def to_rgba(colors: ArrayLike, dtype: DTypeLike = np.uint8) -> NDArray:
+def to_rgba(colors: Optional[ArrayLike], dtype: DTypeLike = np.uint8) -> NDArray:
     """
     Convert a single or multiple RGB colors to RGBA colors.
 

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -829,8 +829,15 @@ def interpolate(values, color_map=None, dtype=np.uint8):
 
     # make input always float
     values = np.asanyarray(values, dtype=np.float64).ravel()
+    # offset to zero
+    values -= values.min()
+    # get the value range to avoid dividing by zero
+    values_ptp = np.ptp(values)
+    if values_ptp > 0.0:
+        values /= values_ptp
+
     # scale values to 0.0 - 1.0 and get colors
-    colors = cmap((values - values.min()) / np.ptp(values))
+    colors = cmap(values)
     # convert to 0-255 RGBA
     rgba = to_rgba(colors, dtype=dtype)
 
@@ -866,8 +873,8 @@ def uv_to_color(uv, image):
     # access colors from pixel locations
     # make sure image is RGBA before getting values
     colors = np.asanyarray(image.convert("RGBA"))[
-        y.round().astype(np.int64) % image.height, 
-        x.round().astype(np.int64) % image.width
+        y.round().astype(np.int64) % image.height,
+        x.round().astype(np.int64) % image.width,
     ]
 
     # conversion to RGBA should have corrected shape

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -464,9 +464,7 @@ class ColorVisuals(Visuals):
         mat, uv = color_to_uv(vertex_colors=self.vertex_colors)
         return TextureVisuals(material=mat, uv=uv)
 
-    def concatenate(
-        self, other: Union[Iterable[Visuals], Visuals], *args
-    ):
+    def concatenate(self, other: Union[Iterable[Visuals], Visuals], *args):
         """
         Concatenate two or more ColorVisuals objects
         into a single object.

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -77,7 +77,7 @@ class ColorVisuals(Visuals):
             util.log.warning("unable to convert colors!")
 
     @caching.cache_decorator
-    def transparency(self):
+    def transparency(self) -> bool:
         """
         Does the current object contain any transparency.
 
@@ -250,7 +250,7 @@ class ColorVisuals(Visuals):
         self._data["vertex_colors"] = colors
         self._cache.verify()
 
-    def _get_colors(self, name: str):
+    def _get_colors(self, name):
         """
         A magical function which maintains the sanity of vertex and face colors.
 
@@ -480,7 +480,7 @@ class ColorVisuals(Visuals):
         result = objects.concatenate(self, other, *args)
         return result
 
-    def _update_key(self, mask: ArrayLike, key):
+    def _update_key(self, mask, key):
         """
         Mask the value contained in the DataStore at a specified key.
 

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -38,7 +38,12 @@ class ColorVisuals(Visuals):
     Store color information about a mesh.
     """
 
-    def __init__(self, mesh=None, face_colors=None, vertex_colors=None):
+    def __init__(
+        self,
+        mesh=None,
+        face_colors: Optional[ArrayLike] = None,
+        vertex_colors: Optional[ArrayLike] = None,
+    ):
         """
         Store color information about a mesh.
 
@@ -90,7 +95,7 @@ class ColorVisuals(Visuals):
         return bool(a_min < 255)
 
     @property
-    def defined(self):
+    def defined(self) -> bool:
         """
         Are any colors defined for the current mesh.
 
@@ -102,7 +107,7 @@ class ColorVisuals(Visuals):
         return self.kind is not None
 
     @property
-    def kind(self):
+    def kind(self) -> Optional[str]:
         """
         What color mode has been set.
 
@@ -129,7 +134,7 @@ class ColorVisuals(Visuals):
     def __hash__(self):
         return self._data.__hash__()
 
-    def copy(self):
+    def copy(self) -> "ColorVisuals":
         """
         Return a copy of the current ColorVisuals object.
 
@@ -149,7 +154,7 @@ class ColorVisuals(Visuals):
         return copied
 
     @property
-    def face_colors(self):
+    def face_colors(self) -> NDArray[np.uint8]:
         """
         Colors defined for each face of a mesh.
 
@@ -163,7 +168,7 @@ class ColorVisuals(Visuals):
         return self._get_colors(name="face")
 
     @face_colors.setter
-    def face_colors(self, values):
+    def face_colors(self, values: ArrayLike):
         """
         Set the colors for each face of a mesh.
 
@@ -194,7 +199,7 @@ class ColorVisuals(Visuals):
         self._cache.verify()
 
     @property
-    def vertex_colors(self):
+    def vertex_colors(self) -> NDArray[np.uint8]:
         """
         Return the colors for each vertex of a mesh
 
@@ -205,7 +210,7 @@ class ColorVisuals(Visuals):
         return self._get_colors(name="vertex")
 
     @vertex_colors.setter
-    def vertex_colors(self, values):
+    def vertex_colors(self, values: ArrayLike):
         """
         Set the colors for each vertex of a mesh
 
@@ -245,7 +250,7 @@ class ColorVisuals(Visuals):
         self._data["vertex_colors"] = colors
         self._cache.verify()
 
-    def _get_colors(self, name):
+    def _get_colors(self, name: str):
         """
         A magical function which maintains the sanity of vertex and face colors.
 
@@ -369,19 +374,19 @@ class ColorVisuals(Visuals):
                     raise ValueError("unsupported name!!!")
                 self._cache.verify()
 
-    def update_vertices(self, mask):
+    def update_vertices(self, mask: ArrayLike):
         """
         Apply a mask to remove or duplicate vertex properties.
         """
         self._update_key(mask, "vertex_colors")
 
-    def update_faces(self, mask):
+    def update_faces(self, mask: ArrayLike):
         """
         Apply a mask to remove or duplicate face properties
         """
         self._update_key(mask, "face_colors")
 
-    def face_subset(self, face_index):
+    def face_subset(self, face_index: ArrayLike):
         """
         Given a mask of face indices, return a sliced version.
 
@@ -409,7 +414,7 @@ class ColorVisuals(Visuals):
         return result
 
     @property
-    def main_color(self):
+    def main_color(self) -> NDArray[np.uint8]:
         """
         What is the most commonly occurring color.
 
@@ -450,7 +455,7 @@ class ColorVisuals(Visuals):
         mat, uv = color_to_uv(vertex_colors=self.vertex_colors)
         return TextureVisuals(material=mat, uv=uv)
 
-    def concatenate(self, other, *args):
+    def concatenate(self, other: "ColorVisuals", *args) -> "ColorVisuals":
         """
         Concatenate two or more ColorVisuals objects
         into a single object.
@@ -473,7 +478,7 @@ class ColorVisuals(Visuals):
         result = objects.concatenate(self, other, *args)
         return result
 
-    def _update_key(self, mask, key):
+    def _update_key(self, mask: ArrayLike, key):
         """
         Mask the value contained in the DataStore at a specified key.
 
@@ -555,7 +560,7 @@ class VertexColor(Visuals):
         return self._colors.__hash__()
 
 
-def to_rgba(colors, dtype: DTypeLike = np.uint8) -> NDArray:
+def to_rgba(colors: ArrayLike, dtype: DTypeLike = np.uint8) -> NDArray:
     """
     Convert a single or multiple RGB colors to RGBA colors.
 
@@ -625,7 +630,7 @@ def to_float(colors: ArrayLike) -> NDArray[np.float64]:
         raise ValueError("only works on int or float colors!")
 
 
-def hex_to_rgba(color):
+def hex_to_rgba(color: str) -> NDArray[np.uint8]:
     """
     Turn a string hex color to a (4,) RGBA color.
 
@@ -668,6 +673,8 @@ def hsv_to_rgba(hsv: ArrayLike, dtype: DTypeLike = np.uint8) -> NDArray:
     hsv = np.array(hsv, dtype=np.float64)
     if len(hsv.shape) != 2 or hsv.shape[1] != 3:
         raise ValueError("(n, 3) values of HSV are required")
+    # clip values in-place to 0.0-1.0 range
+    np.clip(hsv, a_min=0.0, a_max=0.0, out=hsv)
 
     # expand into flat arrays for each of
     # hue, saturation, and value
@@ -706,7 +713,7 @@ def hsv_to_rgba(hsv: ArrayLike, dtype: DTypeLike = np.uint8) -> NDArray:
     raise ValueError(f"dtype `{dtype}` not supported")
 
 
-def random_color(dtype: DTypeLike = np.uint8, count: Optional[Integer] = None):
+def random_color(dtype: DTypeLike = np.uint8, count: Optional[Integer] = None) -> NDArray:
     """
     Return a random RGB color using datatype specified.
 
@@ -737,7 +744,7 @@ def random_color(dtype: DTypeLike = np.uint8, count: Optional[Integer] = None):
     return colors
 
 
-def vertex_to_face_color(vertex_colors, faces):
+def vertex_to_face_color(vertex_colors: ArrayLike, faces: ArrayLike) -> NDArray[np.uint8]:
     """
     Convert a list of vertex colors to face colors.
 
@@ -827,7 +834,9 @@ def colors_to_materials(colors: ArrayLike, count: Optional[Integer] = None):
     return diffuse, index
 
 
-def linear_color_map(values, color_range=None):
+def linear_color_map(
+    values: ArrayLike, color_range: Optional[ArrayLike] = None
+) -> NDArray[np.uint8]:
     """
     Linearly interpolate between two colors.
 
@@ -959,7 +968,7 @@ def uv_to_color(uv, image) -> NDArray[np.uint8]:
     return colors
 
 
-def uv_to_interpolated_color(uv, image) -> NDArray[np.uint8]:
+def uv_to_interpolated_color(uv: ArrayLike, image) -> NDArray[np.uint8]:
     """
     Get the color from texture image using bilinear sampling.
 
@@ -1025,7 +1034,7 @@ def uv_to_interpolated_color(uv, image) -> NDArray[np.uint8]:
     return colors
 
 
-def color_to_uv(vertex_colors):
+def color_to_uv(vertex_colors: ArrayLike):
     """
     Pack vertex colors into UV coordinates and a simple image material
 

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -29,7 +29,16 @@ import numpy as np
 from .. import caching, util
 from ..constants import tol
 from ..grouping import unique_rows
-from ..typed import ArrayLike, DTypeLike, Integer, Iterable, NDArray, Optional, Union
+from ..typed import (
+    ArrayLike,
+    DTypeLike,
+    Integer,
+    Iterable,
+    NDArray,
+    Optional,
+    Tuple,
+    Union,
+)
 from .base import Visuals
 
 
@@ -562,7 +571,9 @@ class VertexColor(Visuals):
         return self._colors.__hash__()
 
 
-def to_rgba(colors: Optional[ArrayLike], dtype: DTypeLike = np.uint8) -> NDArray:
+def to_rgba(
+    colors: Union[ArrayLike, None, Tuple], dtype: DTypeLike = np.uint8
+) -> NDArray:
     """
     Convert a single or multiple RGB colors to RGBA colors.
 

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -466,7 +466,7 @@ class ColorVisuals(Visuals):
 
     def concatenate(
         self, other: Union[Iterable[Visuals], Visuals], *args
-    ) -> "ColorVisuals":
+    ):
         """
         Concatenate two or more ColorVisuals objects
         into a single object.

--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -249,9 +249,7 @@ class MultiMaterial(Material):
         hash : int
           Xor hash of the contained materials.
         """
-        hashed = int(np.bitwise_xor.reduce([hash(m) for m in self.materials]))
-
-        return hashed
+        return int(np.bitwise_xor.reduce([hash(m) for m in self.materials]))
 
     def __iter__(self):
         return iter(self.materials)


### PR DESCRIPTION
A very common source of annoyance and confusion is that `trimesh.load` can return lots of different types depending on what type of file was passed (i.e. #2239). This refactor changes the return types for the loading functions to:

- `trimesh.load_scene -> Scene`
  - This loads into a `Scene`, the most general container which can hold any loadable type. Most people should probably use this to load geometry. 
- `trimesh.load_mesh -> Trimesh`
  - Forces all mesh objects in a scene into a single `Trimesh` object. This potentially has to drop information and irreversibly concatenate multiple meshes. 
  - The implementation of the concatenation logic is now in `Scene.to_mesh` rather than load. 
- `trimesh.load_path -> Path`
  - This loads into either a `Path2D` or `Path3D` which both inherit from `Path`
- `trimesh.load -> Geometry`
  - This was the original load entry point and is deprecated, but there are no current plans to remove it. It has been modified into a thin wrapper for `load_scene` that attempts to match the behavior of the previous loader for backwards compatibility. In my testing against the current `main` branch it was returning the same types [99.8% of the time](https://gist.github.com/mikedh/8de541e066ce842932b1f6cd97c214ca) although there may be other subtle differences.
  - `trimesh.load(..., force='mesh')` will emit a deprecation warning in favor of `load_mesh`
  - `trimesh.load(..., force='scene')` will emit a deprecation warning in favor of `load_scene`

Additional changes:
- Removes `Geometry.metadata['file_path']` in favor of `Geometry.source.file_path`. Everything that inherits from `Geometry` should now have a `.source` attribute which is a typed dataclass. This was something of a struggle as `file_path` was populated into metadata on load, but we also try to make sure `metadata` is preserved through round-trips if at all possible. And so the `load` inserted *different* keys into the metadata. Making it first-class information rather than a loose key seems like an improvement, but users will have to replace `mesh.metadata["file_name"]` with `mesh.source.file_name`. 
- Moves all network fetching into `WebResolver` so it can be more easily gated by `allow_remote`. 
- Removes code for the following deprecations:
  - January 2025 deprecation for `trimesh.resources.get` in favor of the typed alternatives (`get_json`, `get_bytes`, etc). 
  - January 2025 deprecation for `Scene.deduplicated` in favor of a very short list comprehension on `Scene.duplicate_nodes`
  - March 2024 deprecation for `trimesh.graph.smoothed` in favor of `trimesh.graph.smooth_shaded`. 
- Adds the following new deprecations:
  - January 2026 `Path3D.to_planar` -> `Path3D.to_2D` to be consistent with `Path2D.to_3D`. 
- Fixes #2335 
- Fixes #2330 
- Fixes #2239
- Releases #2313 
- Releases #2327 
- Releases #2336
- Releases #2339



