### PR TITLE
Add vertex attributes in path

### DIFF
--- a/tests/generic.py
+++ b/tests/generic.py
@@ -6,6 +6,7 @@ might need, to reduce the amount of boilerplate.
 
 import os
 import sys
+import io
 import json
 import copy
 import time
@@ -565,6 +566,47 @@ def roundtrip(exported, file_type, **kwargs):
     return trimesh.load(
         file_obj=trimesh.util.wrap_as_stream(exported), file_type=file_type, **kwargs
     )
+
+
+def to_glb_bytes(geom):
+    """
+    Returns the content of the binary glTF file for the given geometry.
+
+    Parameters
+    ----------
+    geom : trimesh.Geometry
+      Geometry to export
+
+    Returns
+    -------
+    data : bytes
+      Content of the binary glTF file
+    """
+    data = trimesh.exchange.gltf.export_glb(geom)
+
+    return data
+
+
+def from_dlb_bytes(data):
+    """
+    Returns the scene from the given binary glTF file content.
+
+    Parameters
+    ----------
+    data : bytes
+      Content of the binary glTF file
+
+    Returns
+    -------
+    scene : trimesh.Scene
+      Scene
+    """
+    bytes_stream = io.BytesIO(data)
+    kwargs = trimesh.exchange.gltf.load_glb(bytes_stream)
+
+    scene = trimesh.exchange.load._load_kwargs(kwargs)
+
+    return scene
 
 
 # all the JSON files with truth data

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -568,7 +568,7 @@ def roundtrip(exported, file_type, **kwargs):
     )
 
 
-def to_glb_bytes(geom):
+def to_glb_bytes(geom: trimesh.Geometry) -> bytes:
     """
     Returns the content of the binary glTF file for the given geometry.
 
@@ -587,7 +587,7 @@ def to_glb_bytes(geom):
     return data
 
 
-def from_dlb_bytes(data):
+def from_glb_bytes(data: bytes) -> trimesh.Scene:
     """
     Returns the scene from the given binary glTF file content.
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -110,6 +110,38 @@ def test_discrete():
         # run process manually
         d.process()
 
+    def test_vertex_attributes(self):
+        entities = [
+            g.trimesh.path.entities.Line(
+                points=[0, 1, 2, 3]
+            )
+        ]
+
+        vertices = [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+        ]
+
+        # Test path without clean up
+        path = g.trimesh.path.Path3D(
+            entities=entities,
+            vertices=vertices,
+            vertex_attributes={
+                "test": [1, 2, 3, 4]
+            },
+            process=False,
+        )
+
+        assert len(path.vertices) == 4
+        assert len(path.vertex_attributes["test"]) == 4
+
+        path.process()
+
+        assert len(path.vertices) == 3
+        assert len(path.vertex_attributes["test"]) == 3
+
 
 def test_poly():
     p = g.get_mesh("2D/LM2.dxf")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -124,10 +124,8 @@ def test_path():
         }
     )
 
-    gltf = g.trimesh.exchange.gltf.export_glb(path)
-
-    import io
-    loaded_scene = g.trimesh.exchange.load._load_kwargs(g.trimesh.exchange.gltf.load_glb(io.BytesIO(gltf)))
+    glb_data = g.to_glb_bytes(path)
+    loaded_scene = g.from_dlb_bytes(glb_data)
 
     loaded_path = loaded_scene.geometry["geometry_0"]
     loaded_path.process()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -125,7 +125,7 @@ def test_path():
     )
 
     glb_data = g.to_glb_bytes(path)
-    loaded_scene = g.from_dlb_bytes(glb_data)
+    loaded_scene = g.from_glb_bytes(glb_data)
 
     loaded_path = loaded_scene.geometry["geometry_0"]
     loaded_path.process()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -110,37 +110,33 @@ def test_discrete():
         # run process manually
         d.process()
 
-    def test_vertex_attributes(self):
-        entities = [
+
+def test_path():
+    path = g.trimesh.path.Path3D(
+        entities=[
             g.trimesh.path.entities.Line(
-                points=[0, 1, 2, 3]
+                points=[0, 1, 2]
             )
-        ]
+        ],
+        vertices=[[0, 0, 0], [1, 0, 0], [1, 1, 0]],
+        vertex_attributes={
+            "_test": g.np.array([1, 2, 3], dtype=g.np.float32)
+        }
+    )
 
-        vertices = [
-            [0, 0, 0],
-            [1, 0, 0],
-            [1, 0, 0],
-            [1, 1, 0],
-        ]
+    gltf = g.trimesh.exchange.gltf.export_glb(path)
 
-        # Test path without clean up
-        path = g.trimesh.path.Path3D(
-            entities=entities,
-            vertices=vertices,
-            vertex_attributes={
-                "test": [1, 2, 3, 4]
-            },
-            process=False,
-        )
+    import io
+    loaded_scene = g.trimesh.exchange.load._load_kwargs(g.trimesh.exchange.gltf.load_glb(io.BytesIO(gltf)))
 
-        assert len(path.vertices) == 4
-        assert len(path.vertex_attributes["test"]) == 4
+    loaded_path = loaded_scene.geometry["geometry_0"]
+    loaded_path.process()
 
-        path.process()
+    assert isinstance(loaded_path, g.trimesh.path.Path3D)
 
-        assert len(path.vertices) == 3
-        assert len(path.vertex_attributes["test"]) == 3
+    assert loaded_path.vertices.shape == (3, 3)
+    assert len(loaded_path.entities) == 1
+    assert len(loaded_path.vertex_attributes["_test"]) == 3
 
 
 def test_poly():

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -78,6 +78,7 @@ class Path(parent.Geometry):
         metadata: Optional[Dict] = None,
         process: bool = True,
         colors=None,
+        vertex_attributes: Optional[Dict] = None,
         **kwargs,
     ):
         """
@@ -104,6 +105,10 @@ class Path(parent.Geometry):
         self.metadata = {}
         if isinstance(metadata, dict):
             self.metadata.update(metadata)
+
+        self.vertex_attributes = {}
+        if vertex_attributes is not None:
+            self.vertex_attributes.update(vertex_attributes)
 
         # cache will dump whenever self.crc changes
         self._cache = caching.Cache(id_function=self.__hash__)
@@ -523,6 +528,9 @@ class Path(parent.Geometry):
 
         unique, inverse = grouping.unique_rows(self.vertices, digits=digits)
         self.vertices = self.vertices[unique]
+        self.vertex_attributes = {
+            key: np.array(value)[unique] for key, value in self.vertex_attributes.items()
+        }
 
         entities_ok = np.ones(len(self.entities), dtype=bool)
 


### PR DESCRIPTION
This PR adds support for `vertex_attributes` in paths, to match the functionality of `Trimesh` when importing/exporting custom attributes for lines from/to glTF.