### PR TITLE
Release: Fix fill_holes with face attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ test-arch: ## Run tests on big-endian s390x and 32-bit i386 via QEMU emulation.
 	python3-networkx python3-jsonschema python3-httpx python3-collada python3-rtree \
 	 && python3 -m pytest \
 	tests/test_ply.py tests/test_gltf.py tests/test_voxel.py \
-	tests/test_stl.py tests/test_dae.py tests/test_obj.py -v"
+	tests/test_stl.py tests/test_dae.py tests/test_obj.py \
+	tests/test_runlength.py tests/test_encoding.py -v"
 	docker run --rm --platform linux/386 \
 		-v $(CURDIR):/trimesh \
 		-w /trimesh \
@@ -99,7 +100,7 @@ test-arch: ## Run tests on big-endian s390x and 32-bit i386 via QEMU emulation.
 		bash -c "apt-get update -qq && apt-get install -y -qq \
 	python3-numpy python3-pytest python3-scipy python3-rtree \
 	 && python3 -m pytest \
-	tests/test_voxel.py -v"
+	tests/test_voxel.py tests/test_runlength.py tests/test_encoding.py -v"
 
 .PHONY: publish-docker
 publish-docker: build ## Publish Docker images.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.8"
-version = "4.11.4"
+version = "4.11.5"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -162,7 +162,7 @@ class EncodingTest(g.unittest.TestCase):
         box = g.trimesh.primitives.Box()
         box.apply_translation([0.5, 0.5, 0.5])  # center at origin
         box.apply_scale(5)  # 0 -> 5
-        expected_sparse_indices = np.array(box.vertices)
+        expected_sparse_indices = np.array(box.vertices, dtype=int)
         box.apply_translation([2, 2, 2])  # 2 -> 7
         sparse = np.array(box.vertices, dtype=int)
         encoding = enc.SparseBinaryEncoding(sparse, shape=(9, 9, 9))

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -13,10 +13,15 @@ def test_fill_holes():
         "teapot.stl",
         "soup.stl",
         "featuretype.STL",
+        "featuretype.STEP",
         "angle_block.STL",
         "quadknot.obj",
     ]:
         mesh = g.get_mesh(mesh_name)
+        # handle scene lazily
+        if hasattr(mesh, "geometry"):
+            mesh = next(iter(mesh.geometry.values()))
+
         if not mesh.is_watertight:
             # output of fill_holes should match watertight status
             returned = mesh.fill_holes()
@@ -25,9 +30,17 @@ def test_fill_holes():
 
         hashes = [{mesh._data.__hash__(), hash(mesh)}]
 
-        mesh.faces = mesh.faces[1:-1]
+        # clip off the first and last few faces
+        mask = g.np.ones(len(mesh.faces), dtype=g.np.bool)
+        mask[[0, -1]] = False
+        mesh.update_faces(mask)
+
         assert not mesh.is_watertight
         assert not mesh.is_volume
+
+        # assert face attributes match faces
+        for attrib in mesh.face_attributes.values():
+            assert len(attrib) == len(mesh.faces)
 
         # color some faces
         g.trimesh.repair.broken_faces(mesh, color=[255, 0, 0, 255])
@@ -45,6 +58,11 @@ def test_fill_holes():
 
         hashes.append({mesh._data.__hash__(), hash(mesh)})
         assert hashes[1] != hashes[2]
+
+        # assert the filled holes padded attributes
+        # this is also the test for `mesh.extend_faces`
+        for attrib in mesh.face_attributes.values():
+            assert len(attrib) == len(mesh.faces)
 
         # try broken faces on a watertight mesh
         g.trimesh.repair.broken_faces(mesh, color=[255, 255, 0, 255])
@@ -256,4 +274,4 @@ def test_fix_normals_mixed_multibox():
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()
-    test_fix_normals_mixed_multibox()
+    test_fill_holes()

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -31,7 +31,7 @@ def test_fill_holes():
         hashes = [{mesh._data.__hash__(), hash(mesh)}]
 
         # clip off the first and last few faces
