### PR TITLE
Fix vertex_attributes subdivisions and corresponding test added.

### DIFF
--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -88,7 +88,7 @@ class SubDivideTest(g.unittest.TestCase):
         for m in meshes:
             # set vertex positions as attributes for trivial check after subdivision
             m.vertex_attributes = {"pos": m.vertices}
-            
+
             s = m.subdivide(face_index=[0, len(m.faces) - 1])
             # shouldn't have subdivided in-place
             assert len(s.faces) > len(m.faces)

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -86,6 +86,9 @@ class SubDivideTest(g.unittest.TestCase):
         meshes = [g.trimesh.creation.box(), g.trimesh.creation.icosphere()]
 
         for m in meshes:
+            # set vertex positions as attributes for trivial check after subdivision
+            m.vertex_attributes = {"pos": m.vertices}
+            
             s = m.subdivide(face_index=[0, len(m.faces) - 1])
             # shouldn't have subdivided in-place
             assert len(s.faces) > len(m.faces)
@@ -93,6 +96,8 @@ class SubDivideTest(g.unittest.TestCase):
             assert g.np.isclose(m.area, s.area)
             # volume should be the same
             assert g.np.isclose(m.volume, s.volume)
+            # position attributes and actual vertices should be the same
+            assert g.np.allclose(s.vertex_attributes["pos"], s.vertices)
 
             max_edge = m.scale / 50
             s = m.subdivide_to_size(max_edge=max_edge)

--- a/trimesh/remesh.py
+++ b/trimesh/remesh.py
@@ -90,11 +90,7 @@ def subdivide(
     if vertex_attributes is not None:
         new_attributes = {}
         for key, values in vertex_attributes.items():
-            attr_tris = values[faces_subset]
-            attr_mid = np.vstack(
-                [attr_tris[:, g, :].mean(axis=1) for g in [[0, 1], [1, 2], [2, 0]]]
-            )
-            attr_mid = attr_mid[unique]
+            attr_mid = values[edges[unique]].mean(axis=1)
             new_attributes[key] = np.vstack((values, attr_mid))
         return new_vertices, new_faces, new_attributes
 


### PR DESCRIPTION
Hey Mike,

I think in the simple subdivision routine, the _vertex attribute_ computation somehow got a bit jumbled.
There is some linear triangle-edge interpolation going on - but the new attributes do not match the values that I would have expected.

Thus, I have simplified the per-edge attribute interpolation to be analog to the actual subdiv-vertex position computation and added a testcase to verify.

Cheers
Dennis