### PR TITLE
Fix missing visual copy for primitives

### DIFF
--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -114,7 +114,7 @@ class Primitive(Trimesh):
         """
         raise NotImplementedError()
 
-    def copy(self, **kwargs):
+    def copy(self, include_visual=True, **kwargs):
         """
         Return a copy of the Primitive object.
 
@@ -129,6 +129,11 @@ class Primitive(Trimesh):
         kwargs.pop("kind")
         # create a new object with kwargs
         primitive_copy = type(self)(**kwargs)
+
+        if include_visual:
+            # copy visual information
+            primitive_copy.visual = self.visual.copy()
+        
         # copy metadata
         primitive_copy.metadata = self.metadata.copy()
 

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -133,7 +133,7 @@ class Primitive(Trimesh):
         if include_visual:
             # copy visual information
             primitive_copy.visual = self.visual.copy()
-        
+
         # copy metadata
         primitive_copy.metadata = self.metadata.copy()
 


### PR DESCRIPTION
This fixes the following problem:
```
import trimesh
b = trimesh.primitives.Box()
b.visual.face_colors[:] = [0, 0, 255, 255]

assert b.visual.defined == b.copy().visual.defined
```
This in turn affects `dump` and `export`.

I added `include_visual` as a parameter just to be consistent with `base.py::Trimesh::copy`.