### PR TITLE
Drop support for Python 3.8 and 3.9 (EOL)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
-        exclude:
-            # windows runners have gotten flaky
-          - os: windows-latest
-            python-version: 3.8
-          - os: windows-latest
-            python-version: 3.9
-          - os: macos-13
-            python-version: 3.9
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.13"]
+        python-version: ["3.10", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Github Actions](https://github.com/mikedh/trimesh/workflows/Release%20Trimesh/badge.svg)](https://github.com/mikedh/trimesh/actions) [![codecov](https://codecov.io/gh/mikedh/trimesh/branch/main/graph/badge.svg?token=4PVRQXyl2h)](https://codecov.io/gh/mikedh/trimesh)  [![Docker Image Version (latest by date)](https://img.shields.io/docker/v/trimesh/trimesh?label=docker&sort=semver)](https://hub.docker.com/r/trimesh/trimesh/tags) [![PyPI version](https://badge.fury.io/py/trimesh.svg)](https://badge.fury.io/py/trimesh)
 
 
-Trimesh is a pure Python 3.8+ library for loading and using [triangular meshes](https://en.wikipedia.org/wiki/Triangle_mesh) with an emphasis on watertight surfaces. The goal of the library is to provide a full featured and well tested Trimesh object which allows for easy manipulation and analysis, in the style of the Polygon object in the [Shapely library](https://github.com/Toblerity/Shapely).
+Trimesh is a pure Python 3.10+ library for loading and using [triangular meshes](https://en.wikipedia.org/wiki/Triangle_mesh) with an emphasis on watertight surfaces. The goal of the library is to provide a full featured and well tested Trimesh object which allows for easy manipulation and analysis, in the style of the Polygon object in the [Shapely library](https://github.com/Toblerity/Shapely).
 
 The API is mostly stable, but this should not be relied on and is not guaranteed: install a specific version if you plan on deploying something using `trimesh`.
 
@@ -132,7 +132,7 @@ print(mesh.bounding_box_oriented.volume,
 * Calculate face adjacencies, face angles, vertex defects, convex hulls, etc.
 * Calculate cross sections for a 2D outline, or slice a mesh for a 3D remainder mesh, i.e. slicing for 3D-printing.
 * Split mesh based on face connectivity using networkx, or scipy.sparse
-* Calculate mass properties, including volume, center of mass, moment of inertia, principal components of inertia, etc. 
+* Calculate mass properties, including volume, center of mass, moment of inertia, principal components of inertia, etc.
 * Repair simple problems with triangle winding, normals, and quad/triangle holes
 * Compute rotation/translation/tessellation invariant identifier and find duplicate meshes
 * Check if a mesh is watertight, convex, etc.
@@ -151,6 +151,6 @@ print(mesh.bounding_box_oriented.volume,
 ## Additional Notes
 
 - Check out some cool stuff people have done in the [GitHub network](https://github.com/mikedh/trimesh/network/dependents).
-- Generally `trimesh` API changes should have a one-year period of [printing a `warnings.DeprecationWarning`](https://trimesh.org/contributing.html#deprecations) although that's not always possible (i.e. the pyglet2 viewer rewrite that's been back-burnered for several years.) 
+- Generally `trimesh` API changes should have a one-year period of [printing a `warnings.DeprecationWarning`](https://trimesh.org/contributing.html#deprecations) although that's not always possible (i.e. the pyglet2 viewer rewrite that's been back-burnered for several years.)
 - Docker containers are available on Docker Hub as [`trimesh/trimesh`](https://hub.docker.com/r/trimesh/trimesh/tags) and there's a [container guide](https://trimesh.org/docker.html) in the docs.
 - If you're choosing which format to use, you may want to try [GLB](https://trimesh.org/formats.html) as a fast modern option.

--- a/examples/prepare.py
+++ b/examples/prepare.py
@@ -18,7 +18,6 @@ RawFile ->           # a raw loadable file
 
 import os
 from dataclasses import dataclass
-from typing import Optional
 
 import trimesh
 
@@ -34,7 +33,7 @@ class RawFile:
 
     # the units of the file if it is in a format
     # that does not include units (i.e. STL files)
-    units: Optional[str] = None
+    units: str | None = None
 
 
 @dataclass

--- a/examples/widget.py
+++ b/examples/widget.py
@@ -1,5 +1,5 @@
 """
-Glooey widget example. Only runs with python>=3.6 and pyglet<=1.5.27 (because of Glooey).
+Glooey widget example. Only runs with pyglet<=1.5.27 (because of Glooey).
 """
 
 import io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 
 [project]
 name = "trimesh"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 version = "4.12.1"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
@@ -14,17 +14,16 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Multimedia :: Graphics :: 3D Modeling"
 ]
-dependencies = ["numpy>=1.20"]
+dependencies = ["numpy>=1.21"]
 
 [project.urls]
 homepage = "https://github.com/mikedh/trimesh"
@@ -74,8 +73,7 @@ easy = [
     "jsonschema",
     "networkx",
     "svg.path",
-    "pycollada <= 0.9.0; python_version<'3.9'",
-    "pycollada; python_version>='3.9'",
+    "pycollada",
     "shapely",
     "xxhash",
     "rtree",
@@ -83,9 +81,9 @@ easy = [
     "scipy",
     "embreex",
     "pillow",
-    "vhacdx; python_version>='3.9'",
+    "vhacdx",
     # old versions of mapbox_earcut produce incorrect values on numpy 2.0
-    "mapbox_earcut >= 1.0.2; python_version>='3.9'",
+    "mapbox_earcut >= 1.0.2",
 ]
 
 recommend = [
@@ -115,7 +113,7 @@ test_more = [
     "ezdxf",      # compare our DXF loading with theirs
     "meshio",     # load some FEA-adjacent format s
     "xatlas",     # provide unwrapping for texturing
-    "pytest-beartype; python_version>='3.10'", # fail on bad type hints
+    "pytest-beartype", # fail on bad type hints
     "matplotlib", # compare our color maps with theirs
     "pymeshlab; python_version<'3.14'", # compare our vertex counts
     "triangle; python_version<'3.14'",  # polygon tesselator
@@ -133,7 +131,7 @@ deprecated = ["openctm"]
 all = ["trimesh[easy,recommend,test,test_more,deprecated]"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 90
 
 [tool.ruff.lint]

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -142,17 +142,10 @@ transforms = [
 # should be a (100, 4, 4) float
 transforms = np.array(transforms)
 
-try:
-    # do the imports for Python 2
-    from cStringIO import StringIO
+from io import StringIO
+from io import BytesIO
 
-    PY3 = False
-except ImportError:
-    # if that didn't work we're probably on Python 3
-    from io import StringIO
-    from io import BytesIO
-
-    PY3 = True
+PY3 = True
 
 # are we on linux
 is_linux = "linux" in platform.system().lower()

--- a/tests/test_3mf.py
+++ b/tests/test_3mf.py
@@ -55,10 +55,6 @@ def test_names():
 
 
 def test_roundtrip():
-    if g.sys.version_info < (3, 6):
-        g.log.warning("relies on > Python 3.5")
-        return
-
     # test a scene round-tripped through the
     # 3MF exporter and importer
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -259,10 +259,6 @@ class CacheTest(g.unittest.TestCase):
         # of the subclassed `ndarray` and see if we can get trackedarray
         # to return incorrect hashes. Hopefully this catches new methods
 
-        # only run this test on python 3+ as they changed tobytes
-        if not g.PY3:
-            return
-
         import itertools
         import warnings
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -22,9 +22,6 @@ def test_scene():
         assert scene_split.__hash__() == pre[0]
         assert scene_base.__hash__() == pre[1]
 
-        # __hash__ is a long int which fails isinstance in Python 2
-        assert type(scene_base.__hash__()).__name__ in ("int", "long")
-
         # try out scene appending
         concat = scene_split + scene_base
 

--- a/tests/test_scenegraph.py
+++ b/tests/test_scenegraph.py
@@ -223,9 +223,6 @@ def test_reverse():
 def test_shortest_path():
     # compare the EnforcedForest shortest path algo
     # to the more general networkx.shortest_path algo
-    if g.sys.version_info < (3, 7):
-        # old networkx is a lot different
-        return
 
     tf = g.trimesh.transformations
     # start with a known good random tree

--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -1,7 +1,10 @@
 try:
     from . import generic as g
-except BaseException:
-    import generic as g
+except ImportError:
+    try:
+        import generic as g
+    except ImportError:
+        from tests import generic as g
 
 
 class VoxelGridTest(g.unittest.TestCase):

--- a/trimesh/__init__.py
+++ b/trimesh/__init__.py
@@ -2,7 +2,7 @@
 https://github.com/mikedh/trimesh
 ------------------------------------
 
-Trimesh is a pure Python (2.7- 3.3+) library for loading and using triangular
+Trimesh is a pure Python (3.10+) library for loading and using triangular
 meshes with an emphasis on watertight meshes. The goal of the library is to
 provide a fully featured Trimesh object which allows for easy manipulation
 and analysis, in the style of the Polygon object in the Shapely library.

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -40,8 +40,10 @@ except BaseException:
 def sha256(item) -> int:
     return int(_sha256(item).hexdigest(), 16)
 
+
 def hash_fallback(item):
     return int(_blake2b(item, usedforsecurity=False).hexdigest(), 16)
+
 
 # xxhash is up to 30x faster than sha256:
 # `pip install xxhash`

--- a/trimesh/caching.py
+++ b/trimesh/caching.py
@@ -21,9 +21,9 @@ In [25]: %timeit xxh3_64_intdigest(d)
 """
 
 import os
-import sys
 import time
 from functools import wraps
+from hashlib import blake2b as _blake2b
 from hashlib import sha256 as _sha256
 
 import numpy as np
@@ -40,16 +40,8 @@ except BaseException:
 def sha256(item) -> int:
     return int(_sha256(item).hexdigest(), 16)
 
-
-if sys.version_info >= (3, 9):
-    # blake2b is available on Python 3 and
-    from hashlib import blake2b as _blake2b
-
-    def hash_fallback(item):
-        return int(_blake2b(item, usedforsecurity=False).hexdigest(), 16)
-else:
-    # fallback to sha256
-    hash_fallback = sha256
+def hash_fallback(item):
+    return int(_blake2b(item, usedforsecurity=False).hexdigest(), 16)
 
 # xxhash is up to 30x faster than sha256:
 # `pip install xxhash`

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -1110,8 +1110,7 @@ def _byte_pad(data, bound=4):
     if len(data) % bound != 0:
         # extra bytes to pad with
         count = bound - (len(data) % bound)
-        # bytes(count) only works on Python 3
-        pad = (" " * count).encode("utf-8")
+        pad = bytes(count)
         # combine the padding and data
         result = b"".join([data, pad])
         # we should always divide evenly

--- a/trimesh/exchange/gltf/extensions.py
+++ b/trimesh/exchange/gltf/extensions.py
@@ -6,7 +6,9 @@ Extension registry for glTF import/export with scope-based handlers.
 Each scope has a TypedDict defining the context passed to handlers.
 """
 
-from typing import Any, Callable, OrderedDict, TypedDict
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import Any, TypedDict
 
 from ...constants import log
 from ...typed import Dict, List, Literal, Optional

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import re
 from collections import defaultdict, deque
@@ -788,7 +789,7 @@ def _preprocess_faces(text, use_obj=False, use_groups=False):
     # store (material, object, group, face lines)
     face_tuples = []
 
-    for start, end in zip(splits[:-1], splits[1:]):
+    for start, end in itertools.pairwise(splits):
         # ensure there's always a trailing newline
         chunk = f_chunk[start:end].strip() + "\n"
         if chunk.startswith("o "):

--- a/trimesh/exchange/threemf.py
+++ b/trimesh/exchange/threemf.py
@@ -335,9 +335,10 @@ def export_3MF(mesh, batch_size=4096, compression=zipfile.ZIP_DEFLATED, compress
 
     with zipfile.ZipFile(file_obj, mode="w", **zip_kwargs) as z:
         # 3dmodel.model
-        with z.open("3D/3dmodel.model", mode="w") as f, etree.xmlfile(
-            f, encoding="utf-8"
-        ) as xf:
+        with (
+            z.open("3D/3dmodel.model", mode="w") as f,
+            etree.xmlfile(f, encoding="utf-8") as xf,
+        ):
             xf.write_declaration()
 
             # stream elements
@@ -455,9 +456,10 @@ def export_3MF(mesh, batch_size=4096, compression=zipfile.ZIP_DEFLATED, compress
                 )
 
         # [Content_Types].xml
-        with z.open("[Content_Types].xml", "w") as f, etree.xmlfile(
-            f, encoding="utf-8"
-        ) as xf:
+        with (
+            z.open("[Content_Types].xml", "w") as f,
+            etree.xmlfile(f, encoding="utf-8") as xf,
+        ):
             xf.write_declaration()
             # xml namespaces
             nsmap = {None: "http://schemas.openxmlformats.org/package/2006/content-types"}

--- a/trimesh/exchange/threemf.py
+++ b/trimesh/exchange/threemf.py
@@ -290,7 +290,7 @@ def export_3MF(mesh, batch_size=4096, compression=zipfile.ZIP_DEFLATED, compress
     compression : zipfile.ZIP_*
       Type of zip compression to use in this export.
     compresslevel : int
-      For Python > 3.7 specify the 0-9 compression level.
+      Specify the 0-9 compression level.
 
     Returns
     ---------
@@ -331,9 +331,7 @@ def export_3MF(mesh, batch_size=4096, compression=zipfile.ZIP_DEFLATED, compress
     file_obj = io.BytesIO()
 
     # specify the parameters for the zip container
-    zip_kwargs = {"compression": compression}
-    # compresslevel was added in Python 3.7
-    zip_kwargs["compresslevel"] = compresslevel
+    zip_kwargs = {"compression": compression, "compresslevel": compresslevel}
 
     with zipfile.ZipFile(file_obj, mode="w", **zip_kwargs) as z:
         # 3dmodel.model

--- a/trimesh/path/traversal.py
+++ b/trimesh/path/traversal.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 
 import numpy as np
 
@@ -142,7 +143,7 @@ def vertex_to_entity_path(vertex_path, graph, entities, vertices=None):
     # traverse the entity path and reverse entities in place to
     # align with this path ordering
     round_trip = np.append(entity_path, entity_path[0])
-    round_trip = zip(round_trip[:-1], round_trip[1:])
+    round_trip = itertools.pairwise(round_trip)
     for ea, eb in round_trip:
         da, db = edge_direction(entities[ea].end_points, entities[eb].end_points)
         if da is not None:

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -11,16 +11,11 @@ import abc
 import itertools
 import os
 
+# URL parsing for remote resources via WebResolver
+from urllib.parse import urlparse
+
 from . import caching, util
 from .typed import Dict, Mapping, Optional, Union
-
-# URL parsing for remote resources via WebResolver
-try:
-    # Python 3
-    from urllib.parse import urlparse
-except ImportError:
-    # Python 2
-    from urlparse import urlparse
 
 
 class Resolver(util.ABC):

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -1,4 +1,5 @@
 import collections
+import itertools
 from copy import deepcopy
 
 import numpy as np
@@ -152,7 +153,7 @@ class SceneGraph:
 
             # loop through pairs of the path
             matrices = []
-            for u, v in zip(path[:-1], path[1:]):
+            for u, v in itertools.pairwise(path):
                 forward = data.get((u, v))
                 if forward is not None:
                     if "matrix" in forward:

--- a/trimesh/smoothing.py
+++ b/trimesh/smoothing.py
@@ -293,11 +293,7 @@ def laplacian_calculation(
                 (laplacian.data, np.ones(len(pinned_vertices), dtype=bool))
             )
 
-        # using this instead of the line below
-        # laplacian = laplacian / laplacian.sum(axis=1)
-        # because on Python 3.8 that returns a `numpy.matrix`
-        # value instead of a `sparse.coo_matrix`
-        laplacian = laplacian.multiply(1.0 / laplacian.sum(axis=1))
+        laplacian = laplacian / laplacian.sum(axis=1)
 
     else:
         # get the vertex neighbors from the cache

--- a/trimesh/typed.py
+++ b/trimesh/typed.py
@@ -2,14 +2,8 @@ from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from io import BufferedRandom, BytesIO, StringIO
 from pathlib import Path
 from sys import version_info
-from typing import (
-    IO,
-    Any,
-    BinaryIO,
-    Literal,
-    Optional,
-    TextIO,
-)
+from typing import IO, Any, BinaryIO, Literal, Optional, TextIO
+from typing import Union as Union
 
 from numpy import float64, floating, int64, integer
 from numpy.typing import ArrayLike, DTypeLike, NDArray

--- a/trimesh/typed.py
+++ b/trimesh/typed.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from io import BufferedRandom, BytesIO, StringIO
 from pathlib import Path
 from sys import version_info
@@ -8,33 +9,15 @@ from typing import (
     Literal,
     Optional,
     TextIO,
-    Union,
 )
 
-from numpy import float64, floating, int64, integer, unsignedinteger
-
-# requires numpy>=1.20
+from numpy import float64, floating, int64, integer
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
-if version_info >= (3, 9):
-    # use PEP585 hints on newer python
-    List = list
-    Tuple = tuple
-    Dict = dict
-    Set = set
-    from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
-else:
-    from typing import (
-        Callable,
-        Dict,
-        Hashable,
-        Iterable,
-        List,
-        Mapping,
-        Sequence,
-        Set,
-        Tuple,
-    )
+List = list
+Tuple = tuple
+Dict = dict
+Set = set
 
 if version_info >= (3, 11):
     from typing import Self
@@ -43,27 +26,27 @@ else:
 
 # most loader routes take `file_obj` which can either be
 # a file-like object or a file path, or sometimes a dict
-Stream = Union[IO, BytesIO, StringIO, BinaryIO, TextIO, BufferedRandom]
-Loadable = Union[str, Path, Stream, Dict, None]
+Stream = IO | BytesIO | StringIO | BinaryIO | TextIO | BufferedRandom
+Loadable = str | Path | Stream | Dict | None
 
 # numpy integers do not inherit from python integers, i.e.
 # if you type a function argument as an `int` and then pass
 # a value from a numpy array like `np.ones(10, dtype=np.int64)[0]`
 # you may have a type error.
 # these wrappers union numpy integers and python integers
-Integer = Union[int, integer, unsignedinteger]
+Integer = int | integer
 
 # Numbers which can only be floats and will not accept integers
 # > isinstance(np.ones(1, dtype=np.float32)[0], floating) # True
 # > isinstance(np.ones(1, dtype=np.float32)[0], float) # False
-Floating = Union[float, floating]
+Floating = float | floating
 
 # Many arguments take "any valid number" and don't care if it
 # is an integer or a floating point input.
-Number = Union[Floating, Integer]
+Number = Floating | Integer
 
 # the literals for specifying what viewer to use
-ViewerType = Union[None, Callable, Literal["gl", "jupyter", "marimo"]]
+ViewerType = Callable | Literal["gl", "jupyter", "marimo"] | None
 
 # literal for color maps we include in the library
 ColorMapType = Literal["viridis", "magma", "inferno", "plasma"]

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -9,7 +9,6 @@ import json
 import logging
 import random
 import shutil
-import sys
 import time
 import uuid
 import warnings
@@ -71,12 +70,7 @@ def has_module(name: str) -> bool:
     installed : bool
       True if module is installed
     """
-    if sys.version_info >= (3, 10):
-        # pkgutil was deprecated
-        from importlib.util import find_spec
-    else:
-        # this should work on Python 2.7 and 3.4+
-        from pkgutil import find_loader as find_spec
+    from importlib.util import find_spec
 
     return find_spec(name) is not None
 
@@ -761,7 +755,6 @@ def tolist(data):
 def is_binary_file(file_obj):
     """
     Returns True if file has non-ASCII characters (> 0x7F, or 127)
-    Should work in both Python 2 and 3
     """
     start = file_obj.tell()
     fbytes = file_obj.read(1024)

--- a/trimesh/version.py
+++ b/trimesh/version.py
@@ -7,28 +7,19 @@ if everything else fails.
 
 import json
 import os
-from typing import Optional
 
 
-def _get_version() -> Optional[str]:
+def _get_version() -> str | None:
     """
     Try all our methods to get the version.
     """
 
     try:
-        # Get the version string using package metadata on Python >= 3.8
+        # Get the version string using package metadata
         from importlib.metadata import version
 
         return version("trimesh")
-    except BaseException:
-        pass
-
-    try:
-        # Get the version string using package metadata on Python < 3.8
-        from pkg_resources import get_distribution
-
-        return get_distribution("trimesh").version
-    except BaseException:
+    except Exception:
         pass
 
     try:
@@ -46,7 +37,7 @@ def _get_version() -> Optional[str]:
             # json.loads cleans up the string and removes the quotes
             # this logic requires the first use of "version" be the actual version
             return next(json.loads(L.split("=")[1]) for L in f if "version" in L)
-    except BaseException:
+    except Exception:
         pass
 
     return None


### PR DESCRIPTION
Python 3.9 is EOL since 2025-10-31, so there's no need to support it anymore, and can even be considered as bit of a security risk (especially Python 3.8). See https://devguide.python.org/versions/ for more info.

This drops support for Python 3.8 and 3.9. I also cleaned up the dead branches, and fixed all new ruff errors (pyupgrade, mostly).

---

For some reason I had to add an additional `tests.generic` import attempt in `tests/test_voxel.py` to get the tests to run locally. It'm not sure what's going on with that, and downgrading pytest or using a different `--import-mode` didn't seem to help. The change is backwards-compatible though, so I hope it's not an issue.

---

For context: my goal was actually to increase the type annotation coverage of trimesh (it's currently at 22.9%, see  https://jorenham.github.io/typestats/dashboard/report/#trimesh for details). But doing so would be a lot easier when we don't have to worry about Python<3.10 legacy typing stuff, so I figured I might as well drop those EOL versions first.

But assuming this gets merged, I'd actually first follow-up on this by cleaning up the legacy typing re-exports in `trimesh.typed`, i.e. replace `Union` and `Optional` with `|`, and use `list[_]` instead of `List[_]`, `dict[_, _]` instead of `Dict[_, _]`, etc.

---

Oh and in case it matters here; I didn't use any AI for this.