### PR TITLE
Update transformations.py

### DIFF
--- a/trimesh/transformations.py
+++ b/trimesh/transformations.py
@@ -323,7 +323,7 @@ def rotation_matrix(angle, direction, point=None):
     angle     : float, or sympy.Symbol
       Angle, in radians or symbolic angle
     direction : (3,) float
-      Unit vector along rotation axis
+      Any vector along rotation axis
     point     : (3, ) float, or None
       Origin point of rotation axis
 


### PR DESCRIPTION
In the function rotation_matrix the input array direction is being normalised by the the function unit_vector anyways, so there is no need to explicitly require direction to only consist of unit_vectors in the description of rotation_matrix.