-        mask = g.np.ones(len(mesh.faces), dtype=g.np.bool)
+        mask = g.np.ones(len(mesh.faces), dtype=bool)
         mask[[0, -1]] = False
         mesh.update_faces(mask)
 
@@ -63,6 +63,8 @@ def test_fill_holes():
         # this is also the test for `mesh.extend_faces`
         for attrib in mesh.face_attributes.values():
             assert len(attrib) == len(mesh.faces)
+        # face colors should have been padded to match
+        assert len(mesh.visual.face_colors) == len(mesh.faces)
 
         # try broken faces on a watertight mesh
         g.trimesh.repair.broken_faces(mesh, color=[255, 255, 0, 255])

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -5,7 +5,7 @@ except BaseException:
 
 
 def test_fill_holes():
-    for mesh_name in [
+    meshes = [
         "unit_cube.STL",
         "machinist.XAML",
         "round.stl",
@@ -13,11 +13,19 @@ def test_fill_holes():
         "teapot.stl",
         "soup.stl",
         "featuretype.STL",
-        "featuretype.STEP",
         "angle_block.STL",
         "quadknot.obj",
-    ]:
-        mesh = g.get_mesh(mesh_name)
+    ]
+
+    try:
+        import cascadio  # noqa
+        # if we have cascadio test against a STEP file
+        meshes.append("featuretype.STEP")
+    except ImportError:
+        pass
+
+    for name in meshes:
+        mesh = g.get_mesh(name)
         # handle scene lazily
         if hasattr(mesh, "geometry"):
             mesh = next(iter(mesh.geometry.values()))
@@ -49,12 +57,24 @@ def test_fill_holes():
 
         assert hashes[0] != hashes[1]
 
+        # put face_normals in cache then corrupt one
+        # so we can verify extend_faces preserves cached normals
+        _ = mesh.face_normals
+        mesh._cache.cache["face_normals"].flags.writeable = True
+        mesh._cache.cache["face_normals"][3, :] += 10
+        mesh._cache.cache["face_normals"].flags.writeable = False
+        cached_marker = mesh.face_normals[3].copy()
+        assert (cached_marker >= 9).all()
+
         # run the fill holes operation should succeed
         assert mesh.fill_holes()
         # should be a superset of the last two
         assert mesh.is_volume
         assert mesh.is_watertight
         assert mesh.is_winding_consistent
+
+        # the corrupted normal should have survived from cache
+        assert g.np.allclose(mesh.face_normals[3], cached_marker)
 
         hashes.append({mesh._data.__hash__(), hash(mesh)})
         assert hashes[1] != hashes[2]

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1354,13 +1354,12 @@ class Trimesh(Geometry3D):
             # save previous expensive dot-products
             extend_normals = util.vstack_empty((cached_normals, new_normals))
 
-        # this is usually the case where two vertices of a triangle are just
-        # over tol.merge apart, but the normal calculation is screwed up
-        # these could be fixed by merging the vertices in question here:
-        # if not valid.all():
         if self.visual.defined and self.visual.kind == "face":
             extend_colors = util.vstack_empty(
-                (self.visual.face_colors, np.tile(visual.DEFAULT_COLOR, (4, 1)))
+                (
+                    self.visual.face_colors,
+                    np.tile(visual.DEFAULT_COLOR, (len(new_faces), 1)),
+                )
             )
 
         ##########
@@ -1378,7 +1377,7 @@ class Trimesh(Geometry3D):
 
         def sentinel_pad(dtype):
             # given a numpy dtype return the scalar value
-            # we are padding and extending face attributes withOB
+            # we are padding and extending face attributes with
             if dtype.kind == "i":
                 return -1
             return np.zeros(1, dtype=dtype)[0]
@@ -1386,12 +1385,14 @@ class Trimesh(Geometry3D):
         # collect new, padded face attributes
         new_attribs = {}
         for name, attrib in self.face_attributes.items():
