### PR TITLE
In test_rps, use embreex only if it is installed

### DIFF
--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -27,7 +27,7 @@ def test_rays():
 def test_rps():
     from trimesh import ray as ray_mod
 
-    for use_embree in [True, False]:
+    for use_embree in [True, False] if ray_mod.has_embree else [False]:
         dimension = (10000, 3)
         sphere = g.get_mesh("unit_sphere.STL")
 


### PR DESCRIPTION
Without this PR, when `embreex` is not installed, `test_rps` fails:

```
========================================================================================= FAILURES ==========================================================================================
_________________________________________________________________________________________ test_rps __________________________________________________________________________________________

    def test_rps():
        from trimesh import ray as ray_mod
    
        for use_embree in [True, False]:
            dimension = (10000, 3)
            sphere = g.get_mesh("unit_sphere.STL")
    
            # blow up the number of triangles so we actually get a test
            sphere = sphere.subdivide().subdivide().subdivide()
    
            # assign a different ray intersector
            if use_embree:
>               sphere.ray = ray_mod.ray_pyembree.RayMeshIntersector(sphere)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/test_ray.py:39: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <trimesh.exceptions.ExceptionWrapper object at 0x7f9d3d096350>, args = ('RayMeshIntersector',), kwargs = {}, exc_type = <class 'ModuleNotFoundError'>
exc_args = ("No module named 'embreex'",)

    def __getattribute__(self, *args, **kwargs):
        # will raise when this object is accessed like an object
        # if it's asking for our class type return None
        # this allows isinstance() checks to not re-raise
        if args[0] == "__class__":
            return None.__class__
    
        # re-create our original exception from the type and arguments
        exc_type, exc_args = super().__getattribute__("exception")
>       raise exc_type(*exc_args)
E       ModuleNotFoundError: No module named 'embreex'

trimesh/exceptions.py:35: ModuleNotFoundError
```