### PR TITLE
Release: Mesh.contains fix 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.8"
-version = "4.12.1"
+version = "4.12.2"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -113,6 +113,22 @@ def test_contains():
         assert test_centroid.all()
 
 
+def test_contains_cavity():
+    # https://github.com/mikedh/trimesh/issues/2534
+    from trimesh import ray as ray_mod
+
+    mesh = g.trimesh.boolean.difference(
+        [g.trimesh.creation.box(extents=(1, 1, 1)),
+         g.trimesh.creation.box(extents=(0.1, 0.1, 0.1))])
+    engines = [ray_mod.ray_triangle.RayMeshIntersector]
+    if ray_mod.has_embree:
+        engines.append(ray_mod.ray_pyembree.RayMeshIntersector)
+    for engine in engines:
+        mesh.ray = engine(mesh)
+        # origin sits inside the subtracted cavity
+        assert not mesh.contains([[0, 0, 0]])[0]
+
+
 def test_on_vertex():
     for use_embree in [False]:
         m = g.trimesh.creation.box(use_embree=use_embree)
@@ -135,7 +151,7 @@ def test_on_edge():
     for use_embree in [True, False]:
         m = g.get_mesh("7_8ths_cube.stl", use_embree=use_embree)
 
-        points = [[4.5, 0, -23], [4.5, 0, -2], [0, -1e-6, 0.0], [0, 0, -1]]
+        points = [[4.5, 0, -23], [4.5, 0, -2], [0, -1e-4, 0.0], [0, 0, -1]]
         truth = [False, True, True, True]
         result = g.trimesh.ray.ray_util.contains_points(m.ray, points)
 

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -118,8 +118,11 @@ def test_contains_cavity():
     from trimesh import ray as ray_mod
 
     mesh = g.trimesh.boolean.difference(
-        [g.trimesh.creation.box(extents=(1, 1, 1)),
-         g.trimesh.creation.box(extents=(0.1, 0.1, 0.1))])
+        [
+            g.trimesh.creation.box(extents=(1, 1, 1)),
+            g.trimesh.creation.box(extents=(0.1, 0.1, 0.1)),
+        ]
+    )
     engines = [ray_mod.ray_triangle.RayMeshIntersector]
     if ray_mod.has_embree:
         engines.append(ray_mod.ray_pyembree.RayMeshIntersector)

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -119,8 +119,8 @@ def test_contains_cavity():
 
     mesh = g.trimesh.boolean.difference(
         [
-            g.trimesh.creation.box(extents=(1, 1, 1)),
-            g.trimesh.creation.box(extents=(0.1, 0.1, 0.1)),
+            g.trimesh.creation.box(extents=[1, 1, 1]),
+            g.trimesh.creation.box(extents=[0.1, 0.1, 0.1]),
         ]
     )
     engines = [ray_mod.ray_triangle.RayMeshIntersector]

--- a/trimesh/ray/ray_pyembree.py
+++ b/trimesh/ray/ray_pyembree.py
@@ -17,11 +17,9 @@ from .ray_util import contains_points
 # embree operates on float32 values
 _embree_dtype = np.float32
 
-# when calculating multiple hits we offset the hit to
-# advance the ray past the plane of the triangle we hit
-# hardcode offset for rays larger than our resolution:
-#   np.finfo(_embree_dtype).resolution * 10
-_ray_offset = 1e-5
+# scale-aware base ray offset to step past hit triangles above f32 ULP
+_ray_offset_factor = 1e-6
+_ray_offset_floor = 1e-8
 
 
 class RayMeshIntersector:
@@ -150,7 +148,8 @@ class RayMeshIntersector:
 
         if multiple_hits or return_locations:
             # how much to offset ray to transport to the other side of face
-            ray_offsets = ray_directions * _ray_offset
+            base_offset = max(_ray_offset_floor, self.mesh.scale * _ray_offset_factor)
+            ray_offsets = ray_directions * base_offset
 
             # grab the planes from triangles
             plane_origins = self.mesh.triangles[:, 0, :]
@@ -214,7 +213,7 @@ class RayMeshIntersector:
 
             # clean hits step onto the new face with a fresh base offset
             ray_origins[ok_rays] = new_origins + ray_offsets[ok_rays]
-            ray_offsets[ok_rays] = ray_directions[ok_rays] * _ray_offset
+            ray_offsets[ok_rays] = ray_directions[ok_rays] * base_offset
             # stuck rays double their offset and step further to try to clear
             ray_offsets[dupe_rays] *= 2.0
             ray_origins[dupe_rays] += ray_offsets[dupe_rays]

--- a/trimesh/ray/ray_util.py
+++ b/trimesh/ray/ray_util.py
@@ -54,10 +54,10 @@ def contains_points(
         )
 
     # cast a ray both forwards and backwards
+    # need multiple_hits=True so the parity test counts cavity walls
     _location, index_ray, _c = intersector.intersects_location(
         np.vstack((points[inside_aabb], points[inside_aabb])),
         np.vstack((ray_directions, -ray_directions)),
-        multiple_hits=False,
     )
 
     # if we hit nothing in either direction just return with no hits

--- a/trimesh/ray/ray_util.py
+++ b/trimesh/ray/ray_util.py
@@ -58,6 +58,7 @@ def contains_points(
     _location, index_ray, _c = intersector.intersects_location(
         np.vstack((points[inside_aabb], points[inside_aabb])),
         np.vstack((ray_directions, -ray_directions)),
+        multiple_hits=True,
     )
 
     # if we hit nothing in either direction just return with no hits


### PR DESCRIPTION
`mesh.contains` with multiple hits wasn't tested, and the embree 2 -> 4 move introduced a bug. 

- test and fix #2534
- restores the scale-aware offset for multiple hits.