-            if np.shape(attrib) == (original_length,):
-                # pad integers with -1 and everything else with zeros
-                pad = np.full(
-                    len(new_faces), sentinel_pad(attrib.dtype), dtype=attrib.dtype
-                )
-                new_attribs[name] = np.concatenate((attrib, pad))
+            shape = np.shape(attrib)
+            if len(shape) == 0 or shape[0] != original_length:
+                continue
+            # handle padding of both 1D and 2D face attributes
+            pad_shape = (len(new_faces),) + shape[1:]
+            # pad integers with -1 and everything else with zeros
+            pad = np.full(pad_shape, sentinel_pad(attrib.dtype), dtype=attrib.dtype)
+            new_attribs[name] = np.concatenate((attrib, pad))
         # update outside the loop with new values
         self.face_attributes.update(new_attribs)
 

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -35,6 +35,7 @@ from . import (
     triangles,
     units,
     util,
+    visual,
 )
 from .caching import Cache, DataStore, TrackedArray, cache_decorator
 from .constants import log, tol
@@ -1311,6 +1312,88 @@ class Trimesh(Geometry3D):
         # if our normals were the correct shape apply them
         if util.is_shape(cached_normals, (-1, 3)):
             self.face_normals = cached_normals[mask]
+
+    def extend_faces(self, new_faces: ArrayLike):
+        """
+        Extend `mesh.faces` in-place with new triangles.
+
+        This does substantial bookkeeping: padding face colors
+        and face attributes with default values, and preserving cached
+        face normals to avoid recomputing every normal.
+
+        Parameters
+        ------------
+        new_faces : (n, 3) integer
+          The new faces as indexes of `self.vertices`
+        """
+        new_faces = np.asanyarray(new_faces, dtype=np.int64)
+        if len(new_faces.shape) != 2 or new_faces.shape[1] != 3:
+            raise ValueError(f"Faces must be triangular, not `{new_faces.shape}`!")
+
+        if len(new_faces) == 0:
+            return
+
+        # make sure the cache is up-to-date
+        self._cache.verify()
+
+        # if we manage to extend colors and normals
+        extend_normals, extend_colors = None, None
+
+        # now we can willy-nilly check
+        if "face_normals" in self._cache.cache:
+            cached_normals = self._cache.cache["face_normals"]
+
+            # calculate just the normals for the new faces
+            new_normals, valid = triangles.normals(self.vertices[new_faces])
+            # mask out any zero triangles we created
+            new_faces = new_faces[valid]
+
+            if len(new_faces) == 0 or len(cached_normals) == 0:
+                return
+
+            # save previous expensive dot-products
+            extend_normals = util.vstack_empty((cached_normals, new_normals))
+
+        # this is usually the case where two vertices of a triangle are just
+        # over tol.merge apart, but the normal calculation is screwed up
+        # these could be fixed by merging the vertices in question here:
+        # if not valid.all():
+        if self.visual.defined and self.visual.kind == "face":
+            extend_colors = util.vstack_empty(
+                (self.visual.face_colors, np.tile(visual.DEFAULT_COLOR, (4, 1)))
+            )
+
+        ##########
+        # DO ALL MUTATION AT THE END HERE
+        # apply the new faces
+        original_length = len(self._data["faces"])
+        self.faces = util.vstack_empty((self._data["faces"], new_faces))
+        # dump the cache to set the new hash to the stacked faces
+        self._cache.verify()
+        # save us a normals recompute if we can
+        if extend_normals is not None:
+            self.face_normals = extend_normals
+        if extend_colors is not None:
+            self.visual.face_colors = extend_colors
+
+        def sentinel_pad(dtype):
+            # given a numpy dtype return the scalar value
+            # we are padding and extending face attributes withOB
+            if dtype.kind == "i":
+                return -1
+            return np.zeros(1, dtype=dtype)[0]
+
+        # collect new, padded face attributes
+        new_attribs = {}
+        for name, attrib in self.face_attributes.items():
+            if np.shape(attrib) == (original_length,):
+                # pad integers with -1 and everything else with zeros
+                pad = np.full(
+                    len(new_faces), sentinel_pad(attrib.dtype), dtype=attrib.dtype
+                )
+                new_attribs[name] = np.concatenate((attrib, pad))
+        # update outside the loop with new values
+        self.face_attributes.update(new_attribs)
 
     def remove_infinite_values(self) -> None:
         """

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1372,23 +1372,16 @@ class Trimesh(Geometry3D):
         if extend_colors is not None:
             self.visual.face_colors = extend_colors
 
-        def sentinel_pad(dtype):
-            # given a numpy dtype return the scalar value
-            # we are padding and extending face attributes with
-            if dtype.kind == "i":
-                return -1
-            return np.zeros(1, dtype=dtype)[0]
-
         # collect new, padded face attributes
         new_attribs = {}
         for name, attrib in self.face_attributes.items():
             shape = np.shape(attrib)
             if len(shape) == 0 or shape[0] != original_length:
                 continue
-            # handle padding of both 1D and 2D face attributes
-            pad_shape = (len(new_faces),) + shape[1:]
             # pad integers with -1 and everything else with zeros
-            pad = np.full(pad_shape, sentinel_pad(attrib.dtype), dtype=attrib.dtype)
+            fill = -1 if attrib.dtype.kind == "i" else 0
+            pad_shape = (len(new_faces),) + shape[1:]
+            pad = np.full(pad_shape, fill, dtype=attrib.dtype)
             new_attribs[name] = np.concatenate((attrib, pad))
         # update outside the loop with new values
         self.face_attributes.update(new_attribs)

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1339,20 +1339,17 @@ class Trimesh(Geometry3D):
         # if we manage to extend colors and normals
         extend_normals, extend_colors = None, None
 
-        # now we can willy-nilly check
+        # always filter degenerate triangles
+        new_normals, valid = triangles.normals(self.vertices[new_faces])
+        new_faces = new_faces[valid]
+        if len(new_faces) == 0:
+            return
+
+        # save cached normals if available to avoid a full recompute
         if "face_normals" in self._cache.cache:
             cached_normals = self._cache.cache["face_normals"]
-
-            # calculate just the normals for the new faces
-            new_normals, valid = triangles.normals(self.vertices[new_faces])
-            # mask out any zero triangles we created
-            new_faces = new_faces[valid]
-
-            if len(new_faces) == 0 or len(cached_normals) == 0:
-                return
-
-            # save previous expensive dot-products
-            extend_normals = util.vstack_empty((cached_normals, new_normals))
+            if len(cached_normals) > 0:
+                extend_normals = util.vstack_empty((cached_normals, new_normals))
 
         if self.visual.defined and self.visual.kind == "face":
             extend_colors = util.vstack_empty(

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1368,7 +1368,7 @@ class Trimesh(Geometry3D):
         self._cache.verify()
         # save us a normals recompute if we can
         if extend_normals is not None:
-            self.face_normals = extend_normals
+            self._cache["face_normals"] = extend_normals
         if extend_colors is not None:
             self.visual.face_colors = extend_colors
 

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -160,7 +160,7 @@ def triangulate_quads(quads, dtype=np.int64) -> NDArray:
     Returns
     -----------
     faces : (m, 3) int
-      Vertex indices of triangular faces.c
+      Vertex indices of triangular faces.
     """
 
     if len(quads) == 0:
