### PR TITLE
Material fixes for `trimesh.util.concatenate()`

### DIFF
--- a/tests/test_pbr_concatenate.py
+++ b/tests/test_pbr_concatenate.py
@@ -1,0 +1,149 @@
+"""
+Test for PBR material concatenation bug fix.
+
+Tests that concatenating meshes with PBR materials preserves
+metallicFactor and roughnessFactor values and creates correct
+UV mappings for textures.
+"""
+
+try:
+    from . import generic as g
+except BaseException:
+    import generic as g
+
+
+class PBRConcatenateTest(g.unittest.TestCase):
+    def test_pbr_factors_preserved(self):
+        """
+        Test that metallicFactor and roughnessFactor are preserved
+        when concatenating meshes with PBR materials.
+
+        This tests the fix for the bug where these factors became None
+        after concatenation, causing meshes to appear shiny/metallic.
+        """
+        # Create two boxes with PBR materials
+        box1 = g.trimesh.creation.box(extents=[1, 1, 1])
+        mat1 = g.trimesh.visual.material.PBRMaterial(
+            baseColorFactor=[255, 51, 51, 255],  # Red
+            metallicFactor=0.0,
+            roughnessFactor=1.0,
+        )
+        box1.visual = g.trimesh.visual.TextureVisuals(material=mat1)
+
+        box2 = g.trimesh.creation.box(extents=[1, 1, 1])
+        mat2 = g.trimesh.visual.material.PBRMaterial(
+            baseColorFactor=[51, 255, 51, 255],  # Green
+            metallicFactor=0.0,
+            roughnessFactor=1.0,
+        )
+        box2.visual = g.trimesh.visual.TextureVisuals(material=mat2)
+        box2.apply_translation([1.5, 0, 0])
+
+        # Concatenate the meshes
+        merged = g.trimesh.util.concatenate([box1, box2])
+
+        # Check that the factors are NOT None (bug was they became None)
+        # They should be set to 1.0 when textures are created
+        assert merged.visual.material.metallicFactor is not None, (
+            "metallicFactor should not be None after concatenation"
+        )
+        assert merged.visual.material.roughnessFactor is not None, (
+            "roughnessFactor should not be None after concatenation"
+        )
+        
+        # When textures are created, factors should be 1.0
+        assert merged.visual.material.metallicFactor == 1.0
+        assert merged.visual.material.roughnessFactor == 1.0
+
+        # Check that textures were created
+        assert merged.visual.material.baseColorTexture is not None
+        assert merged.visual.material.metallicRoughnessTexture is not None
+
+    def test_pbr_uv_mapping(self):
+        """
+        Test that UV coordinates correctly map to material values
+        in the packed textures after concatenation.
+
+        This verifies the fix for UV coordinate calculation and
+        texture packing consistency.
+        """
+        # Create two boxes with different colors but same PBR values
+        box1 = g.trimesh.creation.box(extents=[0.5, 0.5, 0.5])
+        mat1 = g.trimesh.visual.material.PBRMaterial(
+            baseColorFactor=[255, 0, 0, 255],
+            metallicFactor=0.0,
+            roughnessFactor=1.0,
+        )
+        box1.visual = g.trimesh.visual.TextureVisuals(material=mat1)
+
+        box2 = g.trimesh.creation.box(extents=[0.5, 0.5, 0.5])
+        mat2 = g.trimesh.visual.material.PBRMaterial(
+            baseColorFactor=[0, 255, 0, 255],
+            metallicFactor=0.0,
+            roughnessFactor=1.0,
+        )
+        box2.visual = g.trimesh.visual.TextureVisuals(material=mat2)
+        box2.apply_translation([1, 0, 0])
+
+        # Concatenate
+        merged = g.trimesh.util.concatenate([box1, box2])
+
+        # Get the metallicRoughness texture
+        tex = g.np.array(merged.visual.material.metallicRoughnessTexture)
+
+        # Check that all UV coordinates map to the correct material values
+        # In glTF: Blue channel = metallic, Green channel = roughness
+        for u, v in merged.visual.uv:
+            # Convert UV to pixel coordinates
+            px = int(round(u * (tex.shape[1] - 1)))
+            py = int(round((1 - v) * (tex.shape[0] - 1)))
+
+            if 0 <= px < tex.shape[1] and 0 <= py < tex.shape[0]:
+                roughness = tex[py, px, 1]  # Green channel
+                metallic = tex[py, px, 2]  # Blue channel
+
+                # All vertices should map to roughness=255 (1.0) and metallic=0 (0.0)
+                assert roughness == 255, (
+                    f"UV ({u:.3f}, {v:.3f}) maps to wrong roughness: {roughness}"
+                )
+                assert metallic == 0, (
+                    f"UV ({u:.3f}, {v:.3f}) maps to wrong metallic: {metallic}"
+                )
+
+    def test_pbr_identical_materials(self):
+        """
+        Test that concatenating meshes with identical PBR materials
+        preserves the scalar values without creating textures.
+        """
+        # Create two boxes with identical materials
+        box1 = g.trimesh.creation.box(extents=[0.5, 0.5, 0.5])
+        mat1 = g.trimesh.visual.material.PBRMaterial(
+            baseColorFactor=[128, 128, 128, 255],
+            metallicFactor=0.5,
+            roughnessFactor=0.7,
+        )
+        box1.visual = g.trimesh.visual.TextureVisuals(material=mat1)
+
+        box2 = g.trimesh.creation.box(extents=[0.5, 0.5, 0.5])
+        mat2 = g.trimesh.visual.material.PBRMaterial(
+            baseColorFactor=[128, 128, 128, 255],  # Same color
+            metallicFactor=0.5,  # Same metallic
+            roughnessFactor=0.7,  # Same roughness
+        )
+        box2.visual = g.trimesh.visual.TextureVisuals(material=mat2)
+        box2.apply_translation([1, 0, 0])
+
+        # Concatenate
+        merged = g.trimesh.util.concatenate([box1, box2])
+
+        # When materials are identical, scalar values should be preserved
+        assert merged.visual.material.metallicFactor == 0.5
+        assert merged.visual.material.roughnessFactor == 0.7
+
+        # No metallicRoughness texture should be created for identical materials
+        assert merged.visual.material.metallicRoughnessTexture is None
+
+
+if __name__ == "__main__":
+    g.trimesh.util.attach_to_log()
+    g.unittest.main()

