### PR TITLE
Fix: Blender 4.2

### DIFF
--- a/trimesh/resources/templates/blender_boolean.py.tmpl
+++ b/trimesh/resources/templates/blender_boolean.py.tmpl
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     mesh_post = os.path.abspath(r'$MESH_POST')
 
     for filename in mesh_pre:  # use data.objects instead of context.scene.objects
-        bpy.ops.import_mesh.stl(filepath=os.path.abspath(filename))
+        bpy.ops.wm.stl_import(filepath=os.path.abspath(filename))
 
     mesh = bpy.data.objects[0]
     # Make sure mesh is the active object
@@ -62,6 +62,6 @@ if __name__ == '__main__':
         bpy.ops.object.modifier_apply(modifier=mod.name)
 
     delete_nonresult(bpy)
-    bpy.ops.export_mesh.stl(
+    bpy.ops.wm.stl_export(
         filepath=mesh_post,
-        use_mesh_modifiers=True)
+        apply_modifiers=True)


### PR DESCRIPTION
For some reason `bpy.ops.import_stl` was failing on Blender 4.2. This switches it to `bpy.ops.wm.stl_import` as suggested [here](https://blender.stackexchange.com/questions/321366/correct-way-of-using-bpy-ops-import-mesh-stl-bpy-function). It wasn't clear to me what version of blender added this, but the interface should really be checking the version range. 

We should also probably deprecate the blender interface, since `manifold3d` came along and is great, and calling blender with subprocess is pretty janky. Fixes #2267 