### PR TITLE
utils.concatenate now also concats vert and face attributes

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -155,6 +155,8 @@ class UtilTests(unittest.TestCase):
         meshes = []
         for _i in range(count):
             m = a.copy()
+            m.vertex_attributes["test"] = np.arange(len(m.vertices))
+            m.face_attributes["test"] = np.arange(len(m.faces))
             m.apply_translation([a.scale, 0, 0])
             meshes.append(m)
 
@@ -162,6 +164,8 @@ class UtilTests(unittest.TestCase):
         r = g.trimesh.util.concatenate(meshes)
         assert g.np.isclose(r.volume, a.volume * count)
         assert a.__hash__() == hA
+        assert r.vertex_attributes["test"].shape[0] == len(r.vertices)
+        assert r.face_attributes["test"].shape[0] == len(r.faces)
 
     def test_concat_vertex_normals(self):
         # vertex normals should only be included if they already exist

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1489,6 +1489,28 @@ def concatenate(
     except BaseException:
         pass
 
+    vertex_attributes = {}
+    # concatenate vertex attributes
+    keys = is_mesh[0].vertex_attributes.keys()
+    # if all meshes have the same vertex attributes
+    if len(keys) > 0 and all(
+        all(key in mesh.vertex_attributes for key in keys) for mesh in is_mesh[1:]
+    ):
+        for key in keys:
+            vertex_attributes[key] = np.concatenate(
+                [mesh.vertex_attributes[key] for mesh in is_mesh], axis=0
+            )
+
+    face_attributes = {}
+    # concatenate face attributes
+    keys = is_mesh[0].face_attributes.keys()
+    # if all meshes have the same face attributes
+    if all(all(key in mesh.face_attributes for key in keys) for mesh in is_mesh[1:]):
+        for key in keys:
+            face_attributes[key] = np.concatenate(
+                [mesh.face_attributes[key] for mesh in is_mesh], axis=0
+            )
+
     # create the mesh object
     result = trimesh_type(
         vertices=vertices,
@@ -1496,6 +1518,8 @@ def concatenate(
         face_normals=face_normals,
         vertex_normals=vertex_normals,
         visual=visual,
+        vertex_attributes=vertex_attributes,
+        face_attributes=face_attributes,
         metadata=metadata,
         process=False,
     )


### PR DESCRIPTION
I hope this makes sense for trimesh as a whole. It would greatly improve ergonomics for me :)

This addition will only concatenate vertex and face attributes if all keys are found in all meshes. An alternative is discarding attributes that are not in all meshes and concatenating the rest. 