### PR TITLE
Also add map_Kd to the OBJ/MTL material kwargs

### DIFF
--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -338,6 +338,8 @@ def parse_mtl(mtl, resolver=None):
                 # load the bytes into a PIL image
                 # an image file name
                 material["image"] = Image.open(util.wrap_as_stream(file_data))
+                # also store the original map_kd file name
+                material[key] = file_name
             except BaseException:
                 log.debug("failed to load image", exc_info=True)
 


### PR DESCRIPTION
While all the other key/values for the MTL material are provided directly on top of Trimesh's interpretation for SimpleMaterial, then accessible through material.kwargs which is useful for custom handling of the materials, map_Kd isn't. I've had a need for getting the map_Kd file path directly instead of the already loaded PIL.Image.