### PR TITLE
Ensure PIL.Image.resize() always gets a tuple size

### DIFF
--- a/trimesh/visual/gloss.py
+++ b/trimesh/visual/gloss.py
@@ -225,10 +225,10 @@ def specular_to_pbr(
 
     if diffuseTexture is not None and specularGlossinessTexture is not None:
         # reshape to the size of the largest texture
-        max_shape = [
+        max_shape = tuple(
             max(diffuseTexture.size[i], specularGlossinessTexture.size[i])
             for i in range(2)
-        ]
+        )
         if (
             diffuseTexture.size[0] != max_shape[0]
             or diffuseTexture.size[1] != max_shape[1]

--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -1007,7 +1007,7 @@ def pack(
                     scale = max_tex_size.max() / max_tex_size_individual
                     max_tex_size = np.round(max_tex_size / scale).astype(np.int64)
 
-                unpadded_sizes.append(max_tex_size)
+                unpadded_sizes.append(tuple(max_tex_size))
 
             # use the same size for all of them to ensure
             # that texture atlassing is identical

--- a/trimesh/visual/texture.py
+++ b/trimesh/visual/texture.py
@@ -345,6 +345,6 @@ def power_resize(image, resample=1, square=False):
 
     # if we're not powers of two upsize
     if (size != new_size).any():
-        return image.resize(new_size, resample=resample)
+        return image.resize(tuple(new_size), resample=resample)
 
     return image.copy()


### PR DESCRIPTION
Fixes #2247.

I found these by grepping for `\bresize\b` and then auditing the context to decide whether the argument could be something other than a tuple. (I did not check whether every change here corresponds to a particular test regression.)

Then I repeated the tests as described in https://github.com/mikedh/trimesh/issues/2247#issue-2386621640 and confirmed that this fixes all of the regressions I reported, and doesn’t cause any new regressions.