### PR TITLE
Make merge_vertices consistent regardless of caching normals

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -47,6 +47,26 @@ class MargeTest(g.unittest.TestCase):
         assert copied.euler_number == 2
         assert copied.referenced_vertices.sum() == 8
 
+    def test_caching(self):
+        box = g.trimesh.util.concatenate([g.trimesh.creation.box(), g.trimesh.creation.box().apply_translation([1.000002, 0, 0])])
+
+        # Check for consistent behavior
+        for n_vertices, merge_norm in ((16, False), (12, True)):
+            box_1 = box.copy()
+            box_1.merge_vertices(digits_vertex=5, merge_norm=merge_norm)
+            assert len(box_1.vertices) == n_vertices
+
+            box_2 = box.copy()
+            box_2.vertex_normals
+            box_2.merge_vertices(digits_vertex=5, merge_norm=merge_norm)
+            assert len(box_2.vertices) == n_vertices
+
+            box_3 = box.copy()
+            box_3.vertex_normals
+            box_3._cache.delete('vertex_normals')
+            box_3.merge_vertices(digits_vertex=5, merge_norm=merge_norm)
+            assert len(box_3.vertices) == n_vertices
+
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -92,6 +92,8 @@ def merge_vertices(
 
     # check to see if we have vertex normals
     normals = mesh._cache["vertex_normals"]
+    if normals is None:
+        normals = mesh.vertex_normals
     if not merge_norm and np.shape(normals) == mesh.vertices.shape:
         stacked.append(normals * (10**digits_norm))
 


### PR DESCRIPTION
`merge_vertices` acts differently depending on whether vertex normals have been cached or not, see https://github.com/mikedh/trimesh/blob/cc0d3231814d3afe5c0a693d77f4f840668da1a7/trimesh/grouping.py#L94

To have consistent behaviour the vertex normals are now computed if they are not in cache and added to the stack if `merge_norm` is `False`. That way the added unit test is passing.

This fix can't be merged as is because it seems to have some side effects and unit tests are failing. I still opened this pull request because it seems to me that `merge_vertices` should not depend on whether something is in the cache or not. 

@mikedh  Please feel free to make any modifications or close this pull request.