### PR TITLE
fix check_volume variable propogation during mesh boolean operations

### DIFF
--- a/trimesh/boolean.py
+++ b/trimesh/boolean.py
@@ -45,6 +45,7 @@ def difference(
     """
     if check_volume and not all(m.is_volume for m in meshes):
         raise ValueError("Not all meshes are volumes!")
+    kwargs.update({"check_volume": check_volume})
 
     return _engines[engine](meshes, operation="difference", **kwargs)
 
@@ -75,6 +76,7 @@ def union(
     """
     if check_volume and not all(m.is_volume for m in meshes):
         raise ValueError("Not all meshes are volumes!")
+    kwargs.update({"check_volume": check_volume})
 
     return _engines[engine](meshes, operation="union", **kwargs)
 
@@ -105,6 +107,8 @@ def intersection(
     """
     if check_volume and not all(m.is_volume for m in meshes):
         raise ValueError("Not all meshes are volumes!")
+    kwargs.update({"check_volume": check_volume})
+
     return _engines[engine](meshes, operation="intersection", **kwargs)
 
 

--- a/trimesh/interfaces/blender.py
+++ b/trimesh/interfaces/blender.py
@@ -43,6 +43,7 @@ def boolean(
     use_exact: bool = False,
     use_self: bool = False,
     debug: bool = False,
+    check_volume: bool = True,
 ):
     """
     Run a boolean operation with multiple meshes using Blender.
@@ -59,6 +60,10 @@ def boolean(
       Whether to consider self-intersections.
     debug
       Provide additional output for troubleshooting.
+    check_volume
+      Raise an error if not all meshes are watertight
+      positive volumes. Advanced users may want to ignore
+      this check as it is expensive.
 
     Returns
     ----------
@@ -67,6 +72,9 @@ def boolean(
     """
     if not exists:
         raise ValueError("No blender available!")
+    if check_volume and not all(m.is_volume for m in meshes):
+        raise ValueError("Not all meshes are volumes!")
+
     operation = str.upper(operation)
     if operation == "INTERSECTION":
         operation = "INTERSECT"


### PR DESCRIPTION
This pull request provides a patch fix for the bug reported in issue #2253 by including two changes:

- Adding the check_volume variable to the `kwargs` of the boolean operations for propogation.
- Introducing a volume validity check for the Blender engine, similar to the one used prior to calling the Manifold engine.