### PR TITLE
Fix typing bug in merge_vertices function

### DIFF
--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1112,9 +1112,9 @@ class Trimesh(Geometry3D):
         self,
         merge_tex: Optional[bool] = None,
         merge_norm: Optional[bool] = None,
-        digits_vertex: Optional[bool] = None,
-        digits_norm: Optional[bool] = None,
-        digits_uv: Optional[bool] = None,
+        digits_vertex: Optional[int] = None,
+        digits_norm: Optional[int] = None,
+        digits_uv: Optional[int] = None,
     ) -> None:
         """
         Removes duplicate vertices grouped by position and


### PR DESCRIPTION
Small typing bug that got flagged by pyright when my team updated trimesh recently. 

The python typing for a few arguments is `Optional[bool]` when it should be `Optional[int]` based on the type comments and downstream code.