### PR TITLE
chardet -> charset-normalizer

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -46,7 +46,7 @@ Trimesh has a lot of soft-required upstream packages, and we try to make sure th
 |`httpx`| Do network queries in `trimesh.exchange.load_remote`, will *only* make network requests when asked | `requests`, `aiohttp` | `easy`|
 |`sympy`| Evaluate symbolic algebra | | `recommend`|
 |`xxhash`| Quickly hash arrays, used for our cache checking | | `easy`|
-|`chardet`| When we fail to decode text as UTF-8 we then check with chardet which guesses an encoding,  letting us load files even with weird encodings. | | `easy`|
+|`charset-normalizer`| When we fail to decode text as UTF-8 we then check with charset-normalizer which guesses an encoding,  letting us load files even with weird encodings. | | `easy`|
 |`colorlog`| Printing logs with colors. | | `easy`|
 |`pillow`| Reading raster images for textures and render polygons into raster images. | | `easy`|
 |`svg.path`| Parsing SVG path strings. | | `easy`|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ trimesh = [
 easy = [
     "colorlog",
     "manifold3d>=2.3.0", # do boolean operations    
-    "chardet",
+    "charset-normalizer",
     "lxml",
     "jsonschema",
     "networkx",

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -2272,7 +2272,7 @@ def decode_text(text, initial="utf-8"):
     Try to decode byte input as a string.
 
     Tries initial guess (UTF-8) then if that fails it
-    uses chardet to try another guess before failing.
+    uses charset_normalizer to try another guess before failing.
 
     Parameters
     ------------
@@ -2294,12 +2294,11 @@ def decode_text(text, initial="utf-8"):
         text = text.decode(initial)
     except UnicodeDecodeError:
         # detect different file encodings
-        import chardet
+        from charset_normalizer import detect as charset_normalizer_detect
 
         # try to detect the encoding of the file
-        # only look at the first 1000 characters otherwise
-        # for big files chardet looks at everything and is slow
-        detect = chardet.detect(text[:1000])
+        # only look at the first 1000 characters for speed
+        detect = charset_normalizer_detect(text[:1000])
         # warn on files that aren't UTF-8
         log.debug(
             "Data not {}! Trying {} (confidence {})".format(


### PR DESCRIPTION
This PR removes `chardet` as an `easy` dep and replaces it with `charset_normalizer` which is faster, has a smaller wheel, is more robust, and has an MIT license to match this project.

More info here: https://github.com/jawah/charset_normalizer