### PR TITLE
feat: Marimo Notebook Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ print(mesh.bounding_box_oriented.volume,
 * Import geometry files using the GMSH SDK if installed (BREP, STEP, IGES, INP, BDF, etc)
 * Export meshes as binary STL, binary PLY, ASCII OFF, OBJ, GLTF/GLB 2.0, COLLADA, etc.
 * Export meshes using the GMSH SDK if installed (Abaqus INP, Nastran BDF, etc)
-* Preview meshes using pyglet or in- line in jupyter notebooks using three.js
+* Preview meshes using pyglet or in- line in jupyter/marimo notebooks using three.js
 * Automatic hashing of numpy arrays for change tracking using MD5, zlib CRC, or xxhash
 * Internal caching of computed values validated from hashes
 * Calculate face adjacencies, face angles, vertex defects, etc.
@@ -154,7 +154,7 @@ print(mesh.bounding_box_oriented.volume,
 * Calculate nearest point on mesh surface and signed distance
 * Determine if a point lies inside or outside of a well constructed mesh using signed distance
 * Primitive objects (Box, Cylinder, Sphere, Extrusion) which are subclassed Trimesh objects and have all the same features (inertia, viewers, etc)
-* Simple scene graph and transform tree which can be rendered (pyglet window, three.js in a jupyter notebook, [pyrender](https://github.com/mmatl/pyrender)) or exported.
+* Simple scene graph and transform tree which can be rendered (pyglet window, three.js in a jupyter/marimo notebook, [pyrender](https://github.com/mmatl/pyrender)) or exported.
 * Many utility functions, like transforming points, unitizing vectors, aligning vectors, tracking numpy arrays for changes, grouping rows, etc.
 
 
@@ -174,7 +174,7 @@ Trimesh includes an optional `pyglet` based viewer for debugging and inspecting.
 * `m` maximizes the window
 * `q` closes the window
 
-If called from inside a `jupyter` notebook, `mesh.show()` displays an in-line preview using `three.js` to display the mesh or scene. For more complete rendering (PBR, better lighting, shaders, better off-screen support, etc) [pyrender](https://github.com/mmatl/pyrender) is designed to interoperate with `trimesh` objects.
+If called from inside a `jupyter` or `marimo` notebook, `mesh.show()` displays an in-line preview using `three.js` to display the mesh or scene. For more complete rendering (PBR, better lighting, shaders, better off-screen support, etc) [pyrender](https://github.com/mmatl/pyrender) is designed to interoperate with `trimesh` objects.
 
 ## Projects Using Trimesh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ test_more = [
     "pymeshlab",
     "triangle",
     "ipython",
+    "marimo",
 ]
 
 # interfaces.gmsh will be dropped Jan 2025

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -1343,7 +1343,8 @@ class Scene(Geometry3D):
         viewer : Union[str, callable, None]
           What kind of viewer to use, such as
           'gl' to open a pyglet window, 'notebook'
-          for a jupyter notebook or None
+          for a jupyter notebook, 'marimo' for 
+          a marimo notebook or None
         kwargs : dict
           Includes `smooth`, which will turn
           on or off automatic smooth shading
@@ -1351,10 +1352,12 @@ class Scene(Geometry3D):
 
         if viewer is None:
             # check to see if we are in a notebook or not
-            from ..viewer import in_notebook
+            from ..viewer import in_notebook, in_marimo_notebook
 
             if in_notebook():
                 viewer = "notebook"
+            elif in_marimo_notebook():
+                viewer = "marimo"
             else:
                 viewer = "gl"
 
@@ -1368,6 +1371,10 @@ class Scene(Geometry3D):
             from ..viewer import scene_to_notebook
 
             return scene_to_notebook(self, **kwargs)
+        elif viewer == "marimo":
+            from ..viewer import scene_to_mo_notebook
+
+            return scene_to_mo_notebook(self, **kwargs)
         elif callable(viewer):
             # if a callable method like a custom class
             # constructor was passed run using that

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -1343,7 +1343,7 @@ class Scene(Geometry3D):
         viewer : Union[str, callable, None]
           What kind of viewer to use, such as
           'gl' to open a pyglet window, 'notebook'
-          for a jupyter notebook, 'marimo' for 
+          for a jupyter notebook, 'marimo' for
           a marimo notebook or None
         kwargs : dict
           Includes `smooth`, which will turn
@@ -1352,7 +1352,7 @@ class Scene(Geometry3D):
 
         if viewer is None:
             # check to see if we are in a notebook or not
-            from ..viewer import in_notebook, in_marimo_notebook
+            from ..viewer import in_marimo_notebook, in_notebook
 
             if in_notebook():
                 viewer = "notebook"

--- a/trimesh/viewer/__init__.py
+++ b/trimesh/viewer/__init__.py
@@ -6,7 +6,7 @@ View meshes and scenes via pyglet or inline HTML.
 """
 
 from .. import exceptions
-from .notebook import in_notebook, scene_to_html, scene_to_notebook
+from .notebook import in_notebook, scene_to_html, scene_to_notebook, in_marimo_notebook, scene_to_mo_notebook
 
 try:
     # try importing windowed which will fail
@@ -33,7 +33,10 @@ __all__ = [
     "SceneViewer",
     "SceneWidget",
     "in_notebook",
+    "in_marimo_notebook",
     "render_scene",
     "scene_to_html",
     "scene_to_notebook",
+    "scene_to_mo_notebook"
+]
 ]

--- a/trimesh/viewer/__init__.py
+++ b/trimesh/viewer/__init__.py
@@ -6,7 +6,13 @@ View meshes and scenes via pyglet or inline HTML.
 """
 
 from .. import exceptions
-from .notebook import in_notebook, scene_to_html, scene_to_notebook, in_marimo_notebook, scene_to_mo_notebook
+from .notebook import (
+    in_marimo_notebook,
+    in_notebook,
+    scene_to_html,
+    scene_to_mo_notebook,
+    scene_to_notebook,
+)
 
 try:
     # try importing windowed which will fail
@@ -32,11 +38,10 @@ except BaseException as E:
 __all__ = [
     "SceneViewer",
     "SceneWidget",
-    "in_notebook",
     "in_marimo_notebook",
+    "in_notebook",
     "render_scene",
     "scene_to_html",
-    "scene_to_notebook",
-    "scene_to_mo_notebook"
-]
+    "scene_to_mo_notebook",
+    "scene_to_notebook"
 ]

--- a/trimesh/viewer/notebook.py
+++ b/trimesh/viewer/notebook.py
@@ -143,7 +143,7 @@ def scene_to_mo_notebook(scene, height=500, **kwargs):
     # escape the quotes in the HTML
     srcdoc = as_html.replace('"', "&quot;")
 
-    # Embed as srcdoc attr of IFrame, using mo.iframe 
+    # Embed as srcdoc attr of IFrame, using mo.iframe
     # turns out displaying an empty image. Likely
     # similar to  display.IFrame
     embedded = mo.Html(" ".join(

--- a/trimesh/viewer/notebook.py
+++ b/trimesh/viewer/notebook.py
@@ -3,7 +3,7 @@ notebook.py
 -------------
 
 Render trimesh.Scene objects in HTML
-and jupyter notebooks using three.js
+and jupyter and marimo notebooks using three.js
 """
 
 import base64
@@ -115,5 +115,52 @@ def in_notebook():
 
         return notebook
 
+    except BaseException:
+        return False
+
+def scene_to_mo_notebook(scene, height=500, **kwargs):
+    """
+    Convert a scene to HTML containing embedded geometry
+    and a three.js viewer that will display nicely in
+    an Marimo notebook.
+
+    Parameters
+    -------------
+    scene : trimesh.Scene
+      Source geometry
+
+    Returns
+    -------------
+    html : mo.Html
+      Object containing rendered scene
+    """
+    # keep as soft dependency
+    import marimo as mo
+
+    # convert scene to a full HTML page
+    as_html = scene_to_html(scene=scene)
+
+    # escape the quotes in the HTML
+    srcdoc = as_html.replace('"', "&quot;")
+
+    # Embed as srcdoc attr of IFrame, using mo.iframe 
+    # turns out displaying an empty image. Likely
+    # similar to  display.IFrame
+    embedded = mo.Html(" ".join(
+            [
+                '<div><iframe srcdoc="{srcdoc}"',
+                'width="100%" height="{height}px"',
+                'style="border:none;"></iframe></div>',
+            ]
+        ).format(srcdoc=srcdoc, height=height))
+
+    return embedded
+
+
+
+def in_marimo_notebook():
+    try:
+        import marimo as mo
+        return mo.running_in_notebook()
     except BaseException:
         return False


### PR DESCRIPTION
Added support for Marimo notebooks. Similar to Jupyter/IPython.

Ran a simple test on my branch using marimo (`uv run marimo edit` and built file).

<img width="844" alt="image" src="https://github.com/user-attachments/assets/4cbe7891-089f-46e9-bc83-edaf79556b49" />

This'll also facilitate simpler (and the "only" one from Python today) 3D object/mesh display for Marimo as is discussed in https://github.com/marimo-team/marimo/issues/544