### PR TITLE
Release: Stride Speedup + Hints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     name: Check Code Formatting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - name: Install Formatting
@@ -38,9 +38,9 @@ jobs:
           - os: macos-13
             python-version: 3.9
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Test a minimal install
@@ -57,9 +57,9 @@ jobs:
     needs: [tests, containers]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Install publishing dependencies
@@ -81,7 +81,7 @@ jobs:
     - name: Log In to Docker Hub
       run: echo ${{ secrets.DH_PASS }} | docker login --username mikedh --password-stdin
     - name: Checkout trimesh
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build Images And Docs
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -104,15 +104,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Check Corpus Loading
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Trimesh DiskCache
       id: cache-resolvers
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.trimesh-cache
         key: trimesh-cache
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
          python-version: "3.10"
     - name: Install Trimesh
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Tag Version
         id: set_tag
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - name: Install
@@ -28,9 +28,9 @@ jobs:
         python-version: ["3.8", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-13]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Test a minimal install
@@ -46,7 +46,7 @@ jobs:
     name: Run Tests In Docker
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run Pytest In Docker
       run: make tests
 
@@ -54,15 +54,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Check Corpus Loading
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Trimesh DiskCache
       id: cache-resolvers
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.trimesh-cache
         key: trimesh-cache
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
          python-version: "3.11"
     - name: Install Trimesh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN useradd -m -u 499 -s /bin/bash user && \
 USER user
 
 WORKDIR /home/user
+
+# install a python `venv`
+# this seems a little silly since we're already in a container
+# but if you use Debian methods like `update-alternatives`
+# it won't provide a `pip` which works easily and it isn't
+# easy to know how system packages interact with pip packages
 RUN python3.12 -m venv venv
 
 # So scripts installed from pip are in $PATH
@@ -23,12 +29,24 @@ COPY --chmod=755 docker/trimesh-setup /home/user/venv/bin
 ## install things that need building
 FROM base AS build
 
+USER root
+# install wget for fetching wheels
+RUN apt-get update && \
+    apt-get install --no-install-recommends -qq -y wget ca-certificates && \
+    apt-get clean -y 
+USER user
+
 # copy in essential files
 COPY --chown=499 trimesh/ /home/user/trimesh
 COPY --chown=499 pyproject.toml /home/user/
 
-# install trimesh into .local
+# install trimesh into the venv
 RUN pip install /home/user[easy]
+
+# install FCL, which currently has broken wheels on pypi
+RUN wget https://github.com/BerkeleyAutomation/python-fcl/releases/download/v0.7.0.7/python_fcl-0.7.0.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl && \
+    pip install python_fcl*.whl && \
+    rm python_fcl*.whl
 
 ####################################
 ### Build output image most things should run on

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,7 @@ RUN trimesh-setup --install=test,gmsh,gltf_validator,llvmpipe,binvox
 USER user
 
 # install things like pytest and make sure we're on Numpy 2.X
-# todo : imagio is forcing a downgrade of numpy 2 in-place
-RUN pip install .[all] && pip install --force-reinstall --upgrade "numpy>2" && \
+RUN pip install .[all] && \
     python -c "import numpy as n; assert(n.__version__.startswith('2'))"
 
 # check for lint problems

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,4 +169,4 @@ python_version = "3.8"
 ignore_missing_imports = true
 disallow_untyped_defs = false
 disallow_untyped_calls = false
