### PR TITLE
Fix complex path export

### DIFF
--- a/tests/generic.py
+++ b/tests/generic.py
@@ -26,6 +26,7 @@ import contextlib
 import subprocess
 import collections
 import numpy as np
+import pytest
 
 import trimesh
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -111,52 +111,75 @@ def test_discrete():
         d.process()
 
 
-def test_path():
-    path = g.trimesh.path.Path3D(
-        entities=[g.trimesh.path.entities.Line(points=[0, 1, 2])],
-        vertices=[[0, 0, 0], [1, 0, 0], [1, 1, 0]],
-        vertex_attributes={"_test": g.np.array([1, 2, 3], dtype=g.np.float32)},
-    )
+class TestPath(g.unittest.TestCase):
+    def test_path(self):
+        path = g.trimesh.path.Path3D(
+            entities=[g.trimesh.path.entities.Line(points=[0, 1, 2])],
+            vertices=[[0, 0, 0], [1, 0, 0], [1, 1, 0]],
+            vertex_attributes={"_test": g.np.array([1, 2, 3], dtype=g.np.float32)},
+        )
 
-    glb_data = g.to_glb_bytes(path)
-    loaded_scene = g.from_glb_bytes(glb_data)
+        glb_data = g.to_glb_bytes(path)
+        loaded_scene = g.from_glb_bytes(glb_data)
 
-    loaded_path = loaded_scene.geometry["geometry_0"]
-    loaded_path.process()
+        loaded_path = loaded_scene.geometry["geometry_0"]
+        loaded_path.process()
 
-    assert isinstance(loaded_path, g.trimesh.path.Path3D)
+        assert isinstance(loaded_path, g.trimesh.path.Path3D)
 
-    assert loaded_path.vertices.shape == (3, 3)
-    assert len(loaded_path.entities) == 1
-    assert len(loaded_path.vertex_attributes["_test"]) == 3
+        assert loaded_path.vertices.shape == (3, 3)
+        assert len(loaded_path.entities) == 1
+        assert len(loaded_path.vertex_attributes["_test"]) == 3
 
 
-def test_path_to_gltf():
-    path = g.trimesh.path.Path3D(
-        entities=[
-            g.trimesh.path.entities.Line(points=[0, 1, 2]),
-            g.trimesh.path.entities.Line(points=[3, 4, 5]),
-        ],
-        vertices=g.np.array([
-            [0, 0, 0],
-            [0, 1, 0],
-            [1, 1, 0],
-            [0, 0, 1],
-            [0, 1, 1],
-            [1, 1, 2],
-        ])
-    )
-    path.vertex_attributes = {
-        "_test": g.np.array([0, 0, 0, 1, 1, 1], dtype=g.np.float32)
-    }
+    def test_path_to_gltf_with_line(self):
+        path = g.trimesh.path.Path3D(
+            entities=[
+                g.trimesh.path.entities.Line(points=[0, 1, 2]),
+                g.trimesh.path.entities.Line(points=[3, 4, 5]),
+            ],
+            vertices=g.np.array([
+                [0, 0, 0],
+                [0, 1, 0],
+                [1, 1, 0],
+                [0, 0, 1],
+                [0, 1, 1],
+                [1, 1, 2],
+            ])
+        )
+        path.vertex_attributes = {
+            "_test": g.np.array([0, 0, 0, 1, 1, 1], dtype=g.np.float32)
+        }
 
-    tree, _ = g.trimesh.exchange.gltf._create_gltf_structure(g.trimesh.Scene([path]))
+        tree, _ = g.trimesh.exchange.gltf._create_gltf_structure(g.trimesh.Scene([path]))
 
-    assert len(tree["accessors"]) == 2
+        assert len(tree["accessors"]) == 2
 
-    acc = tree["accessors"]
+        acc = tree["accessors"]
 
