### PR TITLE
Added remove_internal_faces parameter to multibox function

### DIFF
--- a/tests/test_multibox.py
+++ b/tests/test_multibox.py
@@ -1,0 +1,47 @@
+try:
+    from . import generic as g
+except BaseException:
+    import generic as g
+
+
+class MultiboxTest(g.unittest.TestCase):
+    def test_multibox_internal_face_removal(self):
+        np = g.np
+
+        # Create a small 2 * 2 * 2 binary voxelgrid
+        voxelgrid = np.ones((2, 2, 2), dtype=bool)
+        indices = np.argwhere(voxelgrid)
+        points = g.trimesh.voxel.ops.indices_to_points(indices)
+
+        # With internal faces (remove_internal_faces=False)
+        mesh_w_internal_faces = g.trimesh.voxel.ops.multibox(
+            points, pitch=1.0, remove_internal_faces=False
+        )
+
+        # Without internal faces (remove_internal_faces=True)
+        mesh_wo_internal_faces = g.trimesh.voxel.ops.multibox(
+            points, pitch=1.0, remove_internal_faces=True
+        )
+        self.assertLess(
+            len(mesh_wo_internal_faces.faces), len(mesh_w_internal_faces.faces)
+        )
+
+        # Check bounding boxes are equal
+        g.np.testing.assert_allclose(
+            mesh_w_internal_faces.bounds, mesh_wo_internal_faces.bounds
+        )
+
+        # A 2 * 2 * 2 voxelgrid constitutes 8 voxels
+        # Each voxel has 6 sides, with 2 triangular faces per side, totaling 6 * 2 = 12 triangular faces
+        # 8 voxels * 12 triangular faces = 96 triangluar faces (when all the internal faces kept)
+        self.assertEqual(len(mesh_w_internal_faces.faces), 96)
+
+        # A 2 * 2 * 2 block has 6 exposed sides (i.e., top, bottom, front, back, left, right)
+        # Each exposed side has 4 sub-sides corresponding to the 4 voxels, with 2 triangular faces per sub-side, totaling 4 * 2 = 8 triangular faces
+        # 6 exposed sides * 8 triangular face = 48 triangular faces (when all the internal faces removed)
+        self.assertEqual(len(mesh_wo_internal_faces.faces), 48)
+
+
+if __name__ == "__main__":
+    g.trimesh.util.attach_to_log()
+    g.unittest.main()


### PR DESCRIPTION
By default, the `trimesh.voxel.ops.multibox` function returns a Trimesh object with a box at every voxel tenter. However, boxes corresponding to adjacent voxel centers share redundant internal faces. This pull request modifies the this function  by adding the optional boolean `remove_internal_faces` parameter that removes internal faces between adjacent voxels (boxes), resulting in a more lightweight geometry useful for exporting and visualization.

**Notes:**
- Added `remove_internal_faces` param to `trimesh.voxel.ops.multibox`
    - When set to `False` (default), existing behavior is preserved (all faces included).
    - When set to `True`, shared faces between neighboring boxes are excluded from the output mesh.
- Added a corresponding unit test (`test_multibox.py`) for a 2 **3 binary voxel grid.
- All operations on face or vertex arrays implemented with vectorized numpy operations.
- This pull request maintains full backward compatibility.