-disable_error_code = ["method-assign"]
+disable_error_code = ["method-assign", "var-annotated"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ recommend = [
     "pyglet<2",
     "psutil",
     "scikit-image",
+    "fast-simplification",
     # "python-fcl", # do collision checks # TODO : broken on numpy 2
     "openctm", # load `CTM` compressed models
     "cascadio", # load `STEP` files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ recommend = [
     "pyglet<2",
     "psutil",
     "scikit-image",
-    "python-fcl", # do collision checks
+    # "python-fcl", # do collision checks # TODO : broken on numpy 2
     "openctm", # load `CTM` compressed models
     "cascadio", # load `STEP` files
     
@@ -158,7 +158,6 @@ flake8-implicit-str-concat = {"allow-multiline" = false}
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "IPython.embed".msg = "you forgot to remove a debug embed ;)"
 "numpy.empty".msg = "uninitialized arrays are haunted try numpy.zeros"
-
 
 [tool.codespell]
 skip = "*.js*,./docs/built/*,./docs/generate/*,./models*,*.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.8"
-version = "4.4.7"
+version = "4.4.8"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/tests/test_quadric.py
+++ b/tests/test_quadric.py
@@ -1,0 +1,28 @@
+try:
+    from . import generic as g
+except BaseException:
+    import generic as g
+
+
+def test_quadric_simplification():
+    if not g.trimesh.util.has_module("fast_simplification"):
+        return
+
+    m = g.get_mesh("rabbit.obj")
+    assert len(m.faces) > 600
+
+    # should be about half as large
+    a = m.simplify_quadric_decimation(percent=0.5)
+    assert g.np.isclose(len(a.faces), len(m.faces) // 2, rtol=0.2)
+
+    # should have the requested number of faces
+    a = m.simplify_quadric_decimation(face_count=200)
+    assert len(a.faces) == 200
+
+    # see if aggression does anything
+    a = m.simplify_quadric_decimation(percent=0.25, aggression=5)
+    assert len(a.faces) > 0
+
+
+if __name__ == "__main__":
+    test_quadric_simplification()

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2889,7 +2889,7 @@ class Trimesh(Geometry3D):
         """
 
         return boolean.union(
-            meshes=np.append(self, other),
+            meshes=[self, other],
             engine=engine,
             check_volume=check_volume,
             **kwargs,
@@ -2958,7 +2958,7 @@ class Trimesh(Geometry3D):
            Mesh of the volume contained by all passed meshes
         """
         return boolean.intersection(
-            meshes=np.append(self, other),
+            meshes=[self, other],
             engine=engine,
             check_volume=check_volume,
             **kwargs,

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2542,7 +2542,7 @@ class Trimesh(Geometry3D):
         self,
         percent: Optional[Floating] = None,
         face_count: Optional[Integer] = None,
-        aggression: Optional[Floating] = None,
+        aggression: Optional[Integer] = None,
     ) -> "Trimesh":
         """
         A thin wrapper around `pip install fast-simplification`.

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2526,57 +2526,6 @@ class Trimesh(Geometry3D):
 
         return creation.voxelize(mesh=self, pitch=pitch, method=method, **kwargs)
 
-    @cache_decorator
-    def as_open3d(self):
-        """
-        Return an `open3d.geometry.TriangleMesh` version of
-        the current mesh.
-
-        Returns
-        ---------
-        open3d : open3d.geometry.TriangleMesh
-          Current mesh as an open3d object.
-        """
-        import open3d
-
-        # create from numpy arrays
-        return open3d.geometry.TriangleMesh(
-            vertices=open3d.utility.Vector3dVector(self.vertices.copy()),
-            triangles=open3d.utility.Vector3iVector(self.faces.copy()),
-        )
-
-    def simplify_quadratic_decimation(self, *args, **kwargs):
-        """
-        DERECATED MARCH 2024 REPLACE WITH:
-        `mesh.simplify_quadric_decimation`
-        """
-        warnings.warn(
-            "`simplify_quadratic_decimation` is deprecated "
-            + "as it was a typo and will be removed in March 2024: "
-            + "replace with `simplify_quadric_decimation`",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.simplify_quadric_decimation(*args, **kwargs)
-
-    def simplify_quadric_decimation(self, face_count: int) -> "Trimesh":
-        """
-        A thin wrapper around the `open3d` implementation of this:
-        `open3d.geometry.TriangleMesh.simplify_quadric_decimation`
-
-        Parameters
-        -----------
-        face_count : int
-          Number of faces desired in the resulting mesh.
-
-        Returns
-        ---------
-        simple : trimesh.Trimesh
-          Simplified version of mesh.
-        """
-        simple = self.as_open3d.simplify_quadric_decimation(int(face_count))
-        return Trimesh(vertices=simple.vertices, faces=simple.triangles)
-
     def outline(self, face_ids: Optional[NDArray[int64]] = None, **kwargs) -> Path3D:
         """
         Given a list of face indexes find the outline of those
@@ -3055,7 +3004,7 @@ class Trimesh(Geometry3D):
             )
         )
 
-    def copy(self, include_cache: bool = False) -> "Trimesh":
+    def copy(self, include_cache: bool = False, include_visual: bool = True) -> "Trimesh":
         """
         Safely return a copy of the current mesh.
 
@@ -3079,8 +3028,11 @@ class Trimesh(Geometry3D):
         copied = Trimesh()
         # always deepcopy vertex and face data
         copied._data.data = copy.deepcopy(self._data.data)
-        # copy visual information
-        copied.visual = self.visual.copy()
+
+        if include_visual:
+            # copy visual information
+            copied.visual = self.visual.copy()
+
         # get metadata
         copied.metadata = copy.deepcopy(self.metadata)
 

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -8,7 +8,7 @@ Do boolean operations on meshes using either Blender or Manifold.
 import numpy as np
 
 from . import exceptions, interfaces
-from .typed import Callable, Optional, Sequence
+from .typed import Callable, Optional, Sequence, Union
 
 try:
     from manifold3d import Manifold, Mesh
@@ -162,7 +162,7 @@ def boolean_manifold(
     return Trimesh(vertices=result_mesh.vert_properties, faces=result_mesh.tri_verts)
 
 
-def reduce_cascade(operation: Callable, items: Sequence):
+def reduce_cascade(operation: Callable, items: Union[Sequence, ArrayLike]):
     """
     Call an operation function in a cascaded pairwise way against a
     flat list of items.

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -8,7 +8,7 @@ Do boolean operations on meshes using either Blender or Manifold.
 import numpy as np
 
 from . import exceptions, interfaces
-from .typed import ArrayLike, Callable, Optional
+from .typed import Callable, Optional, Sequence
 
 try:
     from manifold3d import Manifold, Mesh
@@ -18,7 +18,7 @@ except BaseException as E:
 
 
 def difference(
-    meshes: ArrayLike, engine: Optional[str] = None, check_volume: bool = True, **kwargs
+    meshes: Sequence, engine: Optional[str] = None, check_volume: bool = True, **kwargs
 ):
     """
     Compute the boolean difference between a mesh an n other meshes.
@@ -48,7 +48,7 @@ def difference(
 
 
 def union(
-    meshes: ArrayLike, engine: Optional[str] = None, check_volume: bool = True, **kwargs
+    meshes: Sequence, engine: Optional[str] = None, check_volume: bool = True, **kwargs
 ):
     """
     Compute the boolean union between a mesh an n other meshes.
@@ -78,7 +78,7 @@ def union(
 
 
 def intersection(
-    meshes: ArrayLike, engine: Optional[str] = None, check_volume: bool = True, **kwargs
+    meshes: Sequence, engine: Optional[str] = None, check_volume: bool = True, **kwargs
 ):
     """
     Compute the boolean intersection between a mesh and other meshes.
@@ -107,7 +107,7 @@ def intersection(
 
 
 def boolean_manifold(
-    meshes: ArrayLike,
+    meshes: Sequence,
     operation: str,
     check_volume: bool = True,
     **kwargs,
@@ -162,7 +162,7 @@ def boolean_manifold(
     return Trimesh(vertices=result_mesh.vert_properties, faces=result_mesh.tri_verts)
 
 
-def reduce_cascade(operation: Callable, items: ArrayLike):
+def reduce_cascade(operation: Callable, items: Sequence):
     """
     Call an operation function in a cascaded pairwise way against a
     flat list of items.

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -8,7 +8,7 @@ Do boolean operations on meshes using either Blender or Manifold.
 import numpy as np
 
 from . import exceptions, interfaces
-from .typed import Callable, Optional, Sequence, Union
+from .typed import Callable, NDArray, Optional, Sequence, Union
 
 try:
     from manifold3d import Manifold, Mesh
@@ -162,7 +162,7 @@ def boolean_manifold(
     return Trimesh(vertices=result_mesh.vert_properties, faces=result_mesh.tri_verts)
 
 
-def reduce_cascade(operation: Callable, items: Union[Sequence, ArrayLike]):
+def reduce_cascade(operation: Callable, items: Union[Sequence, NDArray]):
     """
     Call an operation function in a cascaded pairwise way against a
     flat list of items.

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1446,9 +1446,14 @@ def _read_buffers(
                     assert 0 <= start <= start + length <= len(data)
                     access[index] = np.array(
                         np.lib.stride_tricks.as_strided(
-                            np.frombuffer(data, dtype=np.uint8, offset=start, count=length),
-                            [count, per_row], [stride, 1]
-                        ).view(dtype).reshape(shape)
+                            np.frombuffer(
+                                data, dtype=np.uint8, offset=start, count=length
+                            ),
+                            [count, per_row],
+                            [stride, 1],
+                        )
+                        .view(dtype)
+                        .reshape(shape)
                     )
                 else:
                     # length is the number of bytes per item times total

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -348,10 +348,11 @@ def parse_mtl(mtl, resolver=None):
                 # if there is only one value return that
                 if len(value) == 1:
                     value = value[0]
-                # store the key by mapped value
-                material[mapped[key]] = value
-                # also store key by OBJ name
-                material[key] = value
+                if material is not None:
+                    # store the key by mapped value
+                    material[mapped[key]] = value
+                    # also store key by OBJ name
+                    material[key] = value
             except BaseException:
                 log.debug("failed to convert color!", exc_info=True)
         # pass everything as kwargs to material constructor

--- a/trimesh/inertia.py
+++ b/trimesh/inertia.py
@@ -10,10 +10,13 @@ internal consistency.
 
 import numpy as np
 
-from trimesh import util
+from .typed import ArrayLike, NDArray, Number, Optional, float64
+from .util import multi_dot
 
 
-def cylinder_inertia(mass, radius, height, transform=None):
+def cylinder_inertia(
+    mass: Number, radius: Number, height: Number, transform: Optional[ArrayLike] = None
+) -> NDArray[float64]:
     """
     Return the inertia tensor of a cylinder.
 
@@ -49,7 +52,7 @@ def cylinder_inertia(mass, radius, height, transform=None):
     return inertia
 
 
-def sphere_inertia(mass, radius):
+def sphere_inertia(mass: Number, radius: Number) -> NDArray[float64]:
     """
     Return the inertia tensor of a sphere.
 
@@ -65,11 +68,10 @@ def sphere_inertia(mass, radius):
     inertia : (3, 3) float
       Inertia tensor
     """
-    inertia = (2.0 / 5.0) * (radius**2) * mass * np.eye(3)
-    return inertia
+    return (2.0 / 5.0) * (radius**2) * mass * np.eye(3)
 
 
-def principal_axis(inertia):
+def principal_axis(inertia: ArrayLike):
     """
     Find the principal components and principal axis
     of inertia from the inertia tensor.
@@ -103,7 +105,12 @@ def principal_axis(inertia):
     return components, vectors
 
 
-def transform_inertia(transform, inertia_tensor, parallel_axis=False, mass=None):
+def transform_inertia(
+    transform: ArrayLike,
+    inertia_tensor: ArrayLike,
+    parallel_axis: bool = False,
+    mass: Optional[Number] = None,
+):
     """
      Transform an inertia tensor to a new frame.
 
@@ -172,9 +179,9 @@ def transform_inertia(transform, inertia_tensor, parallel_axis=False, mass=None)
         )
         aligned_inertia = inertia_tensor + mass * M
 
-        return util.multi_dot([rotation.T, aligned_inertia, rotation])
+        return multi_dot([rotation.T, aligned_inertia, rotation])
 
-    return util.multi_dot([rotation, inertia_tensor, rotation.T])
+    return multi_dot([rotation, inertia_tensor, rotation.T])
 
 
 def radial_symmetry(mesh):
@@ -250,7 +257,7 @@ def radial_symmetry(mesh):
     return None, None, None
 
 
-def scene_inertia(scene, transform):
+def scene_inertia(scene, transform: Optional[ArrayLike] = None) -> NDArray[float64]:
     """
     Calculate the inertia of a scene about a specific frame.
 
@@ -260,6 +267,11 @@ def scene_inertia(scene, transform):
       Scene with geometry.
     transform : None or (4, 4) float
       Homogeneous transform to compute inertia at.
+
+    Returns
+    ----------
+    moment : (3, 3)
+      Inertia tensor about requested frame
     """
     # shortcuts for tight loop
     graph = scene.graph

--- a/trimesh/interval.py
+++ b/trimesh/interval.py
@@ -95,11 +95,10 @@ def union(intervals: ArrayLike, sort: bool = True) -> NDArray[float64]:
         intervals = intervals[intervals[:, 0].argsort()]
 
     # we know we will have at least one interval
-    unions = [intervals[0]]
+    unions = [intervals[0].tolist()]
 
     for begin, end in intervals[1:]:
         if unions[-1][1] >= begin:
-            #
             unions[-1][1] = max(unions[-1][1], end)
         else:
             unions.append([begin, end])

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -13,7 +13,7 @@ from . import bounds, caching
 from . import transformations as tf
 from .caching import cache_decorator
 from .constants import tol
-from .typed import Dict, Optional
+from .typed import Any, ArrayLike, Dict, Optional
 from .util import ABC
 
 
@@ -40,7 +40,7 @@ class Geometry(ABC):
         pass
 
     @abc.abstractmethod
-    def apply_transform(self, matrix):
+    def apply_transform(self, matrix: ArrayLike) -> Any:
         pass
 
     @property

--- a/trimesh/parent.py
+++ b/trimesh/parent.py
@@ -248,10 +248,9 @@ class Geometry3D(Geometry):
         from . import bounds, primitives
 
         to_origin, extents = bounds.oriented_bounds(self)
-        obb = primitives.Box(
+        return primitives.Box(
             transform=np.linalg.inv(to_origin), extents=extents, mutable=False
         )
-        return obb
 
     @caching.cache_decorator
     def bounding_sphere(self):

--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -359,8 +359,8 @@ def stitch(mesh, faces=None, insert_vertices=False):
 
     Parameters
     -----------
-    vertices : (n, 3) float
-      Vertices in space.
+    mesh : trimesh.Trimesh
+      Mesh to create fan stitch on.
     faces : (n,) int
       Face indexes to stitch with triangle fans.
     insert_vertices : bool

--- a/trimesh/typed.py
+++ b/trimesh/typed.py
@@ -37,6 +37,11 @@ Loadable = Union[str, Path, Stream, Dict, None]
 # these wrappers union numpy integers and python integers
 Integer = Union[int, integer, unsignedinteger]
 
+# Numbers which can only be floats and will not accept integers
+# > isinstance(np.ones(1, dtype=np.float32)[0], floating) # True
+# > isinstance(np.ones(1, dtype=np.float32)[0], float) # False
+Floating = Union[float, floating]
+
 # Many arguments take "any valid number."
 Number = Union[float, floating, Integer]
 


### PR DESCRIPTION
- add some type hints to `trimesh.inertia`
- in `trimesh.base` replace `caching.cache_decorator` with `cache_decorator`. 
- add `mesh.copy(..., include_visual: bool = True)` option to copy meshes skipping the visual data.
- release #2275 
- release #2277
- remove `mesh.as_open3d` immediately and without deprecation as unfortunately it appears to be untested and fully broken in 2024. 
  - This modifies `mesh.simplify_quadric_decimation` to use [pyvista/fast-simplification](https://github.com/pyvista/fast-simplification), which as of testing only requires `numpy` and has `cibuildwheel` set up. I added it to the `recommend` pip extra which most people won't get, and if it works out we might move it up to `easy`.
  - Applies March 2024 deprecation by removing `Trimesh.simplify_quadratic_decimation`
- add FCL back to docker images for tests with a workaround for currently broken PyPi wheels.
- in docker we should no longer have to `force-reinstall` the `[all]` extra since release of https://github.com/imageio/imageio/pull/1098
- updates github actions versions for checkout/cache/setup-python to silence warnings.