### PR TITLE
Fix formatting in `nricp_amberg`/`nricp_sumner` comparsion docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN uv venv --python=python3.13 venv
 ENV PATH="/home/user/venv/bin:$PATH"
 ENV VIRTUAL_ENV="/home/user/venv"
 # bash script that redirects `pip install X`->`uv pip install X`
-RUN echo "uv pip \$*" > /home/user/venv/bin/pip && \
+RUN echo '#!/bin/sh' > /home/user/venv/bin/pip && \
+    echo 'exec uv pip "$@"' >> /home/user/venv/bin/pip && \
     chmod +x /home/user/venv/bin/pip
 
 # Install helper script to PATH.

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ help: ## Print usage help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 .DEFAULT_GOAL := help
 
+# force amd64 builds on non-amd64 hosts (e.g. Apple Silicon)
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+
 # build the output stage image using buildkit
 .PHONY: build
 build: ## Build the docker images

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -452,14 +452,14 @@ def nricp_amberg(
     at the end of page 3 of the paper.
 
     Comparison between nricp_amberg and nricp_sumner:
-    * nricp_amberg fits to the target mesh in less steps
-    * nricp_amberg can generate sharp edges
-      * only vertices and their neighbors are considered
-    * nricp_sumner tend to preserve more the original shape
-    * nricp_sumner parameters are easier to tune
-    * nricp_sumner solves for triangle positions whereas
-      nricp_amberg solves for vertex transforms
-    * nricp_sumner is less optimized when wn > 0
+      * nricp_amberg fits to the target mesh in less steps
+      * nricp_amberg can generate sharp edges
+          * only vertices and their neighbors are considered
+      * nricp_sumner tend to preserve more the original shape
+      * nricp_sumner parameters are easier to tune
+      * nricp_sumner solves for triangle positions whereas
+        nricp_amberg solves for vertex transforms
+      * nricp_sumner is less optimized when wn > 0
 
     Parameters
     ----------
@@ -850,14 +850,14 @@ def nricp_sumner(
     Allows to register non-rigidly a mesh on another geometry.
 
     Comparison between nricp_amberg and nricp_sumner:
-    * nricp_amberg fits to the target mesh in less steps
-    * nricp_amberg can generate sharp edges (only vertices and their
-        neighbors are considered)
-    * nricp_sumner tend to preserve more the original shape
-    * nricp_sumner parameters are easier to tune
-    * nricp_sumner solves for triangle positions whereas nricp_amberg solves for
-        vertex transforms
-    * nricp_sumner is less optimized when wn > 0
+      * nricp_amberg fits to the target mesh in less steps
+      * nricp_amberg can generate sharp edges
+          * only vertices and their neighbors are considered
+      * nricp_sumner tend to preserve more the original shape
+      * nricp_sumner parameters are easier to tune
+      * nricp_sumner solves for triangle positions whereas
+        nricp_amberg solves for vertex transforms
+      * nricp_sumner is less optimized when wn > 0
 
     Parameters
     ----------


### PR DESCRIPTION
This fixes some formatting issues in the comparison lists under [`nricp_amberg`](https://trimesh.org/trimesh.registration.html#trimesh.registration.nricp_amberg) and [`nricp_sumner`](https://trimesh.org/trimesh.registration.html#trimesh.registration.nricp_sumner) methods in the documentation.

To get docs building locally I also had to make some changes to the Makefile and Dockerfile. I'm happy to remove these changes if they're for some reason specific to my environment, or if they'd fit better in a separate PR.

### Before (current):
<img width="765" height="495" alt="Screenshot 2025-09-22 at 11 43 56 AM" src="https://github.com/user-attachments/assets/67c57e18-c88f-4e7b-943a-a1d4f590770b" />

### After (this PR):
<img width="750" height="477" alt="Screenshot 2025-09-22 at 11 43 43 AM" src="https://github.com/user-attachments/assets/a0c60fd6-b46b-474d-95f7-ac049f7782d2" />
