### PR TITLE
center of mass for flat meshes

### DIFF
--- a/trimesh/triangles.py
+++ b/trimesh/triangles.py
@@ -292,8 +292,8 @@ def mass_properties(
 
     if center_mass is None:
         if np.abs(volume) < tol.zero:
-            # if there is no volume set center of mass to the origin
-            center_mass = np.zeros(3, dtype=np.float64)
+            # if there is no volume set center of mass to the centroid
+            center_mass = np.average(f1 / 3.0, weights=area(triangles, crosses), axis=0)
         else:
             # otherwise get it from the integration
             center_mass = integrated[1:4] / volume


### PR DESCRIPTION
The current calculation of the center of mass returns always the origin for flat meshes. This PR replaces the origin with the centroid of the mesh that is the best estimate of the center of mass for an infinitely thin homogenous flat mesh.

For example, running the script
```python
import numpy as np
import trimesh

# Square [100,101] x [100,101] in the XY plane
vertices = np.array([[100, 100, 0], [101, 100, 0], [101, 101, 0], [100, 101, 0]])
faces = np.array([[0, 1, 2], [0, 2, 3]])
square_mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
print("The current center of mass is", square_mesh.center_mass)
```
the result with the current code is
```>>> The current center of mass is [0. 0. 0.]```

while the update code gives
```>>> The current center of mass is [100.5 100.5   0. ]```