--- a/tests/test_pbr_concatenate.py
+++ b/tests/test_pbr_concatenate.py
@@ -14,12 +14,11 @@ except BaseException:
 
 class PBRConcatenateTest(g.unittest.TestCase):
     def test_pbr_factors_preserved(self):
-        """
-        Test that metallicFactor and roughnessFactor are preserved
-        when concatenating meshes with PBR materials.
+        """Test that metallicFactor and roughnessFactor are preserved when
+        concatenating meshes with PBR materials.
 
-        This tests the fix for the bug where these factors became None
-        after concatenation, causing meshes to appear shiny/metallic.
+        This tests the fix for the bug where these factors became None after
+        concatenation, causing meshes to appear shiny/metallic.
         """
         # Create two boxes with PBR materials
         box1 = g.trimesh.creation.box(extents=[1, 1, 1])
@@ -42,30 +41,18 @@ class PBRConcatenateTest(g.unittest.TestCase):
         # Concatenate the meshes
         merged = g.trimesh.util.concatenate([box1, box2])
 
-        # Check that the factors are NOT None (bug was they became None)
-        # They should be set to 1.0 when textures are created
-        assert merged.visual.material.metallicFactor is not None, (
-            "metallicFactor should not be None after concatenation"
-        )
-        assert merged.visual.material.roughnessFactor is not None, (
-            "roughnessFactor should not be None after concatenation"
-        )
-        
-        # When textures are created, factors should be 1.0
-        assert merged.visual.material.metallicFactor == 1.0
-        assert merged.visual.material.roughnessFactor == 1.0
+        # Factor are `None` because textures are created for metallicFactor and
+        # roughnessFactor
+        assert merged.visual.material.metallicFactor is None
+        assert merged.visual.material.roughnessFactor is None
 
         # Check that textures were created
         assert merged.visual.material.baseColorTexture is not None
         assert merged.visual.material.metallicRoughnessTexture is not None
 
     def test_pbr_uv_mapping(self):
-        """
-        Test that UV coordinates correctly map to material values
-        in the packed textures after concatenation.
-
-        This verifies the fix for UV coordinate calculation and
-        texture packing consistency.
+        """Test that UV coordinates correctly map to material values in the
+        packed textures after concatenation.
         """
         # Create two boxes with different colors but same PBR values
         box1 = g.trimesh.creation.box(extents=[0.5, 0.5, 0.5])
@@ -111,10 +98,8 @@ class PBRConcatenateTest(g.unittest.TestCase):
                 )
 
     def test_pbr_identical_materials(self):
