### PR TITLE
Release: Embree4 + Docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,12 @@ jobs:
     name: Build Docker Images
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # for gh-pages deployment
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Log In to Docker Hub
       env:
@@ -93,11 +98,15 @@ jobs:
         make tests # build docker images and run unit tests
         make publish-docker # push images to docker hub
         make docs # build sphinx docs
-    - name: Deploy Github Pages
-      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+    - name: Configure Pages
+      uses: actions/configure-pages@v5
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        publish_dir: ./html
-        force_orphan: true
+        path: ./html
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
     - name: Logout of registries
       if: always()
       run: |


### PR DESCRIPTION
Release with [Embree 4 support](https://github.com/trimesh/embreex/pull/10). This shouldn't break anything for Embree 2.X which still passes `test_ray.py`. Previous release was blocked by a docs build that was failing (third time's the charm?), check out #2520 for much more detail on the embree changes.

- release https://github.com/mikedh/trimesh/pull/2520
- fix the docs build.
- fix #2528
