### PR TITLE
Don't capture the whole exception in `ExceptionWrapper`

### DIFF
--- a/trimesh/exceptions.py
+++ b/trimesh/exceptions.py
@@ -18,7 +18,7 @@ class ExceptionWrapper:
     """
 
     def __init__(self, exception):
-        self.exception = exception
+        self.exception = (type(exception), exception.args)
 
     def __getattribute__(self, *args, **kwargs):
         # will raise when this object is accessed like an object
@@ -27,8 +27,10 @@ class ExceptionWrapper:
         if args[0] == "__class__":
             return None.__class__
         # otherwise raise our original exception
-        raise super().__getattribute__("exception")
+        exc_ty, exc_args = super().__getattribute__("exception")
+        raise exc_ty(*exc_args)
 
     def __call__(self, *args, **kwargs):
         # will raise when this object is called like a function
-        raise super().__getattribute__("exception")
+        exc_ty, exc_args = super().__getattribute__("exception")
+        raise exc_ty(*exc_args)


### PR DESCRIPTION
`ExceptionWrapper` currently preserves the original `BaseException` instance. Unfortunately, this also includes the exception's traceback, including all stack frames and their locals.

As several trimesh modules are lazily loaded (e.g. `trimesh.path.polygons`), this can permanently leak any locals that were on the stack when a trimesh function is first called.

We now store the exception type and its message/arguments, and recreate the exception when accessing attributes instead. This does mean some information from the original exception is lost, but sadly I don't think that's avoidable.
