### PR TITLE
Efficient Laplacian calculations

### DIFF
--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -4,7 +4,87 @@ except BaseException:
     import generic as g
 
 
+
+def explicit_laplacian_calculation(mesh, equal_weight=True, pinned_vertices=None):
+    """
+    Exact copy of non-sparse calculation of laplacian, for correctness testing.
+
+    Calculate a sparse matrix for laplacian operations.
+    Parameters
+    -------------
+    mesh : trimesh.Trimesh
+      Input geometry
+    equal_weight : bool
+      If True, all neighbors will be considered equally
+      If False, all neighbors will be weighted by inverse distance
+    Returns
+    ----------
+    laplacian : scipy.sparse.coo.coo_matrix
+      Laplacian operator
+    """
+    # get the vertex neighbors from the cache
+    neighbors = mesh.vertex_neighbors
+
+    # if a node is pinned, it will average his coordinates by himself
+    # in practice it will not move
+    if pinned_vertices is not None:
+        for i in pinned_vertices:
+            neighbors[i] = [i]
+
+    # avoid hitting crc checks in loops
+    vertices = mesh.vertices.view(g.np.ndarray)
+
+    # stack neighbors to 1D arrays
+    col = g.np.concatenate(neighbors)
+    row = g.np.concatenate([[i] * len(n) for i, n in enumerate(neighbors)])
+
+    if equal_weight:
+        # equal weights for each neighbor
+        data = g.np.concatenate([[1.0 / len(n)] * len(n) for n in neighbors])
+    else:
+        # umbrella weights, distance-weighted
+        # use dot product of ones to replace array.sum(axis=1)
+        ones = g.np.ones(3)
+        # the distance from verticesex to neighbors
+        norms = [
+            1.0
+            / g.np.maximum(1e-6, g.np.sqrt(g.np.dot((vertices[i] - vertices[n]) ** 2, ones)))
+            for i, n in enumerate(neighbors)
+        ]
+        # normalize group and stack into single array
+        data = g.np.concatenate([i / i.sum() for i in norms])
+
+    # create the sparse matrix
+    matrix = g.trimesh.graph.coo_matrix((data, (row, col)), shape=[len(vertices)] * 2)
+
+    return matrix
+
+
 class SmoothTest(g.unittest.TestCase):
+    def test_laplacian_calculation(self):
+        m = g.trimesh.creation.icosahedron()
+        m.vertices, m.faces = g.trimesh.remesh.subdivide_to_size(m.vertices, m.faces, 0.1)
+
+        explicit_laplacian = explicit_laplacian_calculation(m)
+        laplacian = g.trimesh.smoothing.laplacian_calculation(m)
+
+        assert g.np.allclose(explicit_laplacian.toarray(), laplacian.toarray())
+
+        explicit_laplacian = explicit_laplacian_calculation(m, equal_weight=False)
+        laplacian = g.trimesh.smoothing.laplacian_calculation(m, equal_weight=False)
+
+        assert g.np.allclose(explicit_laplacian.toarray(), laplacian.toarray())
+
+        explicit_laplacian = explicit_laplacian_calculation(m, pinned_vertices=[0, 1, 4])
+        laplacian = g.trimesh.smoothing.laplacian_calculation(m, pinned_vertices=[0, 1, 4])
+
+        assert g.np.allclose(explicit_laplacian.toarray(), laplacian.toarray())
+
+        explicit_laplacian = explicit_laplacian_calculation(m, equal_weight=False, pinned_vertices=[0, 1, 4])
+        laplacian = g.trimesh.smoothing.laplacian_calculation(m, equal_weight=False, pinned_vertices=[0, 1, 4])
+
+        assert g.np.allclose(explicit_laplacian.toarray(), laplacian.toarray())
+
     def test_smooth(self):
         """
         Load a collada scene with pycollada.

--- a/trimesh/smoothing.py
+++ b/trimesh/smoothing.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 import numpy as np
 
 try:
@@ -6,7 +8,8 @@ try:
 except ImportError:
     pass
 
-from . import triangles
+from . import graph, triangles
+from .base import Trimesh
 from .geometry import index_sparse
 from .triangles import mass_properties
 from .util import unitize
@@ -249,9 +252,16 @@ def filter_mut_dif_laplacian(
     return mesh
 
 
-def laplacian_calculation(mesh, equal_weight=True, pinned_vertices=None):
+def laplacian_calculation(
+    mesh: Trimesh,
+    equal_weight: bool = True,
+    pinned_vertices: Optional[List[int]] = None,
+) -> coo_matrix:
     """
     Calculate a sparse matrix for laplacian operations.
