### PR TITLE
Feature: Only Attach To Parent Loggers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.8"
-version = "4.7.1"
+version = "4.7.2"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -906,28 +906,13 @@ def attach_to_log(
     }
 
     if only_parent:
-        # if we have loggers `kerfed`, `kerfed.sub1`, `kerfed.sub2`
-        # this will only attach to `kerfed` and not the sub-loggers
-
         # create a new dict to store only parent loggers
         parent_loggers = {}
-
         # sort logger names to process in hierarchical order
-        sorted_names = sorted(loggers.keys())
-
-        for name in sorted_names:
-            logger = loggers[name]
-            # check if this logger is a child of any existing parent logger
-            is_child = False
-            for parent_name in parent_loggers.keys():
-                if name.startswith(parent_name + "."):
-                    is_child = True
-                    break
-
+        for name in sorted(loggers.keys()):
             # if it's not a child of any existing parent, add it as a parent
-            if not is_child:
-                parent_loggers[name] = logger
-
+            if not any(name.startswith(f"{p}.") for p in parent_loggers.keys()):
+                parent_loggers[name] = loggers[name]
         # replace loggers dict with only parent loggers
         loggers = parent_loggers
 

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -810,10 +810,11 @@ def decimal_to_digits(decimal, min_digits=None) -> int:
 def attach_to_log(
     level=logging.DEBUG,
     handler=None,
-    loggers=None,
-    colors=True,
-    capture_warnings=True,
-    blacklist=None,
+    loggers: Optional[Iterable[logging.Logger]] = None,
+    colors: bool = True,
+    capture_warnings: bool = True,
+    blacklist: Optional[Iterable] = None,
+    only_parent: bool = False,
 ):
     """
     Attach a stream handler to all loggers.
@@ -830,6 +831,9 @@ def attach_to_log(
       If True try to use colorlog formatter
     blacklist : (n,) str
       Names of loggers NOT to attach to
+    only_parent
+      Only attach to parent loggers, i.e. `trimesh`, `trimesh.sub1`, `trimesh.sub2`
+      will only attach to `trimesh` and not the sub-loggers
     """
 
     # default blacklist includes ipython debugging stuff
@@ -885,19 +889,50 @@ def attach_to_log(
     if loggers is None:
         # de-duplicate loggers using a set
         loggers = set(logging.Logger.manager.loggerDict.values())
+
     # add the warnings logging
     loggers.add(logging.getLogger("py.warnings"))
 
     # disable pyembree warnings
     logging.getLogger("pyembree").disabled = True
 
+    # cull loggers that are not actually loggers or are on the blacklist
+    loggers = {
+        L.name: L
+        for L in loggers
+        if hasattr(L, "name")
+        and isinstance(L, logging.Logger)
+        and L.name not in blacklist
+    }
+
+    if only_parent:
+        # if we have loggers `kerfed`, `kerfed.sub1`, `kerfed.sub2`
+        # this will only attach to `kerfed` and not the sub-loggers
+
+        # create a new dict to store only parent loggers
+        parent_loggers = {}
+
+        # sort logger names to process in hierarchical order
+        sorted_names = sorted(loggers.keys())
+
+        for name in sorted_names:
+            logger = loggers[name]
+            # check if this logger is a child of any existing parent logger
+            is_child = False
+            for parent_name in parent_loggers.keys():
+                if name.startswith(parent_name + "."):
+                    is_child = True
+                    break
+
+            # if it's not a child of any existing parent, add it as a parent
+            if not is_child:
+                parent_loggers[name] = logger
+
+        # replace loggers dict with only parent loggers
+        loggers = parent_loggers
+
     # loop through all available loggers
-    for logger in loggers:
-        # skip loggers on the blacklist
-        if logger.__class__.__name__ != "Logger" or any(
-            logger.name.startswith(b) for b in blacklist
-        ):
-            continue
+    for logger in loggers.values():
         logger.addHandler(handler)
         logger.setLevel(level)
 


### PR DESCRIPTION
In `trimesh.util.attach_to_log(only_parent=True) if you have loggers for `project`, `project.other`, `project.other2`, this will only attach to `project. By default it is off so it shouldn't change upstream behavior.

We should also probably be doing instead of `from .util import log`, `log = getLogger(__name__)` everywhere. 
