### PR TITLE
Release: Embree 4 + Doc Build Fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+docs/.deps
+docs/built/
+docs/generate/
+docs/_build/
+docs/_static/examples/
+docs/trimesh*.rst
+docs/examples.*.rst
+docs/README.rst

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@ SPHINXBUILD   ?= sphinx-build
 SPHINXGEN     ?= sphinx-apidoc
 NBCONVERT     ?= jupyter
 PYTHON        ?= python
-PIP           ?= pip
+PIP           ?= uv pip
 BUILDDIR      = built
 TEMPLATESDIR  = templates
 # where to put generated RST files

--- a/helpers/Dockerfile
+++ b/helpers/Dockerfile
@@ -124,13 +124,17 @@ RUN trimesh-setup --install docs
 USER user
 
 COPY --chown=499 README.md .
+COPY --chown=499 pyproject.toml .
 COPY --chown=499 docs ./docs/
 COPY --chown=499 examples ./examples/
 COPY --chown=499 models ./models/
 COPY --chown=499 trimesh ./trimesh/
 
+# autodoc walks trimesh modules that import optional deps
+RUN pip install /home/user[easy,recommend]
+
 WORKDIR /home/user/docs
-RUN make
+RUN make clean && make
 
 ### Copy just the docs so we can output them
 FROM scratch AS docs

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -1,0 +1,58 @@
+try:
+    from . import generic as g
+except BaseException:
+    import generic as g
+
+
+def test_process_validate_stale_adjacency():
+    """
+    https://github.com/mikedh/trimesh/issues/2528
+
+    `process(validate=True)` drops faces under a cache lock, then
+    `fix_normals` reads the stale `face_adjacency` and indexes OOB.
+    """
+    vertices = g.np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [5, 0, 0],
+            [6, 0, 0],
+            [5, 1, 0],
+            [5, 0, 1],
+        ],
+        dtype=g.np.float64,
+    )
+    faces = g.np.array(
+        [
+            [0, 1, 2],
+            [0, 3, 1],
+            [0, 2, 3],
+            [1, 3, 2],
+            [0, 1, 2],
+            [0, 3, 1],
+            [0, 2, 3],
+            [4, 5, 6],
+            [4, 5, 7],
+            [4, 6, 7],
+            [5, 6, 7],
+        ],
+        dtype=g.np.int64,
+    )
+
+    mesh = g.trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+
+    # populate the face_adjacency cache so the subsequent cache lock
+    # hands out the pre-drop version to fix_winding.
+    assert mesh.face_adjacency.max() >= len(mesh.faces) - 1
+
+    mesh.process(validate=True, merge_norm=True)
+
+    # after process the adjacency must not reference dropped faces
+    assert mesh.face_adjacency.max() < len(mesh.faces)
+
+
+if __name__ == "__main__":
+    g.trimesh.util.attach_to_log()
+    test_process_validate_stale_adjacency()

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -296,20 +296,19 @@ class Trimesh(Geometry3D):
         if self.is_empty:
             return self
 
-        # avoid clearing the cache during operations
-        with self._cache:
-            # if we're cleaning remove duplicate
-            # and degenerate faces
-            if validate:
-                # get a mask with only unique and non-degenerate faces
-                mask = self.unique_faces() & self.nondegenerate_faces()
-                self.update_faces(mask)
-                self.fix_normals()
+        # if we're cleaning remove duplicate and degenerate faces. this
+        # mutates face count so it must run OUTSIDE the cache lock — locking
+        # across a face-count change leaves derived caches (face_adjacency,
+        # edges, ...) stale, which fix_normals would then read and blow up on.
+        if validate:
+            # get a mask with only unique and non-degenerate faces
+            mask = self.unique_faces() & self.nondegenerate_faces()
+            self.update_faces(mask)
+            self.fix_normals()
 
-            # since none of our process operations moved vertices or faces
-            # we can keep face and vertex normals in the cache without recomputing
-            # if faces or vertices have been removed, normals are validated before
-            # being returned so there is no danger of inconsistent dimensions
+        # the remaining ops do not change face/vertex count so we can hold
+        # the cache lock to preserve face_normals/vertex_normals across them
+        with self._cache:
             self.remove_infinite_values()
             self.merge_vertices(merge_tex=merge_tex, merge_norm=merge_norm)
             self._cache.clear(exclude={"face_normals", "vertex_normals"})

--- a/trimesh/resources/schema/primitive/wkt.polygon.schema.json
+++ b/trimesh/resources/schema/primitive/wkt.polygon.schema.json
@@ -2,6 +2,6 @@
   "$id": "https://github.com/mikedh/trimesh/blob/main/trimesh/resources/schema/primitive/wkt.polygon.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A single polygon in the Well Known Text format (WKT).",
-  "pattern": " *POLYGON *\\( *\\( *([+-]?([0-9]*[.])?[0-9]+ *[+-]?([0-9]*[.])?[0-9]+ *,* *)*\\) *\\) *",
+  "pattern": " *POLYGON *\\( *\\( *([+-]?([0-9]*[.])?[0-9]+([eE][+-]?[0-9]+)? *[+-]?([0-9]*[.])?[0-9]+([eE][+-]?[0-9]+)? *,* *)*\\) *\\) *",
   "type": "string"
 }


### PR DESCRIPTION
Release with [Embree 4 support](https://github.com/trimesh/embreex/pull/10). This shouldn't break anything for Embree 2.X which still passes `test_ray.py`. Previous release was blocked by a docs build that was failing, check out #2520 for much more detail on the embree changes.

- release https://github.com/mikedh/trimesh/pull/2520
- fix the docs build.
- fix #2528
