### PR TITLE
[BUG] fix rounding issue in uv_to_color()

### DIFF
--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -866,7 +866,8 @@ def uv_to_color(uv, image):
     # access colors from pixel locations
     # make sure image is RGBA before getting values
     colors = np.asanyarray(image.convert("RGBA"))[
-        y.round().astype(np.int64), x.round().astype(np.int64)
+        y.round().astype(np.int64) % image.height, 
+        x.round().astype(np.int64) % image.width
     ]
 
     # conversion to RGBA should have corrected shape


### PR DESCRIPTION
Hi Mike,

I discovered an **index out of bounds** error in the `to_color()` function when converting TextureVisual to ColorVisuals.

The issue occurs in the `uv_to_color()` function [here](https://github.com/mikedh/trimesh/blob/2fcb2b2ea8085d253e692ecd4f71b8f450890d51/trimesh/visual/color.py#L869):
```python
# get texture image pixel positions of UV coordinates
x = (uv[:, 0] * (image.width - 1)) % image.width
y = ((1 - uv[:, 1]) * (image.height - 1)) % image.height

# access colors from pixel locations
# make sure image is RGBA before getting values
colors = np.asanyarray(image.convert("RGBA"))[
    y.round().astype(np.int64), x.round().astype(np.int64)
]
```

The modulus (`%`) operation on float values can cause index out of bounds errors when rounding values near the bounds. For example:
1. Given `uv[i, 0] == -26.05739974975586` and `image.width == 456`
2. Results in `x[i] == 455.883113861084` after modulus operation `x = (uv[:, 0] * (image.width - 1)) % image.width
`
3. When rounded, `x.round().astype(np.int64) == 456`
4. This exceeds valid image indices `[0, 455]`, causing the error

I have fixed this issue in this pull request, please let me know if you have any further concerns!

Best,

Zeyu

