### PR TITLE
Hotfix: Remove a warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.8"
-version = "4.7.3"
+version = "4.7.4"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/trimesh/exchange/gltf.py
+++ b/trimesh/exchange/gltf.py
@@ -1728,7 +1728,7 @@ def _read_buffers(
     base_frame = "world"
     if base_frame in name_index:
         # todo : handle this?
-        log.warning("file contains a `world` node, we may stomp on it")
+        log.debug("file contains a `world` node, we may stomp on it")
     names[base_frame] = base_frame
 
     # visited, kwargs for scene.graph.update


### PR DESCRIPTION
GLTF files with a node named "world" were warning, which is not necessary. This changes the warning to a debug. 