-        """
-        Test that concatenating meshes with identical PBR materials
-        preserves the scalar values without creating textures.
-        """
+        """Test that concatenating meshes with identical PBR materials
+        preserves the scalar values without creating textures."""
         # Create two boxes with identical materials
         box1 = g.trimesh.creation.box(extents=[0.5, 0.5, 0.5])
         mat1 = g.trimesh.visual.material.PBRMaterial(

--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -811,6 +811,17 @@ def pack(
         )
         return Image.fromarray(img)
 
+    def lin2srgb(lin):
+        """
+        Converts linear color values to sRGB color values.
+        See: https://entropymine.com/imageworsener/srgbformula/
+        """
+        s = np.empty_like(lin)
+        mask = lin > 0.00313066844250063
+        s[mask] = 1.055 * np.power(lin[mask], (1.0 / 2.4)) - 0.055
+        s[~mask] = 12.92 * lin[~mask]
+        return s
+
     def get_base_color_texture(mat):
         """
         Logic for extracting a simple image from each material.
@@ -823,9 +834,20 @@ def pack(
                     mat.baseColorTexture, factor=mat.baseColorFactor, mode="RGBA"
                 )
             elif mat.baseColorFactor is not None:
-                c = color.to_rgba(mat.baseColorFactor)
+                # Per glTF 2.0 spec (https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html):
+                # - baseColorFactor: "defines linear multipliers for the sampled texels"
+                # - baseColorTexture: "RGB components MUST be encoded with the sRGB transfer function"
+                #
+                # Therefore when creating a texture from baseColorFactor values,
+                # we need to convert from linear to sRGB space
+                c_linear = color.to_float(mat.baseColorFactor).reshape(4)
+
+                # Apply proper sRGB gamma correction to RGB channels
+                c_srgb = np.concatenate([lin2srgb(c_linear[:3]), c_linear[3:4]])
+
+                # Convert to uint8
+                c = np.round(c_srgb * 255).astype(np.uint8)
                 assert c.shape == (4,)
-                assert c.dtype == np.uint8
                 img = color_image(c)
 
             if img is not None and mat.alphaMode != "BLEND":


### PR DESCRIPTION
Hi @mikedh!

We've been having some trouble with materials changing after I call `trimesh.util.concatenate()`.

Here's a code snippet to demonstrate. We create a red mesh, a green mesh, and a concatenated mesh:
```python
import numpy as np
import trimesh.util
from trimesh.creation import box
from trimesh.visual import TextureVisuals
from trimesh.visual.material import PBRMaterial


def make_boxes():
    red_box = box(extents=[1, 1, 1])
    red_box.visual = TextureVisuals(
        material=PBRMaterial(
            baseColorFactor=[1.0, 0.2, 0.2, 1.0],
            metallicFactor=0.0,
            roughnessFactor=1.0,
            emissiveFactor=[0.0, 0.0, 0.0],
        )
    )

    green_box = box(extents=[1, 1, 1])
    green_box.visual = TextureVisuals(
        material=PBRMaterial(
            baseColorFactor=np.array([0.2, 1.0, 0.2, 1.0], dtype=np.float32),
            metallicFactor=0.0,
            roughnessFactor=1.0,
            emissiveFactor=[0.0, 0.0, 0.0],
        )
    )
    green_box.apply_translation([1.5, 0, 0])

    both_boxes = trimesh.util.concatenate([red_box, green_box])

    return red_box, green_box, both_boxes
```

If we run this using a source install of trimesh, export, and visualize, here's what we get:

<img width="317" height="201" alt="image" src="https://github.com/user-attachments/assets/4c9f277a-902b-49f2-86cb-de079c8c2114" />

I spent some time investigating this. This PR contains some fixes:
- **Metallic-roughness texture channel order.** `metallic` is allocated to the blue channel of metallic-roughness textures [in the glTF2.0 spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#metallic-roughness-material). It was instead being written to the red.
- **Gamma correction for `baseColorFactor`.** `baseColorFactor` was being copied directly into `baseColorTexture`. The units are different, though: the former is a linear scaling term, but `baseColorTexture` should be encoded with an sRGB transfer function. I copy-and-pasted a conversion function from `gloss.py`; these are local in both files.
- **UV indexing errors caused by deduplication.** Textures were being independently deduplicated during concatenation. It looks like this was causing alignment issues when some textures were unique (red vs green color in the example) but others were duplicated (roughness/metallic in the example are same for both meshes).
    - This part has a lot of moving parts so I added some tests, which fail on `main` but pass with the deduplication fix.

Here are the fixed meshes after these changes:

<img width="447" height="391" alt="image" src="https://github.com/user-attachments/assets/c280d457-54ae-49d6-b371-5597ef94e3ef" />

---

For completeness, the screenshots above were taken using trimesh's glTF export, loaded using GLTFLoader in `three.js` and rendered also via `three.js`. This is the code I used:
```python
import viser  # three.js-based 3D visualizer we're working on!

server = viser.ViserServer()
red_box, green_box, both_boxes = make_boxes()
server.scene.add_mesh_trimesh("/both", both_boxes, position=(0, 2, 0))
server.scene.add_mesh_trimesh("/box1", red_box)
server.scene.add_mesh_trimesh("/box2", green_box)
server.sleep_forever()
```
