### PR TITLE
Fix duplicate ray hits in pyembree intersects_id (#2504)

### DIFF
--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -203,6 +203,30 @@ class RayTests(g.unittest.TestCase):
                 # top or bottom face
                 assert g.np.isclose(p[2], mesh.bounds[:, 2]).any()
 
+    def test_embree_duplicate_hits(self):
+        """
+        Test that multiple_hits=True does not get stuck in a float32 precision
+        loop when coordinates are extremely large
+        """
+        # create a massive box to trigger the floating-point precision bug
+        mesh = g.trimesh.creation.box()
+        mesh.apply_scale(10000.0)
+
+        # Fire a ray straight from the center
+        ray_origins = g.np.array([[0.0, 0.0, 5000.0]])
+        ray_directions = g.np.array([[0.0, 0.0, -1.0]])
+
+        # if pyembree is available, this will test our new mask logic
+        if hasattr(mesh.ray, '_scene'):
+            index_tri, _ = mesh.ray.intersects_id(
+                ray_origins,
+                ray_directions,
+                multiple_hits=True
+            )
+            
+            # The ray should hit exactly one face as it exits the cube
+            assert len(index_tri) == 1
+
         def test_broken(self):
             """
             Test a mesh with badly defined face normals

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -223,7 +223,7 @@ class RayTests(g.unittest.TestCase):
                 ray_directions,
                 multiple_hits=True
             )
-            
+
             # The ray should hit exactly one face as it exits the cube
             assert len(index_tri) == 1
 

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -184,9 +184,12 @@ class RayMeshIntersector:
             # ray, which is bizzarely slower than our calculation
 
             query = self._scene.run(ray_origins[current], ray_directions[current])
+
+            current_index = np.nonzero(current)[0]
             # basically we need to reduce the rays to the ones that hit
             # something
-            hit = query != -1
+            hit = (query != -1) & (query != last_hit_triangles[current_index])
+            last_hit_triangles[current_index[hit]] = query[hit]
             # which triangle indexes were hit
             hit_triangle = query[hit]
 
@@ -197,15 +200,13 @@ class RayMeshIntersector:
             current[current_index_no_hit] = False
 
             # PROPOSED FIX
-            # Check if these rays hit the exact same triangle as the previous loop
-            is_duplicate = last_hit_triangles[current_index_hit] == hit_triangle
-            is_new_hit = ~is_duplicate
+            current_index_no_hit = current_index[~hit]
+            current_index_hit = current_index[hit]
+            current[current_index_no_hit] = False
 
-            last_hit_triangles[current_index_hit] = hit_triangle
-
-            if is_new_hit.any():
-                result_triangle.append(hit_triangle[is_new_hit])
-                result_ray_idx.append(current_index_hit[is_new_hit])
+            # always append to avoid np.hstack concatenation crashes
+            result_triangle.append(hit_triangle)
+            result_ray_idx.append(current_index_hit)
 
             # if we don't need all of the hits, return the first one
             if (not multiple_hits and not return_locations) or not hit.any():

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -171,6 +171,10 @@ class RayMeshIntersector:
             plane_origins = self.mesh.triangles[:, 0, :]
             plane_normals = self.mesh.face_normals
 
+        # Proposed FIX
+        # NEW CODE: Track the last triangle hit by each ray to prevent logging duplicates
+        last_hit_triangles = np.full(len(ray_origins), -1, dtype=np.int64)
+
         # use a for loop rather than a while to ensure this exits
         # if a ray is offset from a triangle and then is reported
         # hitting itself this could get stuck on that one triangle
@@ -192,9 +196,16 @@ class RayMeshIntersector:
             current_index_hit = current_index[hit]
             current[current_index_no_hit] = False
 
-            # append the triangle and ray index to the results
-            result_triangle.append(hit_triangle)
-            result_ray_idx.append(current_index_hit)
+            # PROPOSED FIX
+            # Check if these rays hit the exact same triangle as the previous loop
+            is_duplicate = last_hit_triangles[current_index_hit] == hit_triangle
+            is_new_hit = ~is_duplicate
+
+            last_hit_triangles[current_index_hit] = hit_triangle
+
+            if is_new_hit.any():
+                result_triangle.append(hit_triangle[is_new_hit])
+                result_ray_idx.append(current_index_hit[is_new_hit])
 
             # if we don't need all of the hits, return the first one
             if (not multiple_hits and not return_locations) or not hit.any():


### PR DESCRIPTION
When querying rays with multiple_hits=True at large coordinate scales the float32 precision of embree combined with a very small _scale caused the distance offset to be swallowed. Because the ray origin didn't actually advance, the loop repeatedly hit the exact same triangle until it reached max_hits.

I added a tracker array last_hit_triangle inside the max_hits loop in ray_pyembree.py. If a ray hits the exact same triangle two iterations in a row, the logic now correctly filters it out as a duplicate while allowing the "ray" to continue advancing.