### PR TITLE
Docs/documentation fixes

### DIFF
--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -73,8 +73,8 @@ When you remove the embed and see the profile result you can then tweak the line
 ### Automatic Formatting
 Trimesh uses `ruff` for both linting and formatting which is configured in `pyproject.toml`, you can run with:
 ```
-ruff . --fix
-ruff format .
+ruff check --fix
+ruff format
 ```
 
 ## Docstrings

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -28,6 +28,9 @@ def oriented_bounds_2D(points, qhull_options="QbB"):
     """
     Find an oriented bounding box for an array of 2D points.
 
+    Details on qhull options:
+      http://www.qhull.org/html/qh-quick.htm#options
+
     Parameters
     ----------
     points : (n,2) float

--- a/trimesh/convex.py
+++ b/trimesh/convex.py
@@ -219,6 +219,9 @@ def hull_points(obj, qhull_options="QbB Pp"):
     """
     Try to extract a convex set of points from multiple input formats.
 
+    Details on qhull options:
+      http://www.qhull.org/html/qh-quick.htm#options
+
     Parameters
     ---------
     obj: Trimesh object

--- a/trimesh/path/repair.py
+++ b/trimesh/path/repair.py
@@ -14,24 +14,13 @@ from . import segments
 
 def fill_gaps(path, distance=0.025):
     """
-    For 3D line segments defined by two points, turn
-    them in to an origin defined as the closest point along
-    the line to the zero origin as well as a direction vector
-    and start and end parameter.
+    Find vertices without degree 2 and try to connect to
+    other vertices. Operations are done in-place.
 
     Parameters
     ------------
-    segments : (n, 2, 3) float
+    segments : trimesh.path.Path2D
        Line segments defined by start and end points
-
-    Returns
-    --------------
-    origins : (n, 3) float
-       Point on line closest to [0, 0, 0]
-    vectors : (n, 3) float
-       Unit line directions
-    parameters : (n, 2) float
-       Start and end distance pairs for each line
     """
 
     # find any vertex without degree 2 (connected to two things)


### PR DESCRIPTION
This PR implements a few small fixes on documentations:
- [docs: fix documentation for path.repair.fill_gaps](https://github.com/mikedh/trimesh/commit/5948baa858149926388ed620a4777fe63dbdf95b) 
- [docs: update ruff commands in contributing guide](https://github.com/mikedh/trimesh/commit/03339d874e7f2d53ad7bfd7fdc942c9c6a9f2e50)
- [docs: add links to qhull options in oriented_bounds_2D and hull_points](https://github.com/mikedh/trimesh/commit/2740d805fb630fc35bec22b42c200c8214c0eaf5)