-    assert acc[0]["count"] == acc[1]["count"]
+        assert acc[0]["count"] == acc[1]["count"]
+
+    def test_path_to_gltf_with_arc(self):
+        path = g.trimesh.path.Path3D(
+            entities=[
+                g.trimesh.path.entities.Line(points=[0, 1, 2]),
+                g.trimesh.path.entities.Arc(points=[3, 4, 5]),
+            ],
+            vertices=g.np.array([
+                [0, 0, 0],
+                [0, 1, 0],
+                [1, 1, 0],
+                [0, 0, 1],
+                [0, 1, 1],
+                [1, 1, 2],
+            ])
+        )
+        path.vertex_attributes = {
+            "_test": g.np.array([0, 0, 0, 1, 1, 1], dtype=g.np.float32)
+        }
+
+        with g.pytest.raises(ValueError):
+            tree, _ = g.trimesh.exchange.gltf._create_gltf_structure(g.trimesh.Scene([path]))
 
 
 def test_poly():

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -131,6 +131,34 @@ def test_path():
     assert len(loaded_path.vertex_attributes["_test"]) == 3
 
 
+def test_path_to_gltf():
+    path = g.trimesh.path.Path3D(
+        entities=[
+            g.trimesh.path.entities.Line(points=[0, 1, 2]),
+            g.trimesh.path.entities.Line(points=[3, 4, 5]),
+        ],
+        vertices=g.np.array([
+            [0, 0, 0],
+            [0, 1, 0],
+            [1, 1, 0],
+            [0, 0, 1],
+            [0, 1, 1],
+            [1, 1, 2],
+        ])
+    )
+    path.vertex_attributes = {
+        "_test": g.np.array([0, 0, 0, 1, 1, 1], dtype=g.np.float32)
+    }
+
+    tree, _ = g.trimesh.exchange.gltf._create_gltf_structure(g.trimesh.Scene([path]))
+
+    assert len(tree["accessors"]) == 2
+
+    acc = tree["accessors"]
+
+    assert acc[0]["count"] == acc[1]["count"]
+
+
 def test_poly():
     p = g.get_mesh("2D/LM2.dxf")
     assert p.is_closed

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 import numpy as np
 
 from .. import rendering, resources, transformations, util, visual
+from ..path.entities import Line
 from ..caching import hash_fast
 from ..constants import log, tol
 from ..resolvers import ResolverLike, ZipResolver
@@ -1179,6 +1180,9 @@ def _append_path(path, name, tree, buffer_items):
             data = attrib.astype(np.float32)
         else:
             data = attrib
+
+        if not all([isinstance(e, Line) for e in path.entities]):
+            raise ValueError("Vertex attributes are only supported for Line entities.")
 
         data_discretized = np.array([
             util.stack_lines(e.discrete(data))

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -14,9 +14,9 @@ from copy import deepcopy
 import numpy as np
 
 from .. import rendering, resources, transformations, util, visual
-from ..path.entities import Line
 from ..caching import hash_fast
 from ..constants import log, tol
+from ..path.entities import Line
 from ..resolvers import ResolverLike, ZipResolver
 from ..scene.cameras import Camera
 from ..typed import Dict, List, NDArray, Optional, Stream
@@ -1181,7 +1181,7 @@ def _append_path(path, name, tree, buffer_items):
         else:
             data = attrib
 
-        if not all([isinstance(e, Line) for e in path.entities]):
+        if not all(isinstance(e, Line) for e in path.entities):
             raise ValueError("Vertex attributes are only supported for Line entities.")
 
         data_discretized = np.array([

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1180,14 +1180,18 @@ def _append_path(path, name, tree, buffer_items):
         else:
             data = attrib
 
-        data = util.stack_lines(data).reshape((-1,))
+        data_discretized = np.array([
+            util.stack_lines(e.discrete(data))
+            for e in path.entities
+        ])
+        stacked_data = data_discretized.reshape((-1,))
 
         # store custom vertex attributes
         current["primitives"][0]["attributes"][key] = _data_append(
             acc=tree["accessors"],
             buff=buffer_items,
-            blob=_build_accessor(data),
-            data=data,
+            blob=_build_accessor(stacked_data),
+            data=stacked_data,
         )
 
     tree["meshes"].append(current)


### PR DESCRIPTION
This PR will fix exporting of complex paths (i.e., having multiple `Line` entities).

This will still fail for other entities than `Line` that need proper discretization, but there seems to be no trivial way to solve this problem for curves.