### PR TITLE
`trimesh.bounds.oriented_bounds` is slow for NumPy array input.

### DIFF
--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -9,6 +9,19 @@ class BoundsTest(g.unittest.TestCase):
         meshes = [g.get_mesh(i) for i in ["large_block.STL", "featuretype.STL"]]
         self.meshes = g.np.append(meshes, list(g.get_meshes(5)))
 
+
+    def test_obb_mesh_large(self):
+        """Test the OBB functionality on really large sets of vertices."""
+
+        torus_mesh = g.trimesh.creation.torus(major_radius=5, minor_radius=1, major_sections=512, minor_sections=256)
+        start = g.timeit.default_timer()
+        g.trimesh.bounds.oriented_bounds(torus_mesh.vertices)
+        stop = g.timeit.default_timer()
+
+        # Make sure oriented bound estimation runs within 30 seconds.
+        assert stop - start < 30, f"Took {stop - start} seconds to estimate the oriented bounding box."
+
+
     def test_obb_mesh(self):
         """
         Test the OBB functionality in attributes of Trimesh objects

--- a/trimesh/bounds.py
+++ b/trimesh/bounds.py
@@ -190,7 +190,7 @@ def oriented_bounds(obj, angle_digits=1, ordered=True, normal=None, coplanar_tol
             if util.is_shape(points, (-1, 2)):
                 return oriented_bounds_2D(points)
             elif util.is_shape(points, (-1, 3)):
-                hull = convex.convex_hull(points, repair=False)
+                hull = convex.convex_hull(points, repair=True)
             else:
                 raise ValueError("Points are not (n,3) or (n,2)!")
         else:


### PR DESCRIPTION
Hello,

While using `trimesh==4.5.0` to compute the minimum volume oriented bounding box of a mesh, I noticed the following bug. Running the below code seems to take an extremely long time:
```
torus_mesh = g.trimesh.creation.torus(major_radius=5, minor_radius=1, major_sections=512, minor_sections=256)
trimesh.bounds.oriented_bounds(torus_mesh.vertices)
```

But running this similar piece of code completed in ~7 seconds:
```
torus_mesh = g.trimesh.creation.torus(major_radius=5, minor_radius=1, major_sections=512, minor_sections=256)
trimesh.bounds.oriented_bounds(trimesh.Trimesh(vertices=torus_mesh.vertices))
```

My best guess is that, in the first case, the computed convex hull's face adjacencies seem to be wrong although I'm not sure how exactly. Line 253 in `bounds.py` computes  139156 edges that need to be checked, which doesn't seem right. In the second case, only 516 edges are checked.

I noticed that, in the first case, the convex hull is being computed by `trimesh.convex.convex_hull(..., repair=False)` and, in the second case, the convex hull is effectively being computed with `trimesh.convex.convex_hull(..., repair=True)`. This PR makes both cases use `repair = True`. Hopefully the solution is indeed that simple.

Thanks for the great library!