@@ -183,25 +183,26 @@ def triangulate_quads(quads, dtype=np.int64) -> NDArray:
         pass
 
     # we made it here so we have mixed tris/quads/polygons
-    # filter into the three cases
-    tri = np.array([i for i in quads if len(i) == 3])
-    quad = np.array([i for i in quads if len(i) == 4])
-    # triangulate arbitrary polygons as triangle fans
-    # this isn't guaranteed to be sane if the polygons
-    # aren't convex but that would require a real maniac
-    poly = [
-        [[f[0], f[i + 1], f[i + 2]] for i in range(len(f) - 2)]
-        for f in quads
-        if len(f) > 4
-    ]
+    # do one pass to get the lengths
+    lengths = np.array([len(i) for i in quads], dtype=np.int64)
+
+    # get triangles and quads as clean constant-row numpy arrays
+    tri = np.array([quads[i] for i in np.nonzero(lengths == 3)[0]], dtype=np.int64)
+    quad = np.array([quads[i] for i in np.nonzero(lengths == 4)[0]], dtype=np.int64)
+
+    # get arbitrary polygons as a ragged sequence
+    poly = [quads[i] for i in np.nonzero(lengths > 4)[0]]
 
     if len(quad) == 0 and len(poly) == 0:
+        # only triangles, return triangles
         return tri.astype(dtype)
     if len(poly) > 0:
