### PR TITLE
Add x86 condition for openctm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ recommend = [
     "scikit-image",
     "fast-simplification",
     # "python-fcl", # do collision checks # TODO : broken on numpy 2
-    "openctm", # load `CTM` compressed models
+    "openctm; platform_machine=='x86_64'", # load `CTM` compressed models
     "cascadio", # load `STEP` files
 ]
 


### PR DESCRIPTION
OpenCTM doesn't support Mac ARM:
```
ERROR: Could not find a version that satisfies the requirement openctm==0.0.6 (from versions: none)
ERROR: No matching distribution found for openctm==0.0.6
```

This follows the style from the `embreex` dependency that has similar issues.