### PR TITLE
Make boolean engine selection more flexible

### DIFF
--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -140,14 +140,12 @@ def test_reduce_cascade():
     # the multiply will explode quickly past the integer maximum
     from functools import reduce
 
-    from trimesh.interfaces import manifold
-
     def both(operation, items):
         """
         Run our cascaded reduce and regular reduce.
         """
 
-        b = manifold.reduce_cascade(operation, items)
+        b = g.trimesh.boolean.reduce_cascade(operation, items)
 
         if len(items) > 0:
             assert b == reduce(operation, items)

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -4,10 +4,10 @@ boolean.py
 
 Do boolean operations on meshes using either Blender or Manifold.
 """
-import numpy as np
 
-from . import interfaces
-from .typed import Callable, NDArray, Optional, Sequence, Union
+# for dynamic module imports
+from importlib import import_module
+from .typed import Optional, Sequence
 
 
 def difference(
@@ -99,92 +99,24 @@ def intersection(
     return _engines[engine](meshes, operation="intersection", **kwargs)
 
 
-def reduce_cascade(operation: Callable, items: Union[Sequence, NDArray]):
-    """
-    Call an operation function in a cascaded pairwise way against a
-    flat list of items.
-
-    This should produce the same result as `functools.reduce`
-    if `operation` is commutable like addition or multiplication.
-    This may be faster for an `operation` that runs with a speed
-    proportional to its largest input, which mesh booleans appear to.
-
-    The union of a large number of small meshes appears to be
-    "much faster" using this method.
-
-    This only differs from `functools.reduce` for commutative `operation`
-    in that it returns `None` on empty inputs rather than `functools.reduce`
-    which raises a `TypeError`.
-
-    For example on `a b c d e f g` this function would run and return:
-        a b
-        c d
-        e f
-        ab cd
-        ef g
-        abcd efg
-     -> abcdefg
-
-    Where `functools.reduce` would run and return:
-        a b
-        ab c
-        abc d
-        abcd e
-        abcde f
-        abcdef g
-     -> abcdefg
-
-    Parameters
-    ----------
-    operation
-      The function to call on pairs of items.
-    items
-      The flat list of items to apply operation against.
-    """
-    if len(items) == 0:
-        return None
-    elif len(items) == 1:
-        # skip the loop overhead for a single item
-        return items[0]
-    elif len(items) == 2:
-        # skip the loop overhead for a single pair
-        return operation(items[0], items[1])
-
-    for _ in range(int(1 + np.log2(len(items)))):
-        results = []
-        for i in np.arange(len(items) // 2) * 2:
-            results.append(operation(items[i], items[i + 1]))
-
-        if len(items) % 2:
-            results.append(items[-1])
-
-        items = results
-
-    # logic should have reduced to a single item
-    assert len(results) == 1
-
-    return results[0]
-
-
 # supported backend boolean engines
-# preferred engines are at the top
-_backends = [
-    interfaces.manifold,
-    interfaces.blender,
+# ordered by preference
+all_engines = [
+    "manifold",
+    "blender",
 ]
 
 # test which engines are actually usable
 _engines = {}
-available_engines = ()
-all_engines = ()
-for e in _backends:
-    all_engines = all_engines + e.name
-    if e.exists:
-        _engines[e.name] = e.boolean
-        available_engines = available_engines + e.name
+available_engines = []
+for name in all_engines:
+    engine = import_module("trimesh.interfaces." + name)
+    if engine.exists:
+        _engines[name] = engine.boolean
+        available_engines.append(name)
         if None not in _engines:
             # pick the first available engine as the default
-            _engines[None] = e.boolean
+            _engines[None] = engine.boolean
 
 def set_default_engine(engine):
     if engine not in available_engines:

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -121,4 +121,4 @@ for name in all_engines:
 def set_default_engine(engine):
     if engine not in available_engines:
         raise ValueError(f"Engine {engine} is not available on this system")
-    _engines[None] = available_engines[engine].boolean
+    _engines[None] = _engines[engine]

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -4,8 +4,10 @@ boolean.py
 
 Do boolean operations on meshes using either Blender or Manifold.
 """
+import numpy as np
+
 from . import interfaces
