### PR TITLE
Fix: handle_extensions drops valid falsy results like index 0

### DIFF
--- a/trimesh/exchange/gltf/extensions.py
+++ b/trimesh/exchange/gltf/extensions.py
@@ -194,7 +194,7 @@ def handle_extensions(
         try:
             # Build context dict with data + all kwargs
             context = {"data": data, **kwargs}
-            if result := _handlers[scope][ext_name](context):
+            if (result := _handlers[scope][ext_name](context)) is not None:
                 results[ext_name] = result
         except Exception as e:
             log.warning(f"failed to process extension {ext_name}: {e}")


### PR DESCRIPTION
## Problem

When loading GLB files with `EXT_texture_webp` extension, the first texture (index 0) is silently dropped.

This happens because `handle_extensions()` uses a truthy check:

```python
if result := _handlers[scope][ext_name](context):
    results[ext_name] = result
```

When a handler returns `0` (a valid texture source index), the condition evaluates to `False` and the result is discarded.

## Solution

Change the truthy check to an explicit `None` check:

```python
result = _handlers[scope][ext_name](context)
if result is not None:
    results[ext_name] = result
```

## Impact

- `baseColorTexture` with index 0 was being ignored
- `metallicRoughnessTexture` with index 1 worked fine
- This caused textures to disappear when composing scenes with multiple GLB files

## Reproduction

```python
import trimesh

# GLB with EXT_texture_webp where baseColorTexture uses texture index 0
mesh = trimesh.load("model.glb")
mat = mesh.geometry['geometry_0'].visual.material

print(mat.baseColorTexture)  # None (should be an image)
print(mat.metallicRoughnessTexture)  # OK (index 1 works)
```

## Root Cause

The bug was introduced in commit `c87b149` ("make keywords required") on Dec 17, 2025, which changed `if result is not None:` to `if result :=`.