### PR TITLE
Add missing return on cache hit in `_get_colors`

### DIFF
--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -324,6 +324,8 @@ class ColorVisuals(Visuals):
                 self._cache.verify()
                 # return the stored copy of the colors
                 return self._data[key_colors]
+            # hashes match: colors are unmodified, return the cached object directly
+            return colors
         else:
             # colors have never been accessed
             if self.kind is None:


### PR DESCRIPTION
I'm still waiting for my Alpine Linux trimesh 4.11.5 [MR](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/97599) to be approved, and while waiting the Alpine Python package was updated to 3.14.3 under me. When rebasing my MR, I got the following error on some (armv7, armhf, ppc64le, riscv64, x86) architectures:
```
_______________________________ test_data_model ________________________________
[gw9] linux -- Python 3.14.3 /builds/strophy/aports/testing/py3-trimesh/src/trimesh-4.11.5/.testenv/bin/python3
    def test_data_model():
        """
        Test the probably too- magical color caching and storage
        system.
        """
        m = g.get_mesh("featuretype.STL")
        test_color = [255, 0, 0, 255]
        test_color_2 = [0, 255, 0, 255]
        test_color_transparent = [25, 33, 0, 146]
    
        # there should be nothing in the cache or DataStore when
        # starting
        assert len(m.visual._cache) == 0
        assert len(m.visual._data) == 0
        # no visuals have been defined so this should be None
        assert m.visual.kind is None
        assert not m.visual.defined
    
        # this should cause colors to be generated into cache
        initial_id = id(m.visual.face_colors)
        assert m.visual.face_colors.shape[0] == len(m.faces)
>       assert id(m.visual.face_colors) == initial_id
E       assert 3689302040 == 3689301952
E        +  where 3689302040 = id(TrackedArray([[102, 102, 102, 255],\n              [102, 102, 102, 255],\n              [102, 102, 102, 255],\n          ... 102, 102, 255],\n              [102, 102, 102, 255],\n              [102, 102, 102, 255]], shape=(3476, 4), dtype=uint8))
E        +    where TrackedArray([[102, 102, 102, 255],\n              [102, 102, 102, 255],\n              [102, 102, 102, 255],\n          ... 102, 102, 255],\n              [102, 102, 102, 255],\n              [102, 102, 102, 255]], shape=(3476, 4), dtype=uint8) = <trimesh.visual.color.ColorVisuals object at 0xdc263330>.face_colors
E        +      where <trimesh.visual.color.ColorVisuals object at 0xdc263330> = <trimesh.Trimesh(vertices.shape=(1722, 3), faces.shape=(3476, 3))>.visual
tests/test_color.py:155: AssertionError
```
The cache hit branch of `_get_colors` was missing an early return, causing execution to fall through to `colors = caching.tracked_array(colors)` on every call, which produces a new Python object and replaces the cached entry every time. Something in the allocator has changed between Python 3.12.12 and 3.14.3, so now the identity check no longer passes. The old test was passing entirely by coincidence it seems?