### PR TITLE
add support for path3d export to ply format

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -248,19 +248,71 @@ class ExportTest(g.unittest.TestCase):
         # the scene should be identical after export-> import cycle
         assert g.np.allclose(loaded.extents / source.extents, 1.0)
 
-    def test_ply_path(self):
+    def test_ply_path_empty(self):
         """
-        Should be able to load a path and export it as a PLY
+        Test empty path export does not fail
         """
-        path3D = g.trimesh.load_path([(0, 0, 0), (1, 0, 0), (1, 1, 0)])
+        path3D = g.trimesh.path.Path3D()
+
+        # export to ply
+        ply = path3D.export(file_type="ply")
+        assert len(ply) > 0
+
+        loaded = g.trimesh.load_path(g.trimesh.util.wrap_as_stream(ply), file_type="ply")
+        assert g.np.allclose(loaded.entities, path3D.entities)
+        assert g.np.allclose(loaded.vertices, path3D.vertices)
+
+    def test_ply_path_line(self):
+        """
+        Should be able to load a path and export simple line as a PLY
+        """
+        path3D = g.trimesh.load_path([(0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 1, 1)])
         assert isinstance(path3D, g.trimesh.path.Path3D)
 
-        # export to an ply
+        # export to ply
         ply = path3D.export(file_type="ply")
         assert len(ply) > 0
 
         loaded = g.trimesh.load_path(g.trimesh.util.wrap_as_stream(ply), file_type="ply")
         assert g.np.allclose(loaded.vertices, path3D.vertices)
+
+    def test_ply_path_multi(self):
+        """
+        Should be able to load a path and export multiple entities as a PLY
+        """
+        path3D = g.trimesh.path.Path3D(
+            [
+                g.trimesh.path.entities.Line([0, 1, 2]),
+                g.trimesh.path.entities.Line([2, 0, 1])
+            ],
+            [(0., 0., 0.), (1., 0., 0.), (1., 1., 0.)]
+        )
+
+        # export to ply
+        ply = path3D.export(file_type="ply")
+        assert len(ply) > 0
+
+        loaded = g.trimesh.load_path(g.trimesh.util.wrap_as_stream(ply), file_type="ply")
+        assert len(loaded.entities) == len(path3D.entities)
+        assert len(loaded.vertices) > 0
+
+    def test_ply_path_bezier(self):
+        """
+        Should be able to load a path and export complex curve as a PLY
+        """
+        path3D = g.trimesh.path.Path3D(
+            [g.trimesh.path.entities.Bezier([0, 1, 2])],
+            [(0., 0., 0.), (1., 0., 0.), (1., 1., 0.)]
+        )
+
+        # export to ply
+        ply = path3D.export(file_type="ply")
+        assert len(ply) > 0
+
+        loaded = g.trimesh.load_path(g.trimesh.util.wrap_as_stream(ply), file_type="ply")
+        # note: we cannot recover the exact entities and vertices from the export since it is discretized for ply files
+        assert len(loaded.entities) > 0
+        assert len(loaded.vertices) > 0
 
     def test_gltf_path(self):
         """

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -248,6 +248,20 @@ class ExportTest(g.unittest.TestCase):
         # the scene should be identical after export-> import cycle
         assert g.np.allclose(loaded.extents / source.extents, 1.0)
 
+    def test_ply_path(self):
+        """
+        Should be able to load a path and export it as a PLY
+        """
+        path3D = g.trimesh.load_path([(0, 0, 0), (1, 0, 0), (1, 1, 0)])
+        assert isinstance(path3D, g.trimesh.path.Path3D)
+
+        # export to an ply
+        ply = path3D.export(file_type="ply")
+        assert len(ply) > 0
+
+        loaded = g.trimesh.load_path(g.trimesh.util.wrap_as_stream(ply), file_type="ply")
+        assert g.np.allclose(loaded.vertices, path3D.vertices)
+
     def test_gltf_path(self):
         """
         Check to make sure GLTF exports of Path2D and Path3D

--- a/trimesh/path/exchange/export.py
+++ b/trimesh/path/exchange/export.py
@@ -73,4 +73,9 @@ def _write_export(export, file_obj=None):
     return export
 
 
-_path_exporters = {"dxf": dxf.export_dxf, "svg": svg_io.export_svg, "ply": ply.export_ply, "dict": export_dict}
+_path_exporters = {
+    "dxf": dxf.export_dxf,
+    "svg": svg_io.export_svg,
+    "ply": ply.export_ply,
+    "dict": export_dict,
+}

--- a/trimesh/path/exchange/export.py
+++ b/trimesh/path/exchange/export.py
@@ -1,7 +1,7 @@
 import os
 
 from ... import util
-from . import dxf, svg_io, ply
+from . import dxf, ply, svg_io
 
 
 def export_path(path, file_type=None, file_obj=None, **kwargs):

