### PR TITLE
Fix fill_traversals fragmenting open paths

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -197,6 +197,42 @@ class GraphTest(g.unittest.TestCase):
                 # check all return dtypes
                 assert all(i.dtype == g.np.int64 for i in dfs)
 
+    def test_traversal_no_fragmentation(self):
+        """
+        A DFS traversal of an open chain should not be split
+        into fragments by fill_traversals. Previously, starting
+        DFS from an interior node caused backtracking which
+        produced non-edge consecutive pairs, fragmenting the path.
+        """
+        # simple open chain: 0-1-2-3-4-5-6-7
+        chain = g.np.column_stack([g.np.arange(7), g.np.arange(1, 8)]).astype(
+            g.np.int64
+        )
+
+        dfs = g.trimesh.graph.traversals(chain, mode="dfs")
+        filled = g.trimesh.graph.fill_traversals(dfs, chain)
+
+        # a single connected open chain must produce exactly 1 traversal
+        assert len(filled) == 1
+        # that traversal must contain all 8 nodes
+        assert len(filled[0]) == 8
+
+        # two disjoint chains should produce exactly 2 traversals
+        chain2 = g.np.vstack(
+            [
+                chain,
+                g.np.column_stack(
+                    [
+                        g.np.arange(100, 104),
+                        g.np.arange(101, 105),
+                    ]
+                ).astype(g.np.int64),
+            ]
+        )
+        dfs2 = g.trimesh.graph.traversals(chain2, mode="dfs")
+        filled2 = g.trimesh.graph.fill_traversals(dfs2, chain2)
+        assert len(filled2) == 2
+
     def test_adjacency(self):
         for add_degen in [False, True]:
             for name in ["featuretype.STL", "soup.stl"]:

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -111,6 +111,31 @@ class SectionTest(g.unittest.TestCase):
                 # make sure reconstruction is at z of frame
                 assert g.np.isclose(back_3D.vertices[:, 2].mean(), z_levels[index])
 
+    def test_section_entity_count(self):
+        """
+        A cross-section of a convex shape should produce exactly
+        one entity per connected component. Previously, starting
+        DFS from an interior node fragmented single paths into
+        multiple entities.
+        """
+        # box section at z=0 should be a single closed rectangle
+        box = g.trimesh.creation.box()
+        section = box.section(
+            plane_origin=[0, 0, 0],
+            plane_normal=[0, 0, 1],
+        )
+        assert section is not None
+        assert len(section.entities) == 1
+
+        # cylinder section at z=0 should be a single closed ellipse
+        cyl = g.trimesh.creation.cylinder(radius=1.0, height=2.0)
+        section = cyl.section(
+            plane_origin=[0, 0, 0],
+            plane_normal=[0, 0, 1],
+        )
+        assert section is not None
+        assert len(section.entities) == 1
+
     def test_multi_index(self):
         # make sure returned face indexes on a section are correct
         mesh = g.trimesh.creation.box()

--- a/trimesh/graph.py
+++ b/trimesh/graph.py
@@ -679,12 +679,24 @@ def traversals(edges, mode="bfs"):
     # coo_matrix for csgraph routines
     graph = edges_to_coo(edges)
 
+    # compute node degrees so we can prefer starting traversals
+    # from endpoints (degree-1 nodes). Starting DFS from an
+    # interior node of an open path causes backtracking, which
+    # produces non-edge consecutive pairs that fill_traversals
+    # then splits on, fragmenting a single path into pieces.
+    degree = np.bincount(edges.ravel())
+    endpoints = {n for n in nodes if degree[n] == 1}
+
     # we're going to make a sequence of traversals
     traversals = []
 
     while len(nodes) > 0:
-        # starting at any node
-        start = nodes.pop()
+        # prefer endpoints to avoid DFS backtracking on open paths
+        if endpoints:
+            start = endpoints.pop()
+            nodes.discard(start)
+        else:
+            start = nodes.pop()
         # get an (n,) ordered traversal
         ordered = func(
             graph, i_start=start, return_predecessors=False, directed=False
@@ -693,6 +705,7 @@ def traversals(edges, mode="bfs"):
         traversals.append(ordered)
         # remove the nodes we've consumed
         nodes.difference_update(ordered)
+        endpoints.difference_update(ordered)
 
     return traversals
 


### PR DESCRIPTION
## Summary

`traversals()` uses `set.pop()` to pick the DFS/BFS start node. When this
lands on an interior node of an open path, the traversal backtracks, producing
non-edge consecutive pairs that `_split_traversal` splits on — fragmenting a
single connected path into multiple entities.

**Fix:** Compute node degrees and prefer degree-1 nodes (endpoints) as start
points. For open paths this guarantees end-to-end traversal with no
backtracking. Closed paths (all degree-2) fall back to the original behavior.

## Test plan

- `test_traversal_no_fragmentation` — open chain → 1 traversal; two disjoint chains → 2
- `test_section_entity_count` — box and cylinder sections → 1 entity each
- All existing `test_graph.py` and `test_section.py` tests pass