### PR TITLE
Full resolution is maintained when saving an image of the scene

### DIFF
--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -1053,7 +1053,7 @@ class Scene(Geometry3D):
         """
         from ..viewer.windowed import render_scene
 
-        return render_scene(scene=self, resolution=resolution, **kwargs)
+        return render_scene(scene=self, resolution=resolution, fullscreen=False, resizable=False, **kwargs)
 
     @property
     def units(self) -> Optional[str]:

--- a/trimesh/viewer/windowed.py
+++ b/trimesh/viewer/windowed.py
@@ -41,6 +41,8 @@ class SceneViewer(pyglet.window.Window):
         flags=None,
         visible=True,
         resolution=None,
+        fullscreen=False,
+        resizable=True
         start_loop=True,
         callback=None,
         callback_period=None,
@@ -71,6 +73,10 @@ class SceneViewer(pyglet.window.Window):
           Display window or not
         resolution : (2,) int
           Initial resolution of window
+        fullscreen : bool
+            Determines whether the window is rendered in fullscreen mode.
+        resizable : bool
+            Determines whether the rendered window can be resized by the user.
         start_loop : bool
           Call pyglet.app.run() at the end of init
         callback : function
@@ -173,7 +179,8 @@ class SceneViewer(pyglet.window.Window):
                 super().__init__(
                     config=conf,
                     visible=visible,
-                    resizable=True,
+                    fullscreen=fullscreen,
+                    resizable=resizable,
                     width=resolution[0],
                     height=resolution[1],
                     caption=caption,
@@ -182,7 +189,8 @@ class SceneViewer(pyglet.window.Window):
                 conf = gl.Config(double_buffer=True)
                 super().__init__(
                     config=conf,
-                    resizable=True,
+                    fullscreen=fullscreen,
+                    resizable=resizable,
                     visible=visible,
                     width=resolution[0],
                     height=resolution[1],
@@ -192,7 +200,8 @@ class SceneViewer(pyglet.window.Window):
             # window config was manually passed
             super().__init__(
                 config=window_conf,
-                resizable=True,
+                fullscreen=fullscreen,
+                resizable=resizable,
                 visible=visible,
                 width=resolution[0],
                 height=resolution[1],
@@ -861,7 +870,7 @@ def _geometry_hash(geometry):
     return h
 
 
-def render_scene(scene, resolution=None, visible=True, **kwargs):
+def render_scene(scene, resolution=None, visible=True, fullscreen=False, resizable=True, **kwargs):
     """
     Render a preview of a scene to a PNG. Note that
     whether this works or not highly variable based on
@@ -878,6 +887,12 @@ def render_scene(scene, resolution=None, visible=True, **kwargs):
       platforms refuse to render with hidden windows
       and will likely return a blank image; this is a
       platform issue and cannot be fixed in Python.
+    fullscreen : bool
+      Determines whether the window is rendered in fullscreen mode.
+      Defaults to False (windowed).
+    resizable : bool
+      Determines whether the rendered window can be resized by the user.
+      Defaults to True (resizable).
     kwargs : **
       Passed to SceneViewer
 
@@ -887,7 +902,7 @@ def render_scene(scene, resolution=None, visible=True, **kwargs):
       Image in PNG format
     """
     window = SceneViewer(
-        scene, start_loop=False, visible=visible, resolution=resolution, **kwargs
+        scene, start_loop=False, visible=visible, resolution=resolution, fullscreen=fullscreen, resizable=resizable, **kwargs
     )
 
     from ..util import BytesIO


### PR DESCRIPTION
This pull request addresses an issue where the `render_scene` function, when used in the `save_image` method, could produce images with unexpected resolutions. This occurred because the rendering window was being maximized by default, which, in cases where the specified resolution exceeded the display's native resolution, would result in the image being rendered at the display's resolution. Additionally, the window was resizable, allowing users to accidentally alter the intended resolution.

**Key Changes:**

* **Disabled automatic maximization:** The `fullscreen` parameter in `render_scene` is now set to `False` by default within the `save_image` context. This ensures that the rendering window adheres to the provided `resolution` parameter, even if it's higher than the display resolution.
* **Disabled window resizing:** The `resizable` parameter in `render_scene` is now set to `False` by default within the `save_image` context. This prevents users from manually resizing the rendering window and potentially distorting the dimensions of the captured image.

**Rationale:**

These changes ensure that the `save_image` method produces images with the exact resolution specified by the user, regardless of the display's native resolution. This provides greater control and predictability over the output image dimensions.

**Important Note:**

These changes exclusively affect the behavior of `render_scene` when called by the `save_image` method. The `show` method retains its original behavior, allowing for window maximization and resizing.
