### PR TITLE
Fix linestring to path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ easy = [
     "embreex; platform_machine=='x86_64'",
     "pillow",
     "xatlas",
-    "vhacdx; python_version>='3.9'",
+    # "vhacdx; python_version>='3.9'",
     # old versions of mapbox_earcut produce incorrect values on numpy 2.0
     "mapbox_earcut >= 1.0.2; python_version>='3.9'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ easy = [
     "embreex; platform_machine=='x86_64'",
     "pillow",
     "xatlas",
-    # "vhacdx; python_version>='3.9'",
+    "vhacdx; python_version>='3.9'",
     # old versions of mapbox_earcut produce incorrect values on numpy 2.0
     "mapbox_earcut >= 1.0.2; python_version>='3.9'",
 ]

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -1,0 +1,23 @@
+from trimesh.path.exchange.misc import linestrings_to_path
+from shapely.geometry import LineString, MultiLineString
+
+
+def test_linestrings_to_path():
+    line = LineString([(0, 0), (1, 1), (2, 0)])
+
+    result = linestrings_to_path(line)
+
+    assert len(result["entities"]) == 1
+    assert len(result["vertices"]) == 3
+
+
+def test_multilinestrings_to_path():
+    line = MultiLineString([
+        LineString([(0, 0), (1, 1), (2, 0)]),
+        LineString([(1, 0), (2, 1), (2, 1)])
+    ])
+
+    result = linestrings_to_path(line)
+
+    assert len(result["entities"]) == 2
+    assert len(result["vertices"]) == 6

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -1,4 +1,6 @@
 from trimesh.path.exchange.misc import linestrings_to_path
+from trimesh.path.exchange.load import load_path
+
 from shapely.geometry import LineString, MultiLineString
 
 
@@ -13,11 +15,24 @@ def test_linestrings_to_path():
 
 def test_multilinestrings_to_path():
     line = MultiLineString([
-        LineString([(0, 0), (1, 1), (2, 0)]),
-        LineString([(1, 0), (2, 1), (2, 1)])
+        LineString([(0, 0), (1, 0), (2, 0)]),
+        LineString([(0, 1), (1, 1), (2, 1)])
     ])
 
     result = linestrings_to_path(line)
 
     assert len(result["entities"]) == 2
     assert len(result["vertices"]) == 6
+
+
+def test_load_path_with_multilinestrings():
+    line = MultiLineString([
+        LineString([(0, 0), (1, 0), (2, 0)]),
+        LineString([(0, 1), (1, 1), (2, 1)])
+    ])
+
+    result = load_path(line)
+
+    assert len(result.entities) == 2
+    assert len(result.vertices) == 6
+    assert result.length == 4

--- a/trimesh/path/exchange/misc.py
+++ b/trimesh/path/exchange/misc.py
@@ -1,4 +1,5 @@
 import numpy as np
+import shapely
 
 from ... import graph, grouping, util
 from ...constants import tol_path
@@ -138,7 +139,9 @@ def linestrings_to_path(multi):
     entities = []
     vertices = []
 
-    if not util.is_sequence(multi):
+    if hasattr(multi, "geoms"):
+        multi = list(multi.geoms)
+    else:
         multi = [multi]
 
     for line in multi:

--- a/trimesh/path/exchange/misc.py
+++ b/trimesh/path/exchange/misc.py
@@ -40,7 +40,7 @@ def dict_to_path(as_dict):
 
 def lines_to_path(lines: ArrayLike, index: Optional[NDArray[np.int64]] = None) -> Dict:
     """
-    Turn line segments into a Path2D or Path3D object.
+    Turn line segments into argument to be used for a Path2D or Path3D.
 
     Parameters
     ------------
@@ -51,7 +51,7 @@ def lines_to_path(lines: ArrayLike, index: Optional[NDArray[np.int64]] = None) -
 
     Returns
     -----------
-    kwargs : dict
+    kwargs : Dict
       kwargs for Path constructor
     """
     lines = np.asanyarray(lines, dtype=np.float64)
@@ -121,25 +121,25 @@ def polygon_to_path(polygon):
     return kwargs
 
 
-def linestrings_to_path(multi):
+def linestrings_to_path(multi: shapely.LineString | shapely.MultiLineString) -> Dict:
     """
-    Load shapely LineString objects into a trimesh.path.Path2D object
+    Load shapely LineString objects into arguments to create a Path2D or Path3D.
 
     Parameters
     -------------
     multi : shapely.geometry.LineString or MultiLineString
-      Input 2D geometry
+      Input 2D or 3D geometry
 
     Returns
     -------------
-    kwargs : dict
-      Keyword arguments for Path2D constructor
+    kwargs : Dict
+      Keyword arguments for Path2D or Path3D constructor
     """
     # append to result as we go
     entities = []
     vertices = []
 
-    if hasattr(multi, "geoms"):
+    if isinstance(multi, shapely.MultiLineString):
         multi = list(multi.geoms)
     else:
         multi = [multi]

--- a/trimesh/path/exchange/misc.py
+++ b/trimesh/path/exchange/misc.py
@@ -1,5 +1,4 @@
 import numpy as np
-import shapely
 
 from ... import graph, grouping, util
 from ...constants import tol_path
@@ -121,7 +120,7 @@ def polygon_to_path(polygon):
     return kwargs
 
 
-def linestrings_to_path(multi: shapely.LineString | shapely.MultiLineString) -> Dict:
+def linestrings_to_path(multi) -> Dict:
     """
     Load shapely LineString objects into arguments to create a Path2D or Path3D.
 
@@ -135,6 +134,8 @@ def linestrings_to_path(multi: shapely.LineString | shapely.MultiLineString) -> 
     kwargs : Dict
       Keyword arguments for Path2D or Path3D constructor
     """
+    import shapely
+
     # append to result as we go
     entities = []
     vertices = []


### PR DESCRIPTION
This PR fixes an issues with converting `shapely.Linestring` to `Path3D`.