-        poly = np.vstack(poly)
+        # use numpy slicing to triangulate ragged-sequence polygons
+        poly = util.triangle_fans_to_faces(poly)
     if len(quad) > 0:
+        # trivially tesselate quads
         quad = np.vstack((quad[:, [0, 1, 2]], quad[:, [2, 3, 0]]))
-    # combine triangulated quads with triangles
+    # stack triangles from all three cases
     return util.vstack_empty([tri, quad, poly]).astype(dtype)
 
 

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -200,7 +200,7 @@ def triangulate_quads(quads, dtype=np.int64) -> NDArray:
         # use numpy slicing to triangulate ragged-sequence polygons
         poly = util.triangle_fans_to_faces(poly)
     if len(quad) > 0:
-        # trivially tesselate quads
+        # trivially tessellate quads
         quad = np.vstack((quad[:, [0, 1, 2]], quad[:, [2, 3, 0]]))
     # stack triangles from all three cases
     return util.vstack_empty([tri, quad, poly]).astype(dtype)

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -147,7 +147,7 @@ def vector_angle(pairs):
     return angles
 
 
-def triangulate_quads(quads, dtype=np.int64) -> NDArray:
+def triangulate_quads(quads, dtype=np.int64, use_fan: bool = True) -> NDArray:
     """
     Given an array of quad faces return them as triangle faces,
     also handles pure triangles and mixed triangles and quads.
@@ -156,6 +156,11 @@ def triangulate_quads(quads, dtype=np.int64) -> NDArray:
     -----------
     quads: (n, 4) int
       Vertex indices of quad faces.
+    dtype
+      Data type requested for the return
+    use_fan
+      Triangulate holes larger than quads with fans,
+      which may be wrong if the holes are non-convex
 
     Returns
     -----------
@@ -190,8 +195,12 @@ def triangulate_quads(quads, dtype=np.int64) -> NDArray:
     tri = np.array([quads[i] for i in np.nonzero(lengths == 3)[0]], dtype=np.int64)
     quad = np.array([quads[i] for i in np.nonzero(lengths == 4)[0]], dtype=np.int64)
 
-    # get arbitrary polygons as a ragged sequence
-    poly = [quads[i] for i in np.nonzero(lengths > 4)[0]]
+    if use_fan:
+        # get arbitrary polygons as a ragged sequence
+        poly = [quads[i] for i in np.nonzero(lengths > 4)[0]]
+    else:
+        # skip any hole larger than a quad
+        poly = []
 
     if len(quad) == 0 and len(poly) == 0:
         # only triangles, return triangles

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -604,7 +604,9 @@ def group_rows(data, require_count=None, digits=None):
     return groups_idx
 
 
-def boolean_rows(a: NDArray[np.int64], b: NDArray[np.int64], operation=np.intersect1d):
+def boolean_rows(
+    a: ArrayLike, b: ArrayLike, operation=np.intersect1d
+) -> NDArray[np.int64]:
     """
     Find the rows in two arrays which occur in both rows.
 

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -604,7 +604,7 @@ def group_rows(data, require_count=None, digits=None):
     return groups_idx
 
 
-def boolean_rows(a, b, operation=np.intersect1d):
+def boolean_rows(a: NDArray[np.int64], b: NDArray[np.int64], operation=np.intersect1d):
     """
     Find the rows in two arrays which occur in both rows.
 
@@ -621,7 +621,8 @@ def boolean_rows(a, b, operation=np.intersect1d):
 
     Returns
     --------
-    shared: (p, d) array containing rows in both a and b
+    shared : (p, d) int64
+       Array containing requested rows in both a and b
     """
     a = np.asanyarray(a, dtype=np.int64)
     b = np.asanyarray(b, dtype=np.int64)

--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -212,7 +212,7 @@ def broken_faces(mesh, color=None):
     return broken
 
 
