### PR TITLE
Convert to numpy array if need

### DIFF
--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -83,8 +83,10 @@ def normals(triangles=None, crosses=None):
     valid : (n,) bool
       Was the face nonzero area or not
     """
-    if triangles is not None and triangles.shape[-1] == 2:
-        return np.tile([0.0, 0.0, 1.0], (triangles.shape[0], 1))
+    if triangles is not None:
+        triangles = np.asanyarray(triangles, dtype=np.float64)
+        if triangles.shape[-1] == 2:
+            return np.tile([0.0, 0.0, 1.0], (triangles.shape[0], 1))
     if crosses is None:
         crosses = cross(triangles)
     # unitize the cross product vectors


### PR DESCRIPTION
Due to commit https://github.com/mikedh/trimesh/commit/7f2aa95f6732fe32b91597394675ec6cc0197725 related to issue https://github.com/mikedh/trimesh/pull/2257, the function `normals` does not accept containers such as lists for the parameter `triangles` anymore. This was possible before due to the call of `cross` which itself could handle that.