### PR TITLE
Changed boolean_manifold iteration for improved performance.

### DIFF
--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -139,7 +139,7 @@ class BooleanTest(g.unittest.TestCase):
             assert old_mesh.body_count == new_mesh.body_count
             assert g.np.isclose(old_mesh.volume, new_mesh.volume)
 
-        g.log.info(times)        
+        g.log.info(times)
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -95,6 +95,40 @@ class BooleanTest(g.unittest.TestCase):
 
             assert i.is_empty
 
+    def test_manifold_union(self):
+        if manifold3d is None:
+            return
+
+        meshes = [g.trimesh.primitives.Sphere(center=[x / 2, 0, 0], subdivisions=0) for x in range(100)]
+
+        # the old 'serial' manifold union method
+        tic = g.time.time()
+        manifolds = [
+            manifold3d.Manifold(
+                mesh=manifold3d.Mesh(
+                    vert_properties=g.np.array(mesh.vertices, dtype=g.np.float32),
+                    tri_verts=g.np.array(mesh.faces, dtype=g.np.uint32),
+                )
+            )
+            for mesh in meshes
+        ]
+        result_manifold = manifolds[0]
+        for manifold in manifolds[1:]:
+            result_manifold = result_manifold + manifold
+        result_mesh = result_manifold.to_mesh()
+        old_mesh = g.trimesh.Trimesh(vertices=result_mesh.vert_properties, faces=result_mesh.tri_verts)
+        times = {'serial union': g.time.time() - tic}
+
+        # new 'binary reduction' method
+        tic = g.time.time()
+        new_mesh = g.trimesh.boolean.boolean_manifold(meshes, 'union')
+        times['binary union'] = g.time.time() - tic
+
+        assert old_mesh.is_volume == new_mesh.is_volume
+        assert old_mesh.body_count == new_mesh.body_count
+        assert g.np.isclose(old_mesh.volume, new_mesh.volume)
+
+        g.log.info(times)        
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -95,38 +95,49 @@ class BooleanTest(g.unittest.TestCase):
 
             assert i.is_empty
 
-    def test_manifold_union(self):
+    def test_boolean_manifold(self):
         if manifold3d is None:
             return
 
-        meshes = [g.trimesh.primitives.Sphere(center=[x / 2, 0, 0], subdivisions=0) for x in range(100)]
+        times = {}
+        for operation in ["union", "intersection"]:
 
