### PR TITLE
Robustify DAE shininess parsing

### DIFF
--- a/models/cube_invalid_shininess.dae
+++ b/models/cube_invalid_shininess.dae
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <library_effects>
+    <effect id="Material-effect">
+      <profile_COMMON>
+        <technique sid="common">
+          <phong>
+            <emission>
+              <color sid="emission">0 0 0 1</color>
+            </emission>
+            <ambient>
+              <color sid="ambient">0 0 0 1</color>
+            </ambient>
+            <diffuse>
+              <color sid="diffuse">0 0.05155162 0.3791305 1</color>
+            </diffuse>
+            <specular>
+              <color sid="specular">0.5 0.5 0.5 1</color>
+            </specular>
+            <shininess>
+              <color>0.000000</color>
+            </shininess>
+            <index_of_refraction>
+              <float sid="index_of_refraction">1</float>
+            </index_of_refraction>
+          </phong>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_materials>
+    <material id="Material-material" name="Material">
+      <instance_effect url="#Material-effect"/>
+    </material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="Cube-mesh" name="Cube">
+      <mesh>
+        <source id="Cube-mesh-positions">
+          <float_array id="Cube-mesh-positions-array" count="24">1 1 -1 1 -1 -1 -1 -0.9999998 -1 -0.9999997 1 -1 1 0.9999995 1 0.9999994 -1.000001 1 -1 -0.9999997 1 -1 1 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-positions-array" count="8" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube-mesh-normals">
+          <float_array id="Cube-mesh-normals-array" count="36">0 0 -1 0 0 1 1 0 -2.38419e-7 0 -1 -4.76837e-7 -1 2.38419e-7 -1.49012e-7 2.68221e-7 1 2.38419e-7 0 0 -1 0 0 1 1 -5.96046e-7 3.27825e-7 -4.76837e-7 -1 0 -1 2.38419e-7 -1.19209e-7 2.08616e-7 1 0</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-normals-array" count="12" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="Cube-mesh-vertices">
+          <input semantic="POSITION" source="#Cube-mesh-positions"/>
+        </vertices>
+        <triangles material="Material-material" count="12">
+          <input semantic="VERTEX" source="#Cube-mesh-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#Cube-mesh-normals" offset="1"/>
+          <p>0 0 2 0 3 0 7 1 5 1 4 1 4 2 1 2 0 2 5 3 2 3 1 3 2 4 7 4 3 4 0 5 7 5 4 5 0 6 1 6 2 6 7 7 6 7 5 7 4 8 5 8 1 8 5 9 6 9 2 9 2 10 6 10 7 10 0 11 3 11 7 11</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_controllers/>
+  <library_visual_scenes>
+    <visual_scene id="Scene" name="Scene">
+      <node id="Cube" name="Cube" type="NODE">
+        <matrix sid="transform">1 0 0 -0.1477693 0 1 0 -0.2537472 0 0 1 0.06556333 0 0 0 1</matrix>
+        <instance_geometry url="#Cube-mesh" name="Cube">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="Material-material" target="#Material-material"/>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#Scene"/>
+  </scene>
+</COLLADA>

--- a/tests/test_dae.py
+++ b/tests/test_dae.py
@@ -88,6 +88,14 @@ class DAETest(g.unittest.TestCase):
         # this will compare everything in `material._data`
         assert hash(m.visual.material) == hash(r.visual.material)
 
+    def test_invalid_shininess(self):
+        s = g.get_mesh("cube_invalid_shininess.dae")
+        assert len(s.geometry) == 1
+        m = next(iter(s.geometry.values()))
+
+        # test fallback to default roughness
+        assert m.visual.material.roughnessFactor == 1.0
+
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/trimesh/exchange/dae.py
+++ b/trimesh/exchange/dae.py
@@ -327,7 +327,13 @@ def _parse_material(effect, resolver):
         not isinstance(effect.shininess, collada.material.Map)
         and effect.shininess is not None
     ):
-        roughnessFactor = np.sqrt(2.0 / (2.0 + effect.shininess))
+        try:
+            shininess_value = float(effect.shininess)
+            roughnessFactor = np.sqrt(2.0 / (2.0 + shininess_value))
+        except (TypeError, ValueError):
+            log.warning(
+                f"Invalid shininess value: {effect.shininess}, using default roughness"
+            )
 
     # Compute metallic factor
     metallicFactor = 0.0


### PR DESCRIPTION
I found a lot of online .dae files with invalid `shininess` values. Parsers like `MeshLab` successfully ignore these values and I think `trimesh` should do the same.

As an example, the files from [ArtVIP](https://huggingface.co/datasets/x-humanoid-robomind/ArtVIP) contain these invalid shininess values:
```xml
<shininess>
  <color>0.000000</color>
</shininess>
```
The original code failed with a runtime error: `TypeError: unsupported operand type(s) for +: 'float' and 'tuple'`.
The updated code succeeds and prints the following: `Invalid shininess value: (0.0, 0.0, 0.0, 1.0), using default roughness`