### PR TITLE
Add optional name parameter to min_distance_internal

### DIFF
--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -181,6 +181,10 @@ class CollisionTest(g.unittest.TestCase):
         assert g.np.isclose(dist, 2.0)
         assert names == ("cube2", "cube3")
 
+        dist, names = m.min_distance_internal(name="cube1", return_names=True)
+        assert g.np.isclose(dist, 6.0)
+        assert names == ("cube1", "cube3")
+
         # Test manager-to-manager distance checking
         m = g.trimesh.collision.CollisionManager()
         m.add_object("cube0", cube)


### PR DESCRIPTION
Hi again @mikedh! ^^

Here a PR that extends `CollisionManager.min_distance_internal()` with an optional `name` parameter to compute distances from a specific object to all others.

### Changes
- Added `name=None` parameter to `min_distance_internal()`
- When `name` provided: computes distance from specified object to others
- When `name=None`: existing behavior (all pairs) unchanged
- Temporarily removes target object from manager to avoid self-distance calculation
- Added test check for new functionality

### Usage
```python
# Existing (unchanged)
distance = manager.min_distance_internal()

# New functionality  
distance = manager.min_distance_internal(name="my_object")
```