### PR TITLE
Release: NP2 Overflow Hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,8 @@ USER root
 RUN trimesh-setup --install=test,gmsh,gltf_validator,llvmpipe,binvox
 USER user
 
-# install things like pytest
-# install prerelease for tests and make sure we're on Numpy 2.X
+# install things like pytest and make sure we're on Numpy 2.X
 RUN pip install .[all] && \
-    pip install --pre --upgrade --force-reinstall numpy && \
     python -c "import numpy as n; assert(n.__version__.startswith('2'))"
 
 # check for lint problems

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.8"
-version = "4.4.2"
+version = "4.4.3"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."


### PR DESCRIPTION
- Numpy 2 has stricter rules about overflowing integers, in an upstream application I was seeing `grouping.hashable_rows` overflowing an integer.  
  - fixed by always promoting `float_to_int` to an `int64` on integer input rather than returning any integer type. I also disabled the "int32 vs int64" choice based on maximum value as it may have provided a speedup in some cases, but making this function simpler and have consistent return types seems more valuable. The type hint will be checked by Beartype in the docker image tests. 
- Removed the prerelease install for Numpy 2 in tests since Numpy 2.0.0 was released June 16. 

Traceback for posterity:
```
File "/home/mikedh/trimesh/trimesh/visual/color.py", line 431, in main_color
    unique, inverse = unique_rows(colors)
                      ^^^^^^^^^^^^^^^^^^^
  File "/home/mikedh/trimesh/trimesh/grouping.py", line 451, in unique_rows
    rows = hashable_rows(data, digits=digits)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mikedh/trimesh/trimesh/grouping.py", line 209, in hashable_rows
    bitbang = (as_int.T + threshold).astype(np.uint64)
               ~~~~~~~~~^~~~~~~~~~~
OverflowError: Python integer 32767 out of bounds for uint8

```