### PR TITLE
Fix: color rendering and camera marker direction

### DIFF
--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -1356,7 +1356,7 @@ def camera_marker(
 
     # combine the points into the vertices of an FOV visualization
     points = np.array(
-        [(0, 0, 0), (-x, -y, z), (x, -y, z), (x, y, z), (-x, y, z)], dtype=float
+        [(0, 0, 0), (-x, -y, -z), (x, -y, -z), (x, y, -z), (-x, y, -z)], dtype=float
     )
 
     # create line segments for the FOV visualization

--- a/trimesh/rendering.py
+++ b/trimesh/rendering.py
@@ -117,8 +117,7 @@ def mesh_to_vertexlist(mesh, group=None, smooth=True, smooth_threshold=60000):
         vertex_count = len(vertices)
         normals = smooth.vertex_normals
         faces = smooth.faces
-        vertices = smooth.vertices
-        color_gl = colors_to_gl(mesh.visual.vertex_colors, vertex_count)
+        color_gl = colors_to_gl(smooth.visual.vertex_colors, vertex_count)
     else:
         # we don't have textures or want to smooth so
         # send a polygon soup of disconnected triangles to opengl


### PR DESCRIPTION
### This PR will fix 2 bugs:
- #2373
- Wrong direction of camera FOV visualization

> I assumed in this PR that trimesh uses the same definition of camera coordinate system as **blender**:  
> - the Y-axis pointing upward and the Z-axis pointing forward.    
> - the viewing direction is along the negative Z-axis.   
> [Reference from stackoverflow](https://stackoverflow.com/questions/64977993/applying-opencv-pose-estimation-to-blender-camera)  
> Please let me know if my approach to draw camera markers in the test code is wrong, or there is a different definition of camera coordinate system.  

### Tested with my code snippet:
```py
import trimesh

mesh = trimesh.creation.annulus(1.5, 3, 3, 100)
mesh.visual.face_colors = [0, 0, 255, 100]
mesh2 = trimesh.creation.box(extents=[0.4, 0.4, 0.4])
mesh2.apply_translation([1, 0, 0])
mesh2.visual.vertex_colors = [0, 255, 0, 255]

scene = trimesh.Scene([mesh, mesh2, trimesh.creation.axis(origin_size=0.1)])

# draw a camera with the transform below
camera_transform = \
[[ 1.,  0.,  0.,  0.  ],
 [ 0.,  1.,  0.,  0.  ],
 [ 0.,  0.,  1.,  10. ],
 [ 0.,  0.,  0.,  1.  ]]
scene.camera_transform = camera_transform

camera_marker = trimesh.creation.camera_marker(scene.camera.copy(), marker_height=1)
for geo in camera_marker:
    if isinstance(geo, trimesh.path.Path3D) or isinstance(geo, trimesh.Trimesh):
        geo.apply_transform(camera_transform) 
scene.add_geometry(camera_marker)

# move the camera farther
scene.camera_transform = \
[[ 1.,  0.,  0.,  0.  ],
 [ 0.,  0.8, 0.6, 12. ],
 [ 0.,  -0.6,0.8, 20. ],
 [ 0.,  0.,  0.,  1.  ]]

scene.show(background=[200,200,200], resolution=[500,500])
print(scene.camera_transform)
```
### Result: 
![foto](https://github.com/user-attachments/assets/214b159b-eec3-4f6b-8c45-8b5ce6685dfd)