-def fill_holes(mesh):
+def fill_holes(mesh, use_fan: bool = False):
     """
     Fill boundary holes in-place using fans, which may result
     in bad answers if the holes are non convex!
@@ -224,6 +224,9 @@ def fill_holes(mesh):
     ----------
     mesh : trimesh.Trimesh
         Mesh will be repaired in-place.
+    use_fan
+      If passed, holes larger than quads will be triangulated
+      using fans which are only valid for non-convex holes.
     """
     if len(mesh.faces) < 3:
         return False
@@ -243,7 +246,7 @@ def fill_holes(mesh):
     holes = nx.cycle_basis(nx.from_edgelist(boundary))
 
     # this handles mixed tris, quads, and arbitrary polygons
-    new_faces = triangulate_quads(holes)
+    new_faces = triangulate_quads(holes, use_fan=use_fan)
     if len(new_faces) == 0:
         return False
 

--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -9,8 +9,9 @@ import numpy as np
 
 from . import graph, triangles
 from .constants import log
-from .geometry import faces_to_edges
-from .grouping import group_rows
+from .geometry import faces_to_edges, triangulate_quads
+from .graph import connected_components
+from .grouping import group_rows, hashable_rows
 
 try:
     import networkx as nx
@@ -107,7 +108,7 @@ def fix_inversion(mesh, multibody: bool = False):
         return
 
     # get groups of connected faces
-    groups = graph.connected_components(mesh.face_adjacency)
+    groups = connected_components(mesh.face_adjacency)
 
     # mask of faces to flip
     flip = np.zeros(len(mesh.faces), dtype=bool)
@@ -213,156 +214,60 @@ def broken_faces(mesh, color=None):
 
 def fill_holes(mesh):
     """
-    Fill single- triangle holes on triangular meshes by adding
-    new triangles to fill the holes. New triangles will have
-    proper winding and normals, and if face colors exist the color
-    of the last face will be assigned to the new triangles.
+    Fill boundary holes in-place using fans, which may result
+    in bad answers if the holes are non convex!
+
+    Face colors and attributes will be padded with default values
+    so shapes match.
 
     Parameters
-    ------------
+    ----------
     mesh : trimesh.Trimesh
-      Mesh will be repaired in- place
+        Mesh will be repaired in-place.
     """
+    if len(mesh.faces) < 3 or mesh.is_watertight:
+        return
 
-    def hole_to_faces(hole):
-        """
-        Given a loop of vertex indices  representing a hole
-        turn it into triangular faces.
-        If unable to do so, return None
-
-        Parameters
-        -----------
-        hole : (n,) int
-          Ordered loop of vertex indices
-
-        Returns
-        ---------
-        faces : (n, 3) int
-          New faces
-        vertices : (m, 3) float
-          New vertices
-        """
-        hole = np.asanyarray(hole)
-        # the case where the hole is just a single missing triangle
-        if len(hole) == 3:
-            return [hole], []
-        # the hole is a quad, which we fill with two triangles
-        if len(hole) == 4:
-            face_A = hole[[0, 1, 2]]
-            face_B = hole[[2, 3, 0]]
-            return [face_A, face_B], []
-        return [], []
-
-    if len(mesh.faces) < 3:
-        return False
-
-    if mesh.is_watertight:
-        return True
-
-    # we know that in a watertight mesh every edge will be included twice
-    # thus every edge which appears only once is part of a hole boundary
+    # any edge that occurs once is on the boundary
     boundary_groups = group_rows(mesh.edges_sorted, require_count=1)
-
-    # mesh is not watertight and we have too few edges
-    # edges to do a repair
-    # since we haven't changed anything return False
+    # either watertight or broken in a weird way
     if len(boundary_groups) < 3:
-        return False
+        return
 
-    boundary_edges = mesh.edges[boundary_groups]
-    index_as_dict = [{"index": i} for i in boundary_groups]
+    # ordered edges on the boundary
+    boundary = mesh.edges[boundary_groups]
 
