### PR TITLE
Publish package using official GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
     name: Release To PyPi
     needs: [tests, containers, corpus]
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/trimesh
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -65,14 +70,12 @@ jobs:
     - name: Install publishing dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        pip install build
+    - name: Build
       run: |
         pyproject-build --outdir dist .
-        twine upload dist/*
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
 
   containers:
     name: Build Docker Images


### PR DESCRIPTION
Trusted publishing (with attestations) means I can know for certain that what I download from PyPI is the same artefact which was generated in GitHub CI, meaning that what I see in GitHub is the same as what is installed - handy for auditing (rather than having to manually review all of the installed files on each release).

See [the Python packaging documentation](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing) and [the official pypi-publish GitHub action documentation](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing) on trusted publishing - you'll need to configure an environment in PyPI and GitHub. You will be able to remove the `PYPI_TOKEN` project secret.