### PR TITLE
Fixes a bug where dict_to_path raises an AttributeError when trying to define Line objects

### DIFF
--- a/trimesh/path/exchange/misc.py
+++ b/trimesh/path/exchange/misc.py
@@ -29,8 +29,13 @@ def dict_to_path(as_dict):
     entities = [None] * len(as_dict["entities"])
     # run constructor for dict kwargs
     for entity_index, entity in enumerate(as_dict["entities"]):
+      if entity["type"] == 'Line':
         entities[entity_index] = loaders[entity["type"]](
-            points=entity["points"], closed=entity["closed"]
+          points=entity["points"]
+        )
+      else:
+        entities[entity_index] = loaders[entity["type"]](
+          points=entity["points"], closed=entity["closed"]
         )
     result["entities"] = entities
 


### PR DESCRIPTION
This change resolves https://github.com/mikedh/trimesh/issues/2303