+
+    Note that setting equal_weight to False significantly hampers performance.
+
     Parameters
     -------------
     mesh : trimesh.Trimesh
@@ -259,31 +269,45 @@ def laplacian_calculation(mesh, equal_weight=True, pinned_vertices=None):
     equal_weight : bool
       If True, all neighbors will be considered equally
       If False, all neighbors will be weighted by inverse distance
+    pinned_vertices : None or list of ints
+      If None, no vertices are pinned
+      If list, vertices will be pinned, such that they will not be moved
     Returns
     ----------
     laplacian : scipy.sparse.coo.coo_matrix
       Laplacian operator
     """
-    # get the vertex neighbors from the cache
-    neighbors = mesh.vertex_neighbors
-
-    # if a node is pinned, it will average his coordinates by himself
-    # in practice it will not move
-    if pinned_vertices is not None:
-        for i in pinned_vertices:
-            neighbors[i] = [i]
-
-    # avoid hitting crc checks in loops
-    vertices = mesh.vertices.view(np.ndarray)
-
-    # stack neighbors to 1D arrays
-    col = np.concatenate(neighbors)
-    row = np.concatenate([[i] * len(n) for i, n in enumerate(neighbors)])
-
     if equal_weight:
-        # equal weights for each neighbor
-        data = np.concatenate([[1.0 / len(n)] * len(n) for n in neighbors])
+        laplacian = graph.edges_to_coo(mesh.edges)
+        mesh.vertex_neighbors
+
+        if pinned_vertices is not None:
+            # Set pinned vertices to only have themselves as neighbours
+            laplacian.data[np.isin(laplacian.row, pinned_vertices)] = False
+            laplacian.row = np.concatenate((laplacian.row, pinned_vertices))
+            laplacian.col = np.concatenate((laplacian.col, pinned_vertices))
+            laplacian.data = np.concatenate(
+                (laplacian.data, np.ones(len(pinned_vertices), dtype=bool))
+            )
+
+        laplacian = laplacian / laplacian.sum(axis=1)
     else:
+        # get the vertex neighbors from the cache
+        neighbors = mesh.vertex_neighbors
+
+        # if a node is pinned, it will average his coordinates by himself
+        # in practice it will not move
+        if pinned_vertices is not None:
+            for i in pinned_vertices:
+                neighbors[i] = [i]
+
+        # avoid hitting crc checks in loops
+        vertices = mesh.vertices.view(np.ndarray)
+
+        # stack neighbors to 1D arrays
+        col = np.concatenate(neighbors)
+        row = np.concatenate([[i] * len(n) for i, n in enumerate(neighbors)])
+
         # umbrella weights, distance-weighted
         # use dot product of ones to replace array.sum(axis=1)
         ones = np.ones(3)
@@ -296,10 +320,10 @@ def laplacian_calculation(mesh, equal_weight=True, pinned_vertices=None):
         # normalize group and stack into single array
         data = np.concatenate([i / i.sum() for i in norms])
 
-    # create the sparse matrix
-    matrix = coo_matrix((data, (row, col)), shape=[len(vertices)] * 2)
+        # create the sparse matrix
+        laplacian = coo_matrix((data, (row, col)), shape=[len(vertices)] * 2)
 
-    return matrix
+    return laplacian
 
 
 def get_vertices_normals(mesh):


### PR DESCRIPTION
The current implementation of `trimesh.smoothing.laplacian_calculation` relies on list comprehensions. The case of `equal_weight=True`, at least, can be computed directly using sparse matrix operations. This PR does that, which turns out to be nearly 20 times faster.

I have been unable to figure out a way of computing the `equal_weight=False` case using sparse matrix operations, so I have let the current implementation of that be. This implies quite a performance difference between the two flag values. This is noted in the docstring, which is now also more descriptive.

Correctness tests are added, which include a verbatim copy of the original implementation to test against.

Performance characteristics:
```python
In [1]: import trimesh

In [2]: from tests import test_smoothing

In [3]: m = trimesh.creation.icosphere(8, 10)

In [4]: m.vertices.shape, m.faces.shape
Out[4]: ((655362, 3), (1310720, 3))

In [5]: %timeit trimesh.smoothing.laplacian_calculation(m, equal_weight=True)
44.4 ms ± 783 μs per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [6]: %timeit test_smoothing.explicit_laplacian_calculation(m, equal_weight=True)
790 ms ± 9.89 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [7]: %timeit trimesh.smoothing.laplacian_calculation(m, equal_weight=False)
2.87 s ± 31.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [8]: %timeit test_smoothing.explicit_laplacian_calculation(m, equal_weight=False)
2.91 s ± 34.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
where `test_smoothing.explicit_laplacian_calculation` is the original implementation.