--- a/trimesh/path/exchange/export.py
+++ b/trimesh/path/exchange/export.py
@@ -1,7 +1,7 @@
 import os
 
 from ... import util
-from . import dxf, svg_io
+from . import dxf, svg_io, ply
 
 
 def export_path(path, file_type=None, file_obj=None, **kwargs):
@@ -73,4 +73,4 @@ def _write_export(export, file_obj=None):
     return export
 
 
-_path_exporters = {"dxf": dxf.export_dxf, "svg": svg_io.export_svg, "dict": export_dict}
+_path_exporters = {"dxf": dxf.export_dxf, "svg": svg_io.export_svg, "ply": ply.export_ply, "dict": export_dict}

--- a/trimesh/path/exchange/load.py
+++ b/trimesh/path/exchange/load.py
@@ -5,6 +5,7 @@ from ..path import Path
 from . import misc
 from .dxf import _dxf_loaders
 from .svg_io import svg_to_path
+from .ply import load_ply
 
 
 def load_path(file_obj, file_type=None, **kwargs):
@@ -42,14 +43,22 @@ def load_path(file_obj, file_type=None, **kwargs):
         return file_obj
     elif util.is_file(file_obj):
         # for open file file_objects use loaders
-        kwargs.update(path_loaders[file_type](file_obj, file_type=file_type))
+        if file_type == "ply":
+            # we cannot register this exporter to path_loaders since this is already reserved by TriMesh in ply format in trimesh.load()
+            kwargs.update(load_ply(file_obj, file_type=file_type))
+        else:
+            kwargs.update(path_loaders[file_type](file_obj, file_type=file_type))
     elif util.is_string(file_obj):
         # strings passed are evaluated as file file_objects
         with open(file_obj, "rb") as f:
             # get the file type from the extension
             file_type = os.path.splitext(file_obj)[-1][1:].lower()
-            # call the loader
-            kwargs.update(path_loaders[file_type](f, file_type=file_type))
+            if file_type == "ply":
+                # we cannot register this exporter to path_loaders since this is already reserved by TriMesh in ply format in trimesh.load()
+                kwargs.update(load_ply(f, file_type=file_type))
+            else:
+                # call the loader
+                kwargs.update(path_loaders[file_type](f, file_type=file_type))
     elif util.is_instance_named(file_obj, ["Polygon", "MultiPolygon"]):
         # convert from shapely polygons to Path2D
         kwargs.update(misc.polygon_to_path(file_obj))

--- a/trimesh/path/exchange/load.py
+++ b/trimesh/path/exchange/load.py
@@ -4,8 +4,8 @@ from ... import util
 from ..path import Path
 from . import misc
 from .dxf import _dxf_loaders
-from .svg_io import svg_to_path
 from .ply import load_ply
+from .svg_io import svg_to_path
 
 
 def load_path(file_obj, file_type=None, **kwargs):