-from .typed import Optional, Sequence
+from .typed import Callable, NDArray, Optional, Sequence, Union
 
 
 def difference(
@@ -95,6 +97,73 @@ def intersection(
     if check_volume and not all(m.is_volume for m in meshes):
         raise ValueError("Not all meshes are volumes!")
     return _engines[engine](meshes, operation="intersection", **kwargs)
+
+
+def reduce_cascade(operation: Callable, items: Union[Sequence, NDArray]):
+    """
+    Call an operation function in a cascaded pairwise way against a
+    flat list of items.
+
+    This should produce the same result as `functools.reduce`
+    if `operation` is commutable like addition or multiplication.
+    This may be faster for an `operation` that runs with a speed
+    proportional to its largest input, which mesh booleans appear to.
+
+    The union of a large number of small meshes appears to be
+    "much faster" using this method.
+
+    This only differs from `functools.reduce` for commutative `operation`
+    in that it returns `None` on empty inputs rather than `functools.reduce`
+    which raises a `TypeError`.
+
+    For example on `a b c d e f g` this function would run and return:
+        a b
+        c d
+        e f
+        ab cd
+        ef g
+        abcd efg
+     -> abcdefg
+
+    Where `functools.reduce` would run and return:
+        a b
+        ab c
+        abc d
+        abcd e
+        abcde f
+        abcdef g
+     -> abcdefg
+
+    Parameters
+    ----------
+    operation
+      The function to call on pairs of items.
+    items
+      The flat list of items to apply operation against.
+    """
+    if len(items) == 0:
+        return None
+    elif len(items) == 1:
+        # skip the loop overhead for a single item
+        return items[0]
+    elif len(items) == 2:
+        # skip the loop overhead for a single pair
+        return operation(items[0], items[1])
+
+    for _ in range(int(1 + np.log2(len(items)))):
+        results = []
+        for i in np.arange(len(items) // 2) * 2:
+            results.append(operation(items[i], items[i + 1]))
+
+        if len(items) % 2:
+            results.append(items[-1])
+
+        items = results
+
+    # logic should have reduced to a single item
+    assert len(results) == 1
+
+    return results[0]
 
 
 # supported backend boolean engines

--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -4,17 +4,8 @@ boolean.py
 
 Do boolean operations on meshes using either Blender or Manifold.
 """
-
-import numpy as np
-
-from . import exceptions, interfaces
-from .typed import Callable, NDArray, Optional, Sequence, Union
-
-try:
-    from manifold3d import Manifold, Mesh
-except BaseException as E:
-    Mesh = exceptions.ExceptionWrapper(E)
-    Manifold = exceptions.ExceptionWrapper(E)
+from . import interfaces
+from .typed import Optional, Sequence
 
 
 def difference(
@@ -106,138 +97,27 @@ def intersection(
     return _engines[engine](meshes, operation="intersection", **kwargs)
 
 
-def boolean_manifold(
-    meshes: Sequence,
-    operation: str,
-    check_volume: bool = True,
-    **kwargs,
-):
-    """
-    Run an operation on a set of meshes using the Manifold engine.
+# supported backend boolean engines
+# preferred engines are at the top
+_backends = [
+    interfaces.manifold,
+    interfaces.blender,
+]
 
-    Parameters
-    ----------
-    meshes : list of trimesh.Trimesh
-      Meshes to be processed
-    operation
-      Which boolean operation to do.
-    check_volume
-      Raise an error if not all meshes are watertight
-      positive volumes. Advanced users may want to ignore
-      this check as it is expensive.
-    kwargs
-      Passed through to the `engine`.
-    """
-    if check_volume and not all(m.is_volume for m in meshes):
-        raise ValueError("Not all meshes are volumes!")
+# test which engines are actually usable
+_engines = {}
+available_engines = ()
+all_engines = ()
+for e in _backends:
+    all_engines = all_engines + e.name
+    if e.exists:
+        _engines[e.name] = e.boolean
+        available_engines = available_engines + e.name
+        if None not in _engines:
+            # pick the first available engine as the default
+            _engines[None] = e.boolean
 
-    # Convert to manifold meshes
-    manifolds = [
-        Manifold(
-            mesh=Mesh(
-                vert_properties=np.array(mesh.vertices, dtype=np.float32),
-                tri_verts=np.array(mesh.faces, dtype=np.uint32),
-            )
-        )
-        for mesh in meshes
-    ]
-
-    # Perform operations
-    if operation == "difference":
-        if len(meshes) < 2:
-            raise ValueError("Difference only defined over two meshes.")
-        elif len(meshes) == 2:
-            # apply the single difference
-            result_manifold = manifolds[0] - manifolds[1]
-        elif len(meshes) > 2:
-            # union all the meshes to be subtracted from the final result
-            unioned = reduce_cascade(lambda a, b: a + b, manifolds[1:])
-            # apply the difference
-            result_manifold = manifolds[0] - unioned
-    elif operation == "union":
-        result_manifold = reduce_cascade(lambda a, b: a + b, manifolds)
-    elif operation == "intersection":
-        result_manifold = reduce_cascade(lambda a, b: a ^ b, manifolds)
-    else:
-        raise ValueError(f"Invalid boolean operation: '{operation}'")
-
-    # Convert back to trimesh meshes
-    from . import Trimesh
-
-    result_mesh = result_manifold.to_mesh()
-    return Trimesh(vertices=result_mesh.vert_properties, faces=result_mesh.tri_verts)
-
-
-def reduce_cascade(operation: Callable, items: Union[Sequence, NDArray]):
-    """
-    Call an operation function in a cascaded pairwise way against a
-    flat list of items.
-
-    This should produce the same result as `functools.reduce`
-    if `operation` is commutable like addition or multiplication.
-    This may be faster for an `operation` that runs with a speed
-    proportional to its largest input, which mesh booleans appear to.
-
-    The union of a large number of small meshes appears to be
-    "much faster" using this method.
-
-    This only differs from `functools.reduce` for commutative `operation`
-    in that it returns `None` on empty inputs rather than `functools.reduce`
-    which raises a `TypeError`.
-
-    For example on `a b c d e f g` this function would run and return:
-        a b
-        c d
-        e f
-        ab cd
-        ef g
-        abcd efg
-     -> abcdefg
-
-    Where `functools.reduce` would run and return:
-        a b
-        ab c
-        abc d
-        abcd e
-        abcde f
-        abcdef g
-     -> abcdefg
-
-    Parameters
-    ----------
-    operation
-      The function to call on pairs of items.
-    items
-      The flat list of items to apply operation against.
-    """
-    if len(items) == 0:
-        return None
-    elif len(items) == 1:
-        # skip the loop overhead for a single item
-        return items[0]
-    elif len(items) == 2:
-        # skip the loop overhead for a single pair
-        return operation(items[0], items[1])
-
-    for _ in range(int(1 + np.log2(len(items)))):
-        results = []
-        for i in np.arange(len(items) // 2) * 2:
-            results.append(operation(items[i], items[i + 1]))
-
-        if len(items) % 2:
-            results.append(items[-1])
-
-        items = results
-
-    # logic should have reduced to a single item
-    assert len(results) == 1
-
-    return results[0]
-
-
-# which backend boolean engines
-_engines = {
-    None: boolean_manifold,
-    "manifold": boolean_manifold,
-    "blender": interfaces.blender.boolean,
-}
+def set_default_engine(engine):
+    if engine not in available_engines:
+        raise ValueError(f"Engine {engine} is not available on this system")
+    _engines[None] = available_engines[engine].boolean

--- a/trimesh/interfaces/__init__.py
+++ b/trimesh/interfaces/__init__.py
@@ -1,4 +1,4 @@
 from . import blender, gmsh
 
 # add to __all__ as per pep8
-__all__ = ["blender", "gmsh"]
+__all__ = ["blender", "gmsh", "manifold"]

--- a/trimesh/interfaces/__init__.py
+++ b/trimesh/interfaces/__init__.py
@@ -1,4 +1,4 @@
 from . import blender, gmsh
 
 # add to __all__ as per pep8
-__all__ = ["blender", "gmsh", "manifold"]
+__all__ = ["gmsh"]

--- a/trimesh/interfaces/blender.py
+++ b/trimesh/interfaces/blender.py
@@ -6,6 +6,8 @@ from ..constants import log
 from ..typed import Iterable
 from .generic import MeshScript
 
+name = "blender"
+
 if platform.system() == "Windows":
     # try to find Blender install on Windows
     # split existing path by delimiter

--- a/trimesh/interfaces/blender.py
+++ b/trimesh/interfaces/blender.py
@@ -6,8 +6,6 @@ from ..constants import log
 from ..typed import Iterable
 from .generic import MeshScript
 
-name = "blender"
-
 if platform.system() == "Windows":
     # try to find Blender install on Windows
     # split existing path by delimiter

--- a/trimesh/interfaces/manifold.py
+++ b/trimesh/interfaces/manifold.py
@@ -1,10 +1,9 @@
 import numpy as np
 
 from .. import exceptions
-from ..boolean import reduce_cascade
 from ..typed import Sequence
+from ..util import reduce_cascade
 
-name = "manifold"
 exists = False
 
 try:

--- a/trimesh/interfaces/manifold.py
+++ b/trimesh/interfaces/manifold.py
@@ -1,0 +1,143 @@
+import numpy as np
+
+from .. import exceptions
+from ..typed import Callable, NDArray, Sequence, Union
+
+name = "manifold"
+exists = False
+
+try:
+    from manifold3d import Manifold, Mesh
+    exists = True
+except BaseException as E:
+    Mesh = exceptions.ExceptionWrapper(E)
+    Manifold = exceptions.ExceptionWrapper(E)
+
+
+def boolean(
+    meshes: Sequence,
+    operation: str,
+    check_volume: bool = True,
+    **kwargs,
+):
+    """
+    Run an operation on a set of meshes using the Manifold engine.
+
+    Parameters
+    ----------
+    meshes : list of trimesh.Trimesh
+      Meshes to be processed
+    operation
+      Which boolean operation to do.
+    check_volume
+      Raise an error if not all meshes are watertight
+      positive volumes. Advanced users may want to ignore
+      this check as it is expensive.
+    kwargs
+      Passed through to the `engine`.
+    """
+    if check_volume and not all(m.is_volume for m in meshes):
+        raise ValueError("Not all meshes are volumes!")
+
+    # Convert to manifold meshes
+    manifolds = [
+        Manifold(
+            mesh=Mesh(
+                vert_properties=np.array(mesh.vertices, dtype=np.float32),
+                tri_verts=np.array(mesh.faces, dtype=np.uint32),
+            )
+        )
+        for mesh in meshes
+    ]
+
+    # Perform operations
+    if operation == "difference":
+        if len(meshes) < 2:
+            raise ValueError("Difference only defined over two meshes.")
+        elif len(meshes) == 2:
+            # apply the single difference
+            result_manifold = manifolds[0] - manifolds[1]
+        elif len(meshes) > 2:
+            # union all the meshes to be subtracted from the final result
+            unioned = reduce_cascade(lambda a, b: a + b, manifolds[1:])
+            # apply the difference
+            result_manifold = manifolds[0] - unioned
+    elif operation == "union":
+        result_manifold = reduce_cascade(lambda a, b: a + b, manifolds)
+    elif operation == "intersection":
+        result_manifold = reduce_cascade(lambda a, b: a ^ b, manifolds)
+    else:
+        raise ValueError(f"Invalid boolean operation: '{operation}'")
+
+    # Convert back to trimesh meshes
+    from .. import Trimesh
+
+    result_mesh = result_manifold.to_mesh()
+    return Trimesh(vertices=result_mesh.vert_properties, faces=result_mesh.tri_verts)
+
+
+def reduce_cascade(operation: Callable, items: Union[Sequence, NDArray]):
+    """
+    Call an operation function in a cascaded pairwise way against a
+    flat list of items.
+
+    This should produce the same result as `functools.reduce`
+    if `operation` is commutable like addition or multiplication.
+    This may be faster for an `operation` that runs with a speed
+    proportional to its largest input, which mesh booleans appear to.
+
+    The union of a large number of small meshes appears to be
+    "much faster" using this method.
+
+    This only differs from `functools.reduce` for commutative `operation`
+    in that it returns `None` on empty inputs rather than `functools.reduce`
+    which raises a `TypeError`.
+
+    For example on `a b c d e f g` this function would run and return:
+        a b
+        c d
+        e f
+        ab cd
+        ef g
+        abcd efg
+     -> abcdefg
+
+    Where `functools.reduce` would run and return:
+        a b
+        ab c
+        abc d
+        abcd e
+        abcde f
+        abcdef g
+     -> abcdefg
+
+    Parameters
+    ----------
+    operation
+      The function to call on pairs of items.
+    items
+      The flat list of items to apply operation against.
+    """
+    if len(items) == 0:
+        return None
+    elif len(items) == 1:
+        # skip the loop overhead for a single item
+        return items[0]
+    elif len(items) == 2:
+        # skip the loop overhead for a single pair
+        return operation(items[0], items[1])
+
+    for _ in range(int(1 + np.log2(len(items)))):
+        results = []
+        for i in np.arange(len(items) // 2) * 2:
+            results.append(operation(items[i], items[i + 1]))
+
+        if len(items) % 2:
+            results.append(items[-1])
+
+        items = results
+
+    # logic should have reduced to a single item
+    assert len(results) == 1
+
+    return results[0]

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -3,7 +3,7 @@ from shapely import ops
 from shapely.geometry import Polygon
 
 from .. import bounds, geometry, graph, grouping
-from ..boolean import reduce_cascade
+from ..util import reduce_cascade
 from ..constants import log
 from ..constants import tol_path as tol
 from ..transformations import transform_points

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -23,7 +23,7 @@ from io import BytesIO, StringIO
 import numpy as np
 
 # use our wrapped types for wider version compatibility
-from .typed import Any, Iterable, List, Union
+from .typed import Any, Iterable, List, Union, Callable, NDArray, Optional, Sequence
 
 # create a default logger
 log = logging.getLogger("trimesh")
@@ -2473,3 +2473,70 @@ def unique_name(start, contains, counts=None):
     # this should really never happen since we looped
     # through the full length of contains
     raise ValueError("Unable to establish unique name!")
+
+
+def reduce_cascade(operation: Callable, items: Union[Sequence, NDArray]):
+    """
+    Call an operation function in a cascaded pairwise way against a
+    flat list of items.
+
+    This should produce the same result as `functools.reduce`
+    if `operation` is commutable like addition or multiplication.
+    This may be faster for an `operation` that runs with a speed
+    proportional to its largest input, which mesh booleans appear to.
+
+    The union of a large number of small meshes appears to be
+    "much faster" using this method.
+
+    This only differs from `functools.reduce` for commutative `operation`
+    in that it returns `None` on empty inputs rather than `functools.reduce`
+    which raises a `TypeError`.
+
+    For example on `a b c d e f g` this function would run and return:
+        a b
+        c d
+        e f
+        ab cd
+        ef g
+        abcd efg
+     -> abcdefg
+
+    Where `functools.reduce` would run and return:
+        a b
+        ab c
+        abc d
+        abcd e
+        abcde f
+        abcdef g
+     -> abcdefg
+
+    Parameters
+    ----------
+    operation
+      The function to call on pairs of items.
+    items
+      The flat list of items to apply operation against.
+    """
+    if len(items) == 0:
+        return None
+    elif len(items) == 1:
+        # skip the loop overhead for a single item
+        return items[0]
+    elif len(items) == 2:
+        # skip the loop overhead for a single pair
+        return operation(items[0], items[1])
+
+    for _ in range(int(1 + np.log2(len(items)))):
+        results = []
+        for i in np.arange(len(items) // 2) * 2:
+            results.append(operation(items[i], items[i + 1]))
+
+        if len(items) % 2:
+            results.append(items[-1])
+
+        items = results
+
+    # logic should have reduced to a single item
+    assert len(results) == 1
+
+    return results[0]


### PR DESCRIPTION
Closes: #2306 

As announced, here's a patch that refactors the boolean engine autodetection.

I had to refactor a few things to make the two engines behave the same way and avoid circular imports.

`reduce_cascade` is now in `util.py`. I assumed that this is needed in other places, so I didn't move it into the new interfaces.manifold module.

`interfaces.blender` and `interfaces.manifold` are now dynamic imports. This avoids a circular import loop and allows autodetection at load time.