### PR TITLE
Pass PBRMaterial name to SimpleMaterial during conversion

### DIFF
--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -683,7 +683,7 @@ class PBRMaterial(Material):
           Contains material information in a simple manner
         """
 
-        return SimpleMaterial(image=self.baseColorTexture, diffuse=self.baseColorFactor)
+        return SimpleMaterial(image=self.baseColorTexture, diffuse=self.baseColorFactor, name=self.name)
 
     @property
     def main_color(self):


### PR DESCRIPTION
Hi @mikedh!

Currently the name of PBRMaterial is lost when calling to_simple() which causes issues when exporting meshes with named materials in obj format. More specifically, the baseColorTexture will always be saved as an image with name ```material_0.png```, and I couldn't find any workaround to override this name; this means if saving two such meshes in the same directory, only the last texture image would be available.  I provided the simple fix to pass the name, but please let me know if there is an alternative. 

Thanks for the amazing library! 