--- a/trimesh/path/exchange/ply.py
+++ b/trimesh/path/exchange/ply.py
@@ -1,0 +1,134 @@
+import numpy as np
+from string import Template
+from ... import resources, util
+from ...exchange.ply import _parse_header, _ply_binary, _ply_ascii, _elements_to_kwargs
+from ...typed import Optional, Dict
+from ..entities import Line
+from .misc import edges_to_path
+
+
+def export_ply(
+        path: "Path3D",
+        encoding: Optional[str] = "binary",
+) -> bytes:
+    """
+    Export a path in the PLY format.
+
+    Parameters
+    -----------
+    path: path to export
+    encoding: PLY encoding: 'ascii' or 'binary_little_endian'
+
+    Returns
+    -----------
+    export: bytes of result
+    """
+    # evaluate input args
+    # allow a shortcut for binary
+    if encoding == "binary":
+        encoding = "binary_little_endian"
+    elif encoding not in ["binary_little_endian", "ascii"]:
+        raise ValueError("encoding must be binary or ascii")
+
+    if path.vertices.shape[-1] != 3:
+        raise ValueError("only Path3D export is supported to ply")
+
+    # custom numpy dtypes for exporting
+    dtype_edge = [("index", "<i4", (2))]
+    dtype_vertex = [("vertex", "<f4", (3))]
+
+    # get template strings in dict
+    templates = resources.get_json("templates/ply.json")
+    templates["edge"] = "element edge $edge_count\nproperty int vertex1\nproperty int vertex2\n"
+    # start collecting elements into a string for the header
+    header = [templates["intro"]]
+
+    # check if scene has geometry
+    if hasattr(path, "vertices"):
+        header.append(templates["vertex"])
+        num_vertices = len(path.vertices)
+
+        # create and populate the custom dtype for vertices
+        vertex = np.zeros(num_vertices, dtype=dtype_vertex)
+        vertex["vertex"] = path.vertices.astype(np.float32)
+    else:
+        num_vertices = 0
+
+    header_params = {"vertex_count": num_vertices, "encoding": encoding}
+
+    if hasattr(path, "entities"):
+        header.append(templates["edge"])
+
+        entities = []
+        for e in path.entities:
+            if isinstance(e, Line):
+                for pp in range(len(e.points) - 1):
+                    entities.append((e.points[pp], e.points[pp + 1]))
+            else:
+                raise NotImplementedError(f"type {type(e)} not supported as entities")
+
+        # put mesh edge data into custom dtype to export
+        edges = np.zeros(len(entities), dtype=dtype_edge)
+        edges["index"] = np.asarray(entities, dtype=np.int32)
+        header_params["edge_count"] = len(entities)
+
+    header.append(templates["outro"])
+    export = [Template("".join(header)).substitute(header_params).encode("utf-8")]
+
+    if encoding == "binary_little_endian":
+        if hasattr(path, "vertices"):
+            export.append(vertex.tobytes())
+        if hasattr(path, "entities"):
+            export.append(edges.tobytes())
+    elif encoding == "ascii":
+        export.append(
+            util.structured_array_to_string(vertex, col_delim=" ", row_delim="\n").encode("utf-8"), )
+
+        if hasattr(path, "entities"):
+            export.extend([
+                b"\n",
+                util.structured_array_to_string(edges, col_delim=" ", row_delim="\n").encode("utf-8"),
+            ])
+        export.append(b"\n")
+    else:
+        raise ValueError("encoding must be ascii or binary!")
+
+    return b"".join(export)
+
+
+def load_ply(file_obj, **kwargs) -> Dict:
+    """
+    Load a PLY file to a dictionary containing vertices and entities
+
+    Parameters
+    -----------
+    file_obj: file or file-like object (has object.read method)
+
+    Returns
+    -----------
+    result: keys are entities, vertices and metadata
+    """
+
+    # OrderedDict which is populated from the header
+    elements, is_ascii, image_name = _parse_header(file_obj)
+
+    # functions will fill in elements from file_obj
+    if is_ascii:
+        _ply_ascii(elements, file_obj)
+    else:
+        _ply_binary(elements, file_obj)
+
+    # translate loaded PLY elements to kwargs
+    kwargs = _elements_to_kwargs(image=None, elements=elements, fix_texture=False)
+
+    try:
+        v1 = kwargs["metadata"]["_ply_raw"]["edge"]["data"]["vertex1"]
+        v2 = kwargs["metadata"]["_ply_raw"]["edge"]["data"]["vertex2"]
+        result = edges_to_path([v1, v2], kwargs["vertices"])
+    except KeyError:
+        raise ValueError("Could not load entities!")
+
+    # return result as kwargs for Path2D constructor
+    result.update({"metadata": {}})
+
+    return result

--- a/trimesh/path/exchange/ply.py
+++ b/trimesh/path/exchange/ply.py
@@ -8,8 +8,8 @@ from .misc import edges_to_path
 
 
 def export_ply(
-        path: "Path3D",
-        encoding: Optional[str] = "binary",
+    path: "Path3D",
+    encoding: Optional[str] = "binary",
 ) -> bytes:
     """
     Export a path in the PLY format.
@@ -39,7 +39,9 @@ def export_ply(
 
     # get template strings in dict
     templates = resources.get_json("templates/ply.json")
-    templates["edge"] = "element edge $edge_count\nproperty int vertex1\nproperty int vertex2\n"
+    templates["edge"] = (
+        "element edge $edge_count\nproperty int vertex1\nproperty int vertex2\n"
+    )
     # start collecting elements into a string for the header
     header = [templates["intro"]]
 
@@ -82,13 +84,20 @@ def export_ply(
             export.append(edges.tobytes())
     elif encoding == "ascii":
         export.append(
-            util.structured_array_to_string(vertex, col_delim=" ", row_delim="\n").encode("utf-8"), )
+            util.structured_array_to_string(vertex, col_delim=" ", row_delim="\n").encode(
+                "utf-8"
+            ),
+        )
 
         if hasattr(path, "entities"):
-            export.extend([
-                b"\n",
-                util.structured_array_to_string(edges, col_delim=" ", row_delim="\n").encode("utf-8"),
-            ])
+            export.extend(
+                [
+                    b"\n",
+                    util.structured_array_to_string(
+                        edges, col_delim=" ", row_delim="\n"
+                    ).encode("utf-8"),
+                ]
+            )
         export.append(b"\n")
     else:
         raise ValueError("encoding must be ascii or binary!")


### PR DESCRIPTION
This PR adds support to export `Path3D` object into the `PLY` format. This can be used to visualize the `Path3D` objects in common 3D mesh viewers, such as MeshLab. These are shown as line stripes, as shown below.
This PR contains:
- add export and import capabilities for `PLY` format that uses the `edge` property of the `PLY` format
- add basic unittest that saves and loads a simple `Path3D`

![Screenshot from 2024-09-06 16-01-43](https://github.com/user-attachments/assets/2b05cadb-69b6-4e6b-8bed-3fb40a1d7d45)
