### PR TITLE
Release: Use Debian Docker Base Image

### DIFF
--- a/docker/trimesh-setup
+++ b/docker/trimesh-setup
@@ -35,7 +35,6 @@ config_json = """
       "pandoc"
     ],
     "llvmpipe": [
-      "libgl1-mesa-glx",
       "libgl1-mesa-dri",
       "xvfb",
       "xauth",
@@ -43,8 +42,6 @@ config_json = """
       "freeglut3-dev"
     ],
     "test": [
-      "blender",
-      "openscad",
       "curl",
       "git"
     ],

--- a/examples/docker/render/Dockerfile
+++ b/examples/docker/render/Dockerfile
@@ -8,6 +8,12 @@ RUN trimesh-setup --install llvmpipe
 # go back to the unprivileged user
 USER user
 
+# Set environment variables for software rendering.
+ENV XVFB_WHD="1920x1080x24"\
+    DISPLAY=":99" \
+    LIBGL_ALWAYS_SOFTWARE="1" \
+    GALLIUM_DRIVER="llvmpipe"
+
 # copy our example file which renders a sphere
 COPY render.py .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.8"
-version = "4.4.6"
+version = "4.4.7"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -885,6 +885,7 @@ def _append_mesh(
             buff=buffer_items,
             blob={
                 "componentType": 5121,
+                "normalized": True,
                 "type": "VEC4",
                 "byteOffset": 0,
             },
@@ -1157,6 +1158,7 @@ def _append_path(path, name, tree, buffer_items):
             buff=buffer_items,
             blob={
                 "componentType": 5121,
+                "normalized": True,
                 "type": "VEC4",
                 "byteOffset": 0,
             },
@@ -1227,6 +1229,7 @@ def _append_point(points, name, tree, buffer_items):
             blob={
                 "componentType": 5121,
                 "count": vxlist[0],
+                "normalized": True,
                 "type": kind,
                 "byteOffset": 0,
             },


### PR DESCRIPTION
This PR switches to use the first-party `debian` base images with python from `apt` and a user `venv`, instead of using the `python:3.12-slim-bookworm` Debian base images. This shouldn't make any difference to users of the upstream Docker images unless you were relying on copying `/home/user/.local` which would now be `/home/user/venv`

- [This discussion](https://discuss.python.org/t/why-python-in-debian-docker-image-is-faster-than-official-dockers-python-image/53976) indicates the build of Python in vanilla Debian performed 34% faster on [this simple loop-and-square-integer](https://github.com/fabien-michel/compare-python/blob/master/test.py) benchmark.
- The `python` docker images are from the Docker organization not the Python Software Foundation so the builds are of comparable levels of "official."  
- It's not exactly a benchmark, but running the full `trimesh` test suite in Docker appeared to take [11m 41s on `python:3.12-slim-bookworm`](https://github.com/mikedh/trimesh/actions/runs/10412579076/job/28838600894) vs [9m 24s on `debian:trixie-slim`](https://github.com/mikedh/trimesh/actions/runs/10434533365/job/28897508561) (this PR), a roughly 20% improvement which is in-line with the synthetic benchmark. 