### PR TITLE
Fix/forward kwargs

### DIFF
--- a/tests/test_loaded.py
+++ b/tests/test_loaded.py
@@ -31,6 +31,18 @@ class LoaderTest(g.unittest.TestCase):
         assert len(m.faces) > 0
         assert m.area > 1e-5
 
+    def test_load_mesh(self):
+        # test the influence of the parameter `process` for `load_mesh`
+        with open(g.os.path.join(g.dir_models, "featuretype.STL"), "rb") as file_obj:
+            mesh = g.trimesh.load_mesh(file_obj=file_obj, file_type="stl", process=False)
+            # check that number of vertices is not being reduced
+            assert len(mesh.vertices) == 10428
+
+        with open(g.os.path.join(g.dir_models, "featuretype.STL"), "rb") as file_obj:
+            mesh = g.trimesh.load_mesh(file_obj=file_obj, file_type="stl", process=True)
+            # check that number of vertices is being reduced
+            assert len(mesh.vertices) == 1722
+
     def test_fileobj(self):
         # make sure we don't close file objects that were passed
         # check load_mesh

--- a/trimesh/exchange/stl.py
+++ b/trimesh/exchange/stl.py
@@ -43,14 +43,14 @@ def load_stl(file_obj, **kwargs):
         # if that is true, it is almost certainly a binary STL file
         # if the header doesn't match the file length a HeaderError will be
         # raised
-        return load_stl_binary(file_obj)
+        return {**load_stl_binary(file_obj), **kwargs}
     except HeaderError:
         # move the file back to where it was initially
         file_obj.seek(file_pos)
         # try to load the file as an ASCII STL
         # if the header doesn't match the file length
         # HeaderError will be raised
-        return load_stl_ascii(file_obj)
+        return {**load_stl_ascii(file_obj), **kwargs}
 
 
 def load_stl_binary(file_obj):


### PR DESCRIPTION
With the pull-request https://github.com/mikedh/trimesh/pull/2241, `load_mesh` does not respect the parameter `process` anymore.

With this pull-request, the `kwargs` are being forwarded in `load_stl`.