### PR TITLE
fix documentation for repair.stitch

### DIFF
--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -359,8 +359,8 @@ def stitch(mesh, faces=None, insert_vertices=False):
 
     Parameters
     -----------
-    vertices : (n, 3) float
-      Vertices in space.
+    mesh : trimesh.Trimesh
+      Mesh to create fan stitch on.
     faces : (n,) int
       Face indexes to stitch with triangle fans.
     insert_vertices : bool


### PR DESCRIPTION
This PR fixes the docstring for trimesh.repair.stitch function, which expects a mesh as input and not an array of vertices.