### PR TITLE
Fall back to linear_color_map if matplotlib is not available.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ easy = [
     "vhacdx; python_version>='3.9'",
     # old versions of mapbox_earcut produce incorrect values on numpy 2.0
     "mapbox_earcut >= 1.0.2; python_version>='3.9'",
+    "matplotlib",
 ]
 
 recommend = [

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -911,9 +911,12 @@ def interpolate(
     if color_map is None:
         cmap = linear_color_map
     else:
-        from matplotlib.pyplot import get_cmap
-
-        cmap = get_cmap(color_map)
+        try:
+            from matplotlib.pyplot import get_cmap
+            cmap = get_cmap(color_map)
+        except BaseException:
+            util.log.warning("matplotlib not available, falling back to linear_color_map")
+            cmap = linear_color_map
 
     # make input always float
     values = np.asanyarray(values, dtype=np.float64).ravel()


### PR DESCRIPTION
Resolve #2446 by falling back to [`linear_color_map`](https://github.com/mikedh/trimesh/blob/d8c75b576bf0c6c5c8e263956332b2e50bc2775e/trimesh/visual/color.py#L841) if `matplotlib` is not available.