### PR TITLE
[OBJ] Allow splitting scenes by 'o' and 'g' tags

### DIFF
--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -65,6 +65,18 @@ def test_obj_groups():
     # check to make sure there is signal not just zeros
     # assert g.np.ptp(mesh.metadata['face_groups']) > 0
 
+def test_obj_groups_split():
+    # a wavefront file with groups defined
+    mesh = g.get_mesh("groups.obj", split_groups=True)
+
+    # make sure the right number of meshes are split
+    assert len(mesh.geometry) == 14
+
+    mesh = g.get_mesh("groups.obj", split_objects=True, split_groups=True)
+
+    # make sure the right number of meshes are split
+    assert len(mesh.geometry) == 14
+
 
 def test_obj_negative_indices():
     # a wavefront file with negative indices
@@ -89,7 +101,7 @@ def test_obj_quad():
 
 def test_obj_multiobj():
     # test a wavefront file with multiple objects in the same file
-    scene = g.get_mesh("two_objects.obj", split_object=True, group_material=False)
+    scene = g.get_mesh("two_objects.obj", split_objects=True, group_material=False)
     assert len(scene.geometry) == 2
 
     for mesh in scene.geometry.values():
@@ -108,7 +120,7 @@ def test_obj_split_attributes():
     scene = g.get_mesh(
         "joined_tetrahedra.obj",
         process=False,
-        split_object=True,
+        split_objects=True,
         group_material=False,
     )
 

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -177,10 +177,10 @@ def load_obj(
             faces, faces_tex, faces_norm = _parse_faces_fallback(face_lines)
 
         name = ""
-        if split_objects:
+        if split_objects and current_object is not None:
           name = current_object
         if split_groups:
-          if len(name) > 0:
+          if len(name) > 0 and current_group is not None:
             name += "_"
           name += current_group
         if group_material and len(materials) > 1:


### PR DESCRIPTION
Allow splitting obj files on 'o' and 'g' tags, where previously meshes could only be split by material before. This allows for an obj file with multiple objects and groups to be converted into a scene with multiple meshes.


Fixes #2413