-        # the old 'serial' manifold union method
-        tic = g.time.time()
-        manifolds = [
-            manifold3d.Manifold(
-                mesh=manifold3d.Mesh(
-                    vert_properties=g.np.array(mesh.vertices, dtype=g.np.float32),
-                    tri_verts=g.np.array(mesh.faces, dtype=g.np.uint32),
+            if operation == "union":
+                # chain of icospheres
+                meshes = [g.trimesh.primitives.Sphere(center=[x / 2, 0, 0], subdivisions=0) for x in range(100)]
+            else:
+                # closer icospheres for non-empty-intersection
+                meshes = [g.trimesh.primitives.Sphere(center=[x, x, x], subdivisions=0) for x in g.np.linspace(0, 0.5, 101)]
+
+            # the old 'serial' manifold method
+            tic = g.time.time()
+            manifolds = [
+                manifold3d.Manifold(
+                    mesh=manifold3d.Mesh(
+                        vert_properties=g.np.array(mesh.vertices, dtype=g.np.float32),
+                        tri_verts=g.np.array(mesh.faces, dtype=g.np.uint32),
+                    )
                 )
-            )
-            for mesh in meshes
-        ]
-        result_manifold = manifolds[0]
-        for manifold in manifolds[1:]:
-            result_manifold = result_manifold + manifold
-        result_mesh = result_manifold.to_mesh()
-        old_mesh = g.trimesh.Trimesh(vertices=result_mesh.vert_properties, faces=result_mesh.tri_verts)
-        times = {'serial union': g.time.time() - tic}
+                for mesh in meshes
+            ]
+            result_manifold = manifolds[0]
+            for manifold in manifolds[1:]:
+                if operation == "union":
+                    result_manifold = result_manifold + manifold
+                else: # operation == "intersection":
+                    result_manifold = result_manifold ^ manifold
+            result_mesh = result_manifold.to_mesh()
+            old_mesh = g.trimesh.Trimesh(vertices=result_mesh.vert_properties, faces=result_mesh.tri_verts)
+            times["serial " + operation] = g.time.time() - tic
 
-        # new 'binary reduction' method
-        tic = g.time.time()
-        new_mesh = g.trimesh.boolean.boolean_manifold(meshes, 'union')
-        times['binary union'] = g.time.time() - tic
+            # new 'binary' method
+            tic = g.time.time()
+            new_mesh = g.trimesh.boolean.boolean_manifold(meshes, operation)
+            times["binary " + operation] = g.time.time() - tic
 
-        assert old_mesh.is_volume == new_mesh.is_volume
-        assert old_mesh.body_count == new_mesh.body_count
-        assert g.np.isclose(old_mesh.volume, new_mesh.volume)
+            assert old_mesh.is_volume == new_mesh.is_volume
+            assert old_mesh.body_count == new_mesh.body_count
+            assert g.np.isclose(old_mesh.volume, new_mesh.volume)
 
         g.log.info(times)        
 

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -111,7 +111,6 @@ def boolean_manifold(
     meshes: Iterable,
     operation: str,
     check_volume: bool = True,
-    debug: bool = False,
     **kwargs,
 ):
     """
@@ -127,12 +126,12 @@ def boolean_manifold(
       Raise an error if not all meshes are watertight
       positive volumes. Advanced users may want to ignore
       this check as it is expensive.
-    debug
-      Enable potentially slow additional checks and debug info.
     kwargs
       Passed through to the `engine`.
-
     """
+    if check_volume and not all(m.is_volume for m in meshes):
+        raise ValueError("Not all meshes are volumes!")
+    
     # Convert to manifold meshes
     manifolds = [
         Manifold(
@@ -151,12 +150,16 @@ def boolean_manifold(
 
         result_manifold = manifolds[0] - manifolds[1]
     elif operation == "union":
+        for lvl in range(int(1 + np.log2(len(manifolds)))):
+            results = []
+            for i in np.arange(len(manifolds) // 2) * 2:
+                results.append(manifolds[i] + manifolds[i + 1])    
+            if len(manifolds) % 2:
+                results.append(manifolds[-1])
+            manifolds = results
         result_manifold = manifolds[0]
-        for manifold in manifolds[1:]:
-            result_manifold = result_manifold + manifold
     elif operation == "intersection":
         result_manifold = manifolds[0]
-
         for manifold in manifolds[1:]:
             result_manifold = result_manifold ^ manifold
     else:

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -149,19 +149,18 @@ def boolean_manifold(
             raise ValueError("Difference only defined over two meshes.")
 
         result_manifold = manifolds[0] - manifolds[1]
-    elif operation == "union":
+    elif operation in ["union", "intersection"]:
         for lvl in range(int(1 + np.log2(len(manifolds)))):
             results = []
             for i in np.arange(len(manifolds) // 2) * 2:
-                results.append(manifolds[i] + manifolds[i + 1])    
+                if operation == "union":
+                    results.append(manifolds[i] + manifolds[i + 1])
+                else: # operation == "intersection":
+                    results.append(manifolds[i] ^ manifolds[i + 1])
             if len(manifolds) % 2:
                 results.append(manifolds[-1])
             manifolds = results
         result_manifold = manifolds[0]
-    elif operation == "intersection":
-        result_manifold = manifolds[0]
-        for manifold in manifolds[1:]:
-            result_manifold = result_manifold ^ manifold
     else:
         raise ValueError(f"Invalid boolean operation: '{operation}'")
 

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -131,7 +131,7 @@ def boolean_manifold(
     """
     if check_volume and not all(m.is_volume for m in meshes):
         raise ValueError("Not all meshes are volumes!")
-    
+
     # Convert to manifold meshes
     manifolds = [
         Manifold(
@@ -150,7 +150,7 @@ def boolean_manifold(
 
         result_manifold = manifolds[0] - manifolds[1]
     elif operation in ["union", "intersection"]:
-        for lvl in range(int(1 + np.log2(len(manifolds)))):
+        for _lvl in range(int(1 + np.log2(len(manifolds)))):
             results = []
             for i in np.arange(len(manifolds) // 2) * 2:
                 if operation == "union":


### PR DESCRIPTION
Hey Mike,

I was at a point where I had to perform a massive boolean _union_ operation for **a lot** of small meshes.
The incremental way this was implemented became slower and slower with each manifold that was added.
Therefore, I've implemented a more binary-reduction-like iteration, going like this:
`[a, b, c, d, e, f, g]`
`[ab, cd, ef, g]`
`[abcd, efg]`
`[abcdefg]`

It still performs the same boolean operation for all objects in the input list, but is drastically more performant - especially if the input list is huge.
I have also added a test, verifying that it produces the same result as the original code.

As I was writing this, I realized that it should actually work analogously for the _intersection_ - so I rewrote it too.

Cheers
Dennis