### PR TITLE
Remove additional faces from trimesh.creation.revolve output

### DIFF
--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -138,9 +138,9 @@ def revolve(
     # this is a superset which will then be reduced
     quad = np.array([0, per, 1, 1, per, per + 1])
     # stack the faces for a single slice of the revolution
-    single = np.tile(quad, per).reshape((-1, 3))
+    single = np.tile(quad, per - 1).reshape((-1, 3))
     # `per` is basically the stride of the vertices
-    single += np.tile(np.arange(per), (2, 1)).T.reshape((-1, 1))
+    single += np.tile(np.arange(per - 1), (2, 1)).T.reshape((-1, 1))
     # remove any zero-area triangle
     # this covers many cases without having to think too much
     single = single[triangles.area(vertices[single]) > tol.merge]


### PR DESCRIPTION
The function `trimesh.creation.revolve` produces an additional set of faces linking the points at the beginning and at the end of the provided line.

For example running this snippet, the assertion fails because 48 faces are produced, i.e. 2*sections more than the expected number
```python
import trimesh.creation
import numpy as np

line = np.array([[1.0, 0.0], [1.0, 1.0], [1.0, 2.0], [1.0, 3.0]])
t = trimesh.creation.revolve(line, cap=False, sections=6)
assert t.vertices.shape == (24, 3)
assert t.faces.shape == (36, 3)
```

Viewing the mesh in MeshLab we can notice the presence of problematic faces.
<img width="562" height="692" alt="Screenshot 2025-11-11 alle 19 10 08" src="https://github.com/user-attachments/assets/4a93e77e-2227-4398-b2df-e7917d7e442e" />

This PR fixes the problem by avoiding the creation of the spurious faces, recovering the expected result.
<img width="514" height="689" alt="Screenshot 2025-11-11 alle 19 11 03" src="https://github.com/user-attachments/assets/47ea90c4-fa75-4c68-8997-064d65e59f60" />