-    # we create a graph of the boundary edges, and find cycles.
-    g = nx.from_edgelist(np.column_stack((boundary_edges, index_as_dict)))
-    new_faces = []
-    new_vertex = []
-    for hole in nx.cycle_basis(g):
-        # convert the hole, which is a polygon of vertex indices
-        # to triangles and new vertices
-        faces, vertex = hole_to_faces(hole=hole)
-        if len(faces) == 0:
-            continue
-        # remeshing returns new vertices as negative indices, so change those
-        # to absolute indices which won't be screwed up by the later appends
-        faces = np.array(faces)
-        faces[faces < 0] += len(new_vertex) + len(mesh.vertices) + len(vertex)
-        new_vertex.extend(vertex)
-        new_faces.extend(faces)
-    new_faces = np.array(new_faces)
-    new_vertex = np.array(new_vertex)
+    # use networkx to find cycles of boundary edges
+    holes = nx.cycle_basis(nx.from_edgelist(boundary))
 
+    # this handles mixed tris, quads, and arbitrary polygons
+    new_faces = triangulate_quads(holes)
     if len(new_faces) == 0:
-        # no new faces have been added, so nothing further to do
-        # the mesh is NOT watertight, as boundary groups exist
-        # but we didn't add any new faces to fill them in
-        return False
+        return
 
-    for face_index, face in enumerate(new_faces):
-        # we compare the edge from the new face with
-        # the boundary edge from the source mesh
-        edge_test = face[:2]
-        edge_boundary = mesh.edges[g.get_edge_data(*edge_test)["index"]]
+    # now we need to fix the winding for every new face
+    new_edges = faces_to_edges(new_faces)
 
-        # in a well constructed mesh, the winding is such that adjacent triangles
-        # have reversed edges to each other. Here we check to make sure the
-        # edges are reversed, and if they aren't we simply reverse the face
-        reversed = edge_test[0] == edge_boundary[1]
-        if not reversed:
-            new_faces[face_index] = face[::-1]
+    # the hashable rows for the mesh bouundary edges
+    # and the boundary of the original hole in the mesh
+    # a well-constructed mesh has edges that are REVERSED
+    # so we're going to try a cheap indexing operation
+    hashable_new = hashable_rows(new_edges)
+    hashable_old = hashable_rows(boundary)
 
-    # stack vertices into clean (n, 3) float
-    if len(new_vertex) != 0:
-        new_vertices = np.vstack((mesh.vertices, new_vertex))
-    else:
-        new_vertices = mesh.vertices
+    # the magic trick: if any ordered edge of the NEW face is contained
+    # in the OLD boundary edges, it means the new face has edges that
+    # are in the same order as the boundary, and that new face
+    # needs to be reversed and since new_edges has exactly three
+    # edges per triangle we can compact indexes back to triangles
+    needs_reverse = np.isin(hashable_new, hashable_old).reshape((-1, 3)).any(axis=1)
 
-    # try to save face normals if we can
-    if "face_normals" in mesh._cache.cache:
-        cached_normals = mesh._cache.cache["face_normals"]
-    else:
-        cached_normals = None
+    # now we have some shiny new faces that might even be wound correctly!
+    new_faces[needs_reverse] = np.fliplr(new_faces[needs_reverse])
 
-    # also we can remove any zero are triangles by masking here
-    new_normals, valid = triangles.normals(new_vertices[new_faces])
-    # all the added faces were broken
-    if not valid.any():
-        return False
+    # do the bookkeeping to preserve face normals and pad attributes
+    mesh.extend_faces(new_faces)
 
-    # this is usually the case where two vertices of a triangle are just
-    # over tol.merge apart, but the normal calculation is screwed up
-    # these could be fixed by merging the vertices in question here:
-    # if not valid.all():
-    if mesh.visual.defined and mesh.visual.kind == "face":
-        color = mesh.visual.face_colors
-    else:
-        color = None
-
-    # apply the new faces and vertices
-    mesh.faces = np.vstack((mesh._data["faces"], new_faces[valid]))
-    mesh.vertices = new_vertices
-
-    # dump the cache and set id to the new hash
-    mesh._cache.verify()
-
-    # save us a normals recompute if we can
-    if cached_normals is not None:
-        mesh.face_normals = np.vstack((cached_normals, new_normals))
-
-    # this is usually the case where two vertices of a triangle are just
-    # over tol.merge apart, but the normal calculation is screwed up
-    # these could be fixed by merging the vertices in question here:
-    # if not valid.all():
-    if color is not None:
-        # if face colors exist, assign the last face color to the new faces
-        # note that this is a little cheesey, but it is very inexpensive and
-        # is the right thing to do if the mesh is a single color.
-        color_shape = np.shape(color)
-        if len(color_shape) == 2:
-            new_colors = np.tile(color[-1], (np.sum(valid), 1))
-            new_colors = np.vstack((color, new_colors))
-            mesh.visual.face_colors = new_colors
-
-    log.debug("Filled in mesh with %i triangles", np.sum(valid))
     return mesh.is_watertight
 
 

--- a/trimesh/repair.py
+++ b/trimesh/repair.py
@@ -225,14 +225,16 @@ def fill_holes(mesh):
     mesh : trimesh.Trimesh
         Mesh will be repaired in-place.
     """
-    if len(mesh.faces) < 3 or mesh.is_watertight:
-        return
+    if len(mesh.faces) < 3:
+        return False
+    if mesh.is_watertight:
+        return True
 
     # any edge that occurs once is on the boundary
     boundary_groups = group_rows(mesh.edges_sorted, require_count=1)
     # either watertight or broken in a weird way
     if len(boundary_groups) < 3:
-        return
+        return False
 
     # ordered edges on the boundary
     boundary = mesh.edges[boundary_groups]
@@ -243,12 +245,12 @@ def fill_holes(mesh):
     # this handles mixed tris, quads, and arbitrary polygons
     new_faces = triangulate_quads(holes)
     if len(new_faces) == 0:
-        return
+        return False
 
     # now we need to fix the winding for every new face
     new_edges = faces_to_edges(new_faces)
 
-    # the hashable rows for the mesh bouundary edges
+    # the hashable rows for the mesh boundary edges
     # and the boundary of the original hole in the mesh
     # a well-constructed mesh has edges that are REVERSED
     # so we're going to try a cheap indexing operation

--- a/trimesh/voxel/runlength.py
+++ b/trimesh/voxel/runlength.py
@@ -242,12 +242,14 @@ def rle_to_dense(rle_data, dtype=np.int64):
     if dtype is not None:
         values = np.asanyarray(values, dtype=dtype)
     try:
-        result = np.repeat(np.squeeze(values, axis=-1), np.squeeze(counts, axis=-1))
+        result = np.repeat(
+            np.squeeze(values, axis=-1), np.squeeze(counts, axis=-1).astype(int)
+        )
     except TypeError:
         # on windows it sometimes fails to cast data type
         result = np.repeat(
             np.squeeze(values.astype(np.int64), axis=-1),
-            np.squeeze(counts.astype(np.int64), axis=-1),
+            np.squeeze(counts.astype(int), axis=-1),
         )
     return result
 
@@ -286,8 +288,8 @@ def split_long_rle_lengths(values, lengths, dtype=np.int64):
     max_length = np.iinfo(dtype).max
     lengths = np.asarray(lengths, dtype=np.int64)
     repeats = lengths // max_length
-    if np.any(repeats):
-        repeats += 1
+    if repeats.any():
+        repeats = (repeats + 1).astype(int)
         remainder = lengths % max_length
         values = np.repeat(values, repeats)
         lengths = np.zeros(len(repeats), dtype=dtype)


### PR DESCRIPTION
`Trimesh.fill_holes` was adding new faces but haphazardly managing the bookkeeping: it broke `len(mesh.faces) == len(mesh.face_attributes[n])` if there were any holes filled.

- add `Trimesh.extend_faces` which moves the bookkeeping of "preserve cached face normals to avoid recalculating, pad face colors, pad face attributes" to a generic mesh attribute in the same vein as `mesh.update_faces`.
- refactor the tesselation of the holes in `repair.fill_holes` to use `triangulate_quads` which implemented the hole filling logic but better. Switch the winding search to a numpy indexing trick for new faces.
- Have `geometry.triangulate_quads` use the preexisting `util.triangle_fan_to_faces` which uses numpy instead of a list comprehension and is heavily used and tested in the codebase.

Also:
- try to test and fix #2516 