### PR TITLE
fix for #2269 with new test case for incomplete creation.revolve()

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -312,6 +312,22 @@ class CreationTest(g.unittest.TestCase):
         assert all(s.volume > 0 for s in split)
 
 
+    def test_revolve(self):
+        # create a cross section and revolve it to form some volumes
+        cross_section = [[0, 0], [10, 0], [10, 10], [0, 10]]
+
+        # high sections needed so volume is close to theoretical value for perfect revoulution
+        mesh360 = g.trimesh.creation.revolve(cross_section, 2 * g.np.pi, sections=360)
+        mesh360_volume = g.np.pi * 10**2 * 10
+        assert g.np.isclose(mesh360.volume, mesh360_volume, rtol=.1)
+        assert mesh360.is_volume, "mesh360 should be a valid volume"
+
+        mesh180 = g.trimesh.creation.revolve(cross_section, g.np.pi, sections=180, cap=True)
+        assert g.np.isclose(mesh180.volume, mesh360.volume/2, rtol=.1), \
+            "mesh180 should be half of mesh360 volume"
+        assert mesh180.is_volume, "mesh180 should be a valid volume"
+
+
 def check_triangulation(v, f, true_area):
     assert g.trimesh.util.is_shape(v, (-1, 2))
     assert v.dtype.kind == "f"
@@ -339,7 +355,6 @@ def test_torus():
     )
     assert g.np.allclose(m.extents, extents)
     assert g.np.allclose(m.bounds, [-extents / 2.0, extents / 2.0])
-
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()


### PR DESCRIPTION
Added a cap: bool parameter to creation.revolve(...) and implement additional logic to add end cap faces to an incomplete revolution so that the resultant mesh is a valid volume.