### PR TITLE
Fix texture parsing for absolute paths & ambient=0

### DIFF
--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -143,6 +143,8 @@ class FilePathResolver(Resolver):
         # load the file by path name
         path = os.path.join(self.parent, name.strip())
         if not os.path.exists(path):
+            path = os.path.join(self.parent, name.strip().lstrip('/'))
+        if not os.path.exists(path):
             path = os.path.join(self.parent, os.path.split(name)[-1])
         with open(path, "rb") as f:
             data = f.read()

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -577,6 +577,9 @@ def to_rgba(colors: Any, dtype: DTypeLike = np.uint8) -> NDArray:
     """
     if colors is None:
         return DEFAULT_COLOR
+    # if MTL uses 0 as None
+    if isinstance(colors, (int, float)) and colors == 0:
+        return DEFAULT_COLOR
 
     # colors as numpy array
     colors = np.asanyarray(colors)


### PR DESCRIPTION
We have the following MTL definition that we need to read:

```
newmtl Material_0
	map_Kd /textures/A738B485_DA88_42F8_A49F_8643E7FC47F2.jpg
	Ka 0
	Ks 0
	ao 0
	subsurface 0
	metallic 0
	specularTint 0
	roughness 1
	anisotropicRotation 0
	sheen 0
	sheenTint 0
	clearCoat 0
	clearCoatGloss 0
```

but Trimesh fails to read it in two different instances.

1. The relative path /textures/A738B485_DA88_42F8_A49F_8643E7FC47F2.jpg starts with a leading / so path.join does not work here. e.g. `map_Kd /textures/A738B485_DA88_42F8_A49F_8643E7FC47F2.jpg` even with a parent path like /Users/paul/Downloads/0FABEEBE-68BE-4F36-A268-CAE2853D08A8 it would not become /Users/paul/Downloads/0FABEEBE-68BE-4F36-A268-CAE2853D08A8/textures/A738B485_DA88_42F8_A49F_8643E7FC47F2.jpg but just /textures/A738B485_DA88_42F8_A49F_8643E7FC47F2.jpg because of the leading /

2. Sometimes in the MTL you have a definition like  "Ka 0" which means no ambient light, but the parsing here fail, because it expects a RGB color definition, instead of a simple number.