### PR TITLE
`trimesh.util`: fix typing errors and add missing annotations

### DIFF
--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -13,19 +13,82 @@ import time
 import uuid
 import warnings
 import zipfile
-from collections.abc import Mapping
+from collections.abc import (
+    Callable,
+    Collection,
+    Hashable,
+    Iterator,
+    Mapping,
+    MutableSet,
+    Sequence,
+)
 from copy import deepcopy
 from io import BytesIO, StringIO
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Literal,
+    TypeAlias,
+    TypedDict,
+    TypeGuard,
+    TypeVar,
+    cast,
+    overload,
+)
+
+if TYPE_CHECKING:
+    import rtree
+    from _typeshed import SizedBuffer, SupportsLenAndGetItem, SupportsRead, SupportsWrite
+    from typing_extensions import TypeIs
+
+    from trimesh.base import Trimesh
+    from trimesh.path import Path2D, Path3D
+
 
 import numpy as np
 
 from .iteration import chain
 
 # use our wrapped types for wider version compatibility
-from .typed import ArrayLike, Integer, Iterable, NDArray, float64
+from .typed import ArrayLike, Integer, Iterable, NDArray
+
+# type variables (not to be used outside of this module)
+_T = TypeVar("_T")
+_KT = TypeVar("_KT", bound=Hashable)
+_NonSequenceT = TypeVar("_NonSequenceT", bound=str | bytes | complex)
+_StrOrBytes = TypeVar("_StrOrBytes", bound=str | bytes)
+_ArrayT = TypeVar("_ArrayT", bound=NDArray[Any])
+_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
+_ScalarT = TypeVar("_ScalarT", bound=np.generic)
+_DTypeT = TypeVar("_DTypeT", bound=np.dtype[Any])
+_IntDTypeT = TypeVar("_IntDTypeT", bound=np.dtype[np.integer[Any]])
+
+# shape-typed ndarray aliases
+_VecI64: TypeAlias = np.ndarray[tuple[int], np.dtype[np.int64]]
+_VecF64: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
+_MatI64: TypeAlias = np.ndarray[tuple[int, int], np.dtype[np.int64]]
+_MatF64: TypeAlias = np.ndarray[tuple[int, int], np.dtype[np.float64]]
+
+# typed mappings for `encode_array`
+
+
+class _EncodedArray(TypedDict):
+    dtype: str
+    shape: tuple[int, ...]
+
+
+class _EncodedArrayBase64(_EncodedArray):
+    base64: str
+
+
+class _EncodedArrayBinary(_EncodedArray):
+    binary: bytes
+
 
 # create a default logger
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 ABC = abc.ABC
 now = time.time
@@ -35,9 +98,9 @@ which = shutil.which
 # a floating point threshold for 0.0
 # we are setting it to 100x the resolution of a float64
 # which works out to be 1e-13
-TOL_ZERO = np.finfo(np.float64).resolution * 100
+TOL_ZERO: Final[np.float64] = np.finfo(np.float64).resolution * 100
 # how close to merge vertices
-TOL_MERGE = 1e-8
+TOL_MERGE: Final = 1e-8
 # enable additional potentially slow checks
 _STRICT = False
 
@@ -65,7 +128,23 @@ def has_module(name: str) -> bool:
     return find_spec(name) is not None
 
 
-def unitize(vectors, check_valid=False, threshold=None):
+@overload
+def unitize(
+    vectors: ArrayLike,
+    check_valid: Literal[False] = False,
+    threshold: float | None = None,
+) -> NDArray[np.float64]: ...
+@overload
+def unitize(
+    vectors: ArrayLike,
+    check_valid: Literal[True],
+    threshold: float | None = None,
+) -> tuple[NDArray[np.float64], NDArray[np.bool_] | np.bool_]: ...
+def unitize(
+    vectors: ArrayLike,
+    check_valid: bool = False,
+    threshold: float | None = None,
+) -> NDArray[np.float64] | tuple[NDArray[np.float64], NDArray[np.bool_] | np.bool_]:
     """
     Unitize a vector or an array or row-vectors.
 
@@ -120,7 +199,7 @@ def unitize(vectors, check_valid=False, threshold=None):
     return unit
 
 
-def euclidean(a, b) -> float:
+def euclidean(a: ArrayLike, b: ArrayLike) -> np.float64:
     """
     DEPRECATED: use `np.linalg.norm(a - b)` instead of this.
     """
@@ -137,7 +216,7 @@ def euclidean(a, b) -> float:
     return np.sqrt(((a - b) ** 2).sum())
 
 
-def is_file(obj):
+def is_file(obj: object) -> TypeGuard["SupportsRead[Any] | SupportsWrite[Any]"]:
     """
     Check if an object is file-like
 
@@ -154,7 +233,7 @@ def is_file(obj):
     return hasattr(obj, "read") or hasattr(obj, "write")
 
 
-def is_pathlib(obj):
+def is_pathlib(obj: object) -> bool:
     """
     Check if the object is a `pathlib.Path` or subclass.
 
@@ -173,7 +252,7 @@ def is_pathlib(obj):
     return hasattr(obj, "absolute") and name.endswith("Path")
 
 
-def is_string(obj) -> bool:
+def is_string(obj: object) -> "TypeIs[str]":
     """
     DEPRECATED : this is not necessary since we dropped Python 2.
 
@@ -190,7 +269,7 @@ def is_string(obj) -> bool:
     return isinstance(obj, str)
 
 
-def is_sequence(obj) -> bool:
+def is_sequence(obj: object) -> TypeGuard["SupportsLenAndGetItem[Any]"]:
     """
     Check if an object is a sequence or not.
 
@@ -222,7 +301,7 @@ def is_sequence(obj) -> bool:
     return seq
 
 
-def is_shape(obj, shape, allow_zeros: bool = False) -> bool:
+def is_shape(obj: NDArray[Any], shape: Sequence[int], allow_zeros: bool = False) -> bool:
     """
     Compare the shape of a numpy.ndarray to a target shape,
     with any value less than zero being considered a wildcard
@@ -309,7 +388,13 @@ def is_shape(obj, shape, allow_zeros: bool = False) -> bool:
     return True
 
 
-def make_sequence(obj):
+@overload
+def make_sequence(obj: list[_T] | tuple[_T, ...]) -> list[_T]: ...
+@overload
+def make_sequence(obj: _NonSequenceT) -> list[_NonSequenceT]: ...
+@overload
+def make_sequence(obj: object) -> list[Any]: ...
+def make_sequence(obj: object) -> list[Any]:
     """
     Given an object, if it is a sequence return, otherwise
     add it to a length 1 sequence and return.
@@ -328,12 +413,27 @@ def make_sequence(obj):
        Contains input value
     """
     if is_sequence(obj):
-        return list(obj)
+        # false positive type error caused by bug in typeshed:
+        # https://github.com/python/typeshed/pull/12294
+        return list(obj)  # type: ignore
     else:
         return [obj]
 
 
-def vector_hemisphere(vectors, return_sign=False):
+@overload
+def vector_hemisphere(
+    vectors: ArrayLike,
+    return_sign: Literal[False] = False,
+) -> _MatF64: ...
+@overload
+def vector_hemisphere(
+    vectors: ArrayLike,
+    return_sign: Literal[True],
+) -> tuple[_MatF64, _VecF64]: ...
+def vector_hemisphere(
+    vectors: ArrayLike,
+    return_sign: bool = False,
+) -> _MatF64 | tuple[_MatF64, _VecF64]:
     """
     For a set of 3D vectors alter the sign so they are all in the
     upper hemisphere.
@@ -407,7 +507,7 @@ def vector_hemisphere(vectors, return_sign=False):
     return oriented
 
 
-def vector_to_spherical(cartesian):
+def vector_to_spherical(cartesian: ArrayLike) -> _MatF64:
     """
     Convert a set of cartesian points to (n, 2) spherical unit
     vectors.
@@ -435,7 +535,7 @@ def vector_to_spherical(cartesian):
     return spherical
 
 
-def spherical_to_vector(spherical: ArrayLike) -> NDArray[float64]:
+def spherical_to_vector(spherical: ArrayLike) -> _MatF64:
     """
     Convert an array of `(n, 2)` spherical angles to `(n, 3)` unit vectors.
 
@@ -459,7 +559,13 @@ def spherical_to_vector(spherical: ArrayLike) -> NDArray[float64]:
     return np.column_stack((ct * sp, st * sp, cp))
 
 
-def pairwise(iterable):
+@overload
+def pairwise(
+    iterable: np.ndarray[Any, _DTypeT],
+) -> np.ndarray[tuple[int, int], _DTypeT]: ...
+@overload
+def pairwise(iterable: Iterable[_T]) -> "zip[tuple[_T, _T]]": ...
+def pairwise(iterable: Iterable[Any]) -> "zip[tuple[Any, Any]] | NDArray[Any]":
     """
     For an iterable, group values into pairs.
 
@@ -500,27 +606,10 @@ def pairwise(iterable):
     return zip(a, b)
 
 
-try:
-    # prefer the faster numpy version of multi_dot
-    # only included in recent-ish version of numpy
-    multi_dot = np.linalg.multi_dot
-except AttributeError:
-    log.debug("np.linalg.multi_dot not available, using fallback")
-
-    def multi_dot(arrays):
-        """
-        Compute the dot product of two or more arrays in a single function call.
-        In most versions of numpy this is included, this slower function is
-        provided for backwards compatibility with ancient versions of numpy.
-        """
-        arrays = np.asanyarray(arrays)
-        result = arrays[0].copy()
-        for i in arrays[1:]:
-            result = np.dot(result, i)
-        return result
+multi_dot = np.linalg.multi_dot
 
 
-def diagonal_dot(a, b):
+def diagonal_dot(a: ArrayLike, b: ArrayLike) -> np.ndarray[tuple[int], np.dtype[Any]]:
     """
     Dot product by row of a and b.
 
@@ -574,7 +663,9 @@ def diagonal_dot(a, b):
     return np.dot(a * b, [1.0] * a.shape[1])
 
 
-def row_norm(data):
+def row_norm(
+    data: np.ndarray[tuple[int, int], np.dtype[np.integer[Any] | np.floating[Any]]],
+) -> _VecF64:
     """
     Compute the norm per-row of a numpy array.
 
@@ -600,7 +691,14 @@ def row_norm(data):
     return np.sqrt(np.dot(data**2, [1] * data.shape[1]))
 
 
-def stack_3D(points, return_2D=False):
+@overload
+def stack_3D(points: ArrayLike, return_2D: Literal[False] = False) -> _MatF64: ...
+@overload
+def stack_3D(points: ArrayLike, return_2D: Literal[True]) -> tuple[_MatF64, bool]: ...
+def stack_3D(
+    points: ArrayLike,
+    return_2D: bool = False,
+) -> _MatF64 | tuple[_MatF64, bool]:
     """
     For a list of (n, 2) or (n, 3) points return them
     as (n, 3) 3D points, 2D points on the XY plane.
@@ -640,7 +738,7 @@ def stack_3D(points, return_2D=False):
     return points
 
 
-def grid_arange(bounds, step):
+def grid_arange(bounds: ArrayLike, step: ArrayLike) -> _MatF64:
     """
     Return a grid from an (2,dimension) bounds with samples step distance apart.
 
@@ -671,7 +769,7 @@ def grid_arange(bounds, step):
     return grid
 
 
-def grid_linspace(bounds, count):
+def grid_linspace(bounds: ArrayLike, count: ArrayLike) -> _MatF64:
     """
     Return a grid spaced inside a bounding box with edges spaced using np.linspace.
 
@@ -701,7 +799,7 @@ def grid_linspace(bounds, count):
     return grid
 
 
-def multi_dict(pairs):
+def multi_dict(pairs: Iterable[tuple[_KT, _T]]) -> collections.defaultdict[_KT, list[_T]]:
     """
     Given a set of key value pairs, create a dictionary.
     If a key occurs multiple times, stack the values into an array.
@@ -723,7 +821,7 @@ def multi_dict(pairs):
     return result
 
 
-def tolist(data):
+def tolist(data: object) -> Any:
     """
     Ensure that any arrays or dicts passed containing
     numpy arrays are properly converted to lists
@@ -742,7 +840,7 @@ def tolist(data):
     return result
 
 
-def is_binary_file(file_obj):
+def is_binary_file(file_obj: IO[Any]) -> bool:
     """
     Returns True if file has non-ASCII characters (> 0x7F, or 127)
     """
@@ -760,7 +858,7 @@ def is_binary_file(file_obj):
     return False
 
 
-def distance_to_end(file_obj):
+def distance_to_end(file_obj: IO[Any]) -> int:
     """
     For an open file object how far is it to the end
 
@@ -780,7 +878,7 @@ def distance_to_end(file_obj):
     return distance
 
 
-def decimal_to_digits(decimal, min_digits=None) -> int:
+def decimal_to_digits(decimal: float | np.floating, min_digits: int | None = None) -> int:
     """
     Return the number of digits to the first nonzero decimal.
 
@@ -801,14 +899,14 @@ def decimal_to_digits(decimal, min_digits=None) -> int:
 
 
 def attach_to_log(
-    level=logging.DEBUG,
-    handler=None,
-    loggers: Iterable[logging.Logger] | None = None,
+    level: int = logging.DEBUG,
+    handler: logging.Handler | None = None,
+    loggers: MutableSet[logging.Logger | Any] | None = None,
     colors: bool = True,
     capture_warnings: bool = True,
-    blacklist: Iterable | None = None,
+    blacklist: Iterable[str] | None = None,
     only_parent: bool = True,
-):
+) -> None:
     """
     Attach a stream handler to all loggers.
 
@@ -894,7 +992,7 @@ def attach_to_log(
     logging.getLogger("pyembree").disabled = True
 
     # cull loggers that are not actually loggers or are on the blacklist
-    loggers = {
+    loggers_dict = {
         L.name: L
         for L in loggers
         if hasattr(L, "name")
@@ -906,15 +1004,15 @@ def attach_to_log(
         # create a new dict to store only parent loggers
         parent_loggers = {}
         # sort logger names to process in hierarchical order
-        for name in sorted(loggers.keys()):
+        for name in sorted(loggers_dict.keys()):
             # if it's not a child of any existing parent, add it as a parent
             if not any(name.startswith(f"{p}.") for p in parent_loggers.keys()):
-                parent_loggers[name] = loggers[name]
+                parent_loggers[name] = loggers_dict[name]
         # replace loggers dict with only parent loggers
-        loggers = parent_loggers
+        loggers_dict = parent_loggers
 
     # loop through all available loggers
-    for logger in loggers.values():
+    for logger in loggers_dict.values():
         logger.addHandler(handler)
         logger.setLevel(level)
 
@@ -922,7 +1020,13 @@ def attach_to_log(
     np.set_printoptions(precision=5, suppress=True)
 
 
-def stack_lines(indices):
+@overload
+def stack_lines(
+    indices: np.ndarray[Any, _DTypeT],
+) -> np.ndarray[tuple[int, int], _DTypeT]: ...
+@overload
+def stack_lines(indices: ArrayLike) -> np.ndarray[tuple[int, int], np.dtype[Any]]: ...
+def stack_lines(indices: ArrayLike) -> np.ndarray[tuple[int, int], np.dtype[Any]]:
     """
     Stack a list of values that represent a polyline into
     individual line segments with duplicated consecutive values.
@@ -971,7 +1075,13 @@ def stack_lines(indices):
     return np.column_stack((indices[:-1], indices[1:])).reshape(shape)
 
 
-def append_faces(vertices_seq, faces_seq):
+def append_faces(
+    vertices_seq: Iterable[NDArray[_ScalarT]],
+    faces_seq: Iterable[NDArray[np.integer[Any]]],
+) -> tuple[
+    np.ndarray[tuple[int, int], np.dtype[_ScalarT]],
+    _MatI64,
+]:
     """
     Given a sequence of zero-indexed faces and vertices
     combine them into a single array of faces and
@@ -992,9 +1102,9 @@ def append_faces(vertices_seq, faces_seq):
       Reference vertex indices
     """
     # the length of each vertex array
-    vertices_len = np.array([len(i) for i in vertices_seq])
+    vertices_len: _VecI64 = np.array([len(i) for i in vertices_seq])
     # how much each group of faces needs to be offset
-    face_offset = np.append(0, np.cumsum(vertices_len)[:-1])
+    face_offset: _VecI64 = np.append(0, np.cumsum(vertices_len)[:-1])
 
     new_faces = []
     for offset, faces in zip(face_offset, faces_seq):
@@ -1007,10 +1117,17 @@ def append_faces(vertices_seq, faces_seq):
     # stack to clean (n, 3) int
     faces = vstack_empty(new_faces)
 
+    # the `# type: ignore` is needed due to limitated numpy typing support
     return vertices, faces
 
 
-def array_to_string(array, col_delim=" ", row_delim="\n", digits=8, value_format="{}"):
+def array_to_string(
+    array: ArrayLike,
+    col_delim: str = " ",
+    row_delim: str = "\n",
+    digits: int = 8,
+    value_format: str = "{}",
+) -> str:
     """
     Convert a 1 or 2D array into a string with a specified number
     of digits and delimiter. The reason this exists is that the
@@ -1089,8 +1206,12 @@ def array_to_string(array, col_delim=" ", row_delim="\n", digits=8, value_format
 
 
 def structured_array_to_string(
-    array, col_delim=" ", row_delim="\n", digits=8, value_format="{}"
-):
+    array: ArrayLike,
+    col_delim: str = " ",
+    row_delim: str = "\n",
+    digits: int = 8,
+    value_format: str = "{}",
+) -> str:
     """
     Convert an unstructured array into a string with a specified
     number of digits and delimiter. The reason thisexists is
@@ -1177,7 +1298,30 @@ def structured_array_to_string(
     return formatted
 
 
-def array_to_encoded(array, dtype=None, encoding="base64"):
+@overload
+def array_to_encoded(
+    array: ArrayLike,
+    dtype: np.typing.DTypeLike | None = None,
+    encoding: Literal["base64"] = "base64",
+) -> "_EncodedArrayBase64": ...
+@overload
+def array_to_encoded(
+    array: ArrayLike,
+    dtype: np.typing.DTypeLike | None = None,
+    *,
+    encoding: Literal["binary"],
+) -> "_EncodedArrayBinary": ...
+@overload
+def array_to_encoded(
+    array: ArrayLike,
+    dtype: np.typing.DTypeLike,
+    encoding: Literal["binary"],
+) -> "_EncodedArrayBinary": ...
+def array_to_encoded(
+    array: ArrayLike,
+    dtype: np.typing.DTypeLike | None = None,
+    encoding: str = "base64",
+) -> Mapping[str, Any]:
     """
     Export a numpy array to a compact serializable dictionary.
 
@@ -1205,7 +1349,7 @@ def array_to_encoded(array, dtype=None, encoding="base64"):
     if dtype is None:
         dtype = array.dtype
 
-    encoded = {"dtype": np.dtype(dtype).str, "shape": shape}
+    encoded: dict[str, Any] = {"dtype": np.dtype(dtype).str, "shape": shape}
     if encoding in ["base64", "dict64"]:
         packed = base64.b64encode(flat.astype(dtype).tobytes())
         if hasattr(packed, "decode"):
@@ -1218,7 +1362,8 @@ def array_to_encoded(array, dtype=None, encoding="base64"):
     return encoded
 
 
-def decode_keys(store, encoding="utf-8"):
+# the store key type must be `Any` because the key type changes from `bytes` to `str`
+def decode_keys(store: dict[Any, _T], encoding: str = "utf-8") -> dict[str, _T]:
     """
     If a dictionary has keys that are bytes decode them to a str.
 
@@ -1251,7 +1396,7 @@ def decode_keys(store, encoding="utf-8"):
     return store
 
 
-def comment_strip(text, starts_with="#", new_line="\n"):
+def comment_strip(text: str, starts_with: str = "#", new_line: str = "\n") -> str:
     """
     Strip comments from a text block.
 
@@ -1296,7 +1441,11 @@ def comment_strip(text, starts_with="#", new_line="\n"):
     return result
 
 
-def encoded_to_array(encoded: dict | ArrayLike) -> NDArray:
+@overload
+def encoded_to_array(encoded: _ArrayT) -> _ArrayT: ...
+@overload  # `_StrOrBytes` is used instead of `str | bytes` because `dict` is invariant.
+def encoded_to_array(encoded: ArrayLike | dict[_StrOrBytes, Any]) -> NDArray[Any]: ...
+def encoded_to_array(encoded: ArrayLike | dict[_StrOrBytes, Any]) -> NDArray[Any]:
     """
     Turn a dictionary with base64 encoded strings back into a numpy array.
 
@@ -1321,19 +1470,21 @@ def encoded_to_array(encoded: dict | ArrayLike) -> NDArray:
         else:
             raise ValueError("Unable to extract numpy array from input")
 
-    encoded = decode_keys(encoded)
+    encoded_dict = decode_keys(encoded)
 
-    dtype = np.dtype(encoded["dtype"])
-    if "base64" in encoded:
-        array = np.frombuffer(base64.b64decode(encoded["base64"]), dtype)
-    elif "binary" in encoded:
-        array = np.frombuffer(encoded["binary"], dtype=dtype)
-    if "shape" in encoded:
-        array = array.reshape(encoded["shape"])
+    dtype = np.dtype(encoded_dict["dtype"])
+    if "base64" in encoded_dict:
+        array = np.frombuffer(base64.b64decode(encoded_dict["base64"]), dtype)
+    elif "binary" in encoded_dict:
+        array = np.frombuffer(encoded_dict["binary"], dtype=dtype)
+    else:
+        raise ValueError("Invalid encoded array, no 'base64' or 'binary' key found")
+    if "shape" in encoded_dict:
+        array = array.reshape(encoded_dict["shape"])
     return array
 
 
-def is_instance_named(obj, name):
+def is_instance_named(obj: object, name: str) -> bool:
     """
     Given an object, if it is a member of the class 'name',
     or a subclass of 'name', return True.
@@ -1360,21 +1511,23 @@ def is_instance_named(obj, name):
         return False
 
 
-def type_bases(obj, depth=4):
+def type_bases(obj: object, depth: int = 4) -> list[type[Any]]:
     """
     Return the bases of the object passed.
     """
-    bases = collections.deque([list(obj.__class__.__bases__)])
+    bases: collections.deque[list[Any]] = collections.deque(
+        [list(obj.__class__.__bases__)]
+    )
     for i in range(depth):
         bases.append([i.__base__ for i in bases[-1] if i is not None])
     try:
-        bases = np.hstack(bases)
+        bases_flat = np.hstack(bases)
     except IndexError:
-        bases = []
-    return [i for i in bases if hasattr(i, "__name__")]
+        return []
+    return [i for i in bases_flat if hasattr(i, "__name__")]
 
 
-def type_named(obj, name):
+def type_named(obj: object, name: str) -> type[Any] | None:
     """
     Similar to the type() builtin, but looks in class bases
     for named instance.
@@ -1402,8 +1555,9 @@ def type_named(obj, name):
 
 
 def concatenate(
-    a, b=None
-) -> "trimesh.Trimesh | trimesh.path.Path2D | trimesh.path.Path3D":  # noqa: F821
+    a: "Trimesh | Iterable[Trimesh]",
+    b: "Trimesh | Iterable[Trimesh] | None" = None,
+) -> "Trimesh | Path2D | Path3D":
     """
     Concatenate two or more meshes.
 
@@ -1482,7 +1636,7 @@ def concatenate(
 
     metadata = {}
     try:
-        [metadata.update(deepcopy(m.metadata) for m in is_mesh)]
+        _ = [metadata.update(deepcopy(m.metadata) for m in is_mesh)]
     except BaseException:
         pass
 
@@ -1517,6 +1671,7 @@ def concatenate(
                 )
 
     # create the mesh object
+    assert trimesh_type is not None
     result = trimesh_type(
         vertices=vertices,
         faces=faces,
@@ -1537,14 +1692,33 @@ def concatenate(
     return result
 
 
+@overload
 def submesh(
-    mesh,
-    faces_sequence,
+    mesh: "Trimesh",
+    faces_sequence: Iterable[int],
+    repair: bool = True,
+    only_watertight: bool = False,
+    min_faces: Integer | None = None,
+    append: Literal[False] = False,
+) -> "Trimesh": ...
+@overload
+def submesh(
+    mesh: "Trimesh",
+    faces_sequence: Iterable[int],
+    repair: bool = True,
+    only_watertight: bool = False,
+    min_faces: Integer | None = None,
+    *,
+    append: Literal[True],
+) -> list["Trimesh"]: ...
+def submesh(
+    mesh: "Trimesh",
+    faces_sequence: Iterable[int],
     repair: bool = True,
     only_watertight: bool = False,
     min_faces: Integer | None = None,
     append: bool = False,
-):
+) -> "Trimesh | list[Trimesh]":
     """
     Return a subset of a mesh.
 
@@ -1612,6 +1786,7 @@ def submesh(
         faces.append(mask[current])
         vertices.append(original_vertices[unique])
 
+        assert mesh.visual is not None
         try:
             visuals.append(mesh.visual.face_subset(index))
         except BaseException as E:
@@ -1619,17 +1794,19 @@ def submesh(
             visuals = None
 
     if len(vertices) == 0:
-        return np.array([])
+        return []
 
     # we use type(mesh) rather than importing Trimesh from base
     # to avoid a circular import
     trimesh_type = type_named(mesh, "Trimesh")
+    assert trimesh_type is not None
+
     if append:
         visual = None
         try:
             visuals = np.array(visuals)
             visual = visuals[0].concatenate(visuals[1:])
-        except BaseException:
+        except Exception:
             log.debug("failed to combine visuals", exc_info=True)
         # re-index faces and stack
         vertices, faces = append_faces(vertices, faces)
@@ -1680,7 +1857,7 @@ def submesh(
     return result
 
 
-def zero_pad(data, count, right=True):
+def zero_pad(data: _ArrayT, count: int, right: bool = True) -> _ArrayT | _VecF64:
     """
     Parameters
     ------------
@@ -1707,7 +1884,7 @@ def zero_pad(data, count, right=True):
         return np.asanyarray(data)
 
 
-def jsonify(obj, **kwargs):
+def jsonify(obj: object, **kwargs: Any) -> str:
     """
     A version of json.dumps that can handle numpy arrays
     by creating a custom encoder for numpy dtypes.
@@ -1726,20 +1903,32 @@ def jsonify(obj, **kwargs):
     """
 
     class EdgeEncoder(json.JSONEncoder):
-        def default(self, obj):
+        def default(self, o: Any) -> str:
             # will work for numpy.ndarrays
             # as well as their int64/etc objects
-            if hasattr(obj, "tolist"):
-                return obj.tolist()
-            elif hasattr(obj, "timestamp"):
-                return obj.timestamp()
-            return json.JSONEncoder.default(self, obj)
+            if hasattr(o, "tolist"):
+                return o.tolist()
+            elif hasattr(o, "timestamp"):
+                return o.timestamp()
+            return json.JSONEncoder.default(self, o)
 
     # run the dumps using our encoder
     return json.dumps(obj, cls=EdgeEncoder, **kwargs)
 
 
-def convert_like(item, like):
+@overload
+def convert_like(
+    item: np.ndarray[_ShapeT, Any],
+    like: NDArray[_ScalarT] | _ScalarT,
+) -> np.ndarray[_ShapeT, np.dtype[_ScalarT]]: ...
+@overload
+def convert_like(
+    item: ArrayLike,
+    like: NDArray[_ScalarT] | _ScalarT,
+) -> NDArray[_ScalarT]: ...
+@overload
+def convert_like(item: object, like: object) -> Any: ...
+def convert_like(item: Any, like: Any) -> Any:
     """
     Convert an item to have the dtype of another item
 
@@ -1784,7 +1973,7 @@ def convert_like(item, like):
     return item
 
 
-def bounds_tree(bounds):
+def bounds_tree(bounds: ArrayLike) -> "rtree.index.Index":
     """
     Given a set of axis aligned bounds create an r-tree for
     broad-phase collision detection.
@@ -1827,7 +2016,11 @@ def bounds_tree(bounds):
     )
 
 
-def wrap_as_stream(item):
+@overload
+def wrap_as_stream(item: str) -> StringIO: ...
+@overload
+def wrap_as_stream(item: bytes) -> BytesIO: ...
+def wrap_as_stream(item: str | bytes) -> StringIO | BytesIO:
     """
     Wrap a string or bytes object as a file object.
 
@@ -1848,7 +2041,7 @@ def wrap_as_stream(item):
     raise ValueError(f"{type(item).__name__} is not wrappable!")
 
 
-def sigfig_round(values, sigfig=1):
+def sigfig_round(values: ArrayLike, sigfig: ArrayLike = 1) -> _VecF64:
     """
     Round a single value to a specified number of significant figures.
 
@@ -1882,7 +2075,7 @@ def sigfig_round(values, sigfig=1):
     return rounded
 
 
-def sigfig_int(values, sigfig):
+def sigfig_int(values: ArrayLike, sigfig: ArrayLike) -> tuple[_VecI64, _VecF64]:
     """
     Convert a set of floating point values into integers
     with a specified number of significant figures and an
@@ -1899,7 +2092,7 @@ def sigfig_int(values, sigfig):
     ------------
     as_int : (n,) int
       Every value[i] has sigfig[i] digits
-    multiplier : (n, int)
+    multiplier : (n,) float
       Exponent, so as_int * 10 ** multiplier is
       the same order of magnitude as the input
     """
@@ -1919,7 +2112,10 @@ def sigfig_int(values, sigfig):
     return as_int, multiplier
 
 
-def decompress(file_obj, file_type):
+def decompress(
+    file_obj: "bytes | IO[bytes]",
+    file_type: str,
+) -> dict[str, IO[bytes] | None]:
     """
     Given an open file object and a file type, return all components
     of the archive as open file objects in a dict.
@@ -1958,7 +2154,10 @@ def decompress(file_obj, file_type):
     raise ValueError("Unsupported type passed!")
 
 
-def compress(info, **kwargs):
+def compress(
+    info: Mapping[str, "str | SizedBuffer | SupportsRead[Any]"],
+    **kwargs: Any,
+) -> bytes:
     """
     Compress data stored in a dict.
 
@@ -1978,17 +2177,19 @@ def compress(info, **kwargs):
     with zipfile.ZipFile(
         file_obj, mode="w", compression=zipfile.ZIP_DEFLATED, **kwargs
     ) as zipper:
-        for name, data in info.items():
-            if hasattr(data, "read"):
+        for name, data_or_file in info.items():
+            if hasattr(data_or_file, "read"):
                 # if we were passed a file object, read it
-                data = data.read()
+                data = cast("SupportsRead[Any]", data_or_file).read()
+            else:
+                data = cast("str | SizedBuffer", data_or_file)
             zipper.writestr(name, data)
     file_obj.seek(0)
     compressed = file_obj.read()
     return compressed
 
 
-def split_extension(file_name, special=None) -> str:
+def split_extension(file_name: str, special: Iterable[str] | None = None) -> str:
     """
     Find the file extension of a file name, including support for
     special case multipart file extensions (like .tar.gz)
@@ -2018,7 +2219,9 @@ def split_extension(file_name, special=None) -> str:
     return file_name.split(".")[-1]
 
 
-def triangle_strips_to_faces(strips):
+def triangle_strips_to_faces(
+    strips: "SupportsLenAndGetItem[NDArray[np.integer[Any]]]",
+) -> _MatI64:
     """
     Convert a sequence of triangle strips to (n, 3) faces.
 
@@ -2079,7 +2282,7 @@ def triangle_strips_to_faces(strips):
     return tri
 
 
-def triangle_fans_to_faces(fans):
+def triangle_fans_to_faces(fans: Iterable[NDArray[np.integer[Any]]]) -> _MatI64:
     """
     Convert fans of m + 2 vertex indices in fan format to m triangles
 
@@ -2098,10 +2301,12 @@ def triangle_fans_to_faces(fans):
         np.transpose([fan[0] * np.ones(len(fan) - 2, dtype=int), fan[1:-1], fan[2:]])
         for fan in fans
     ]
-    return np.concatenate(faces)
+    return np.concatenate(faces, dtype=int)
 
 
-def vstack_empty(tup):
+def vstack_empty(
+    tup: Iterable[NDArray[_ScalarT]],
+) -> np.ndarray[tuple[int, int], np.dtype[_ScalarT]]:
     """
     A thin wrapper for numpy.vstack that ignores empty lists.
 
@@ -2128,7 +2333,11 @@ def vstack_empty(tup):
     return np.vstack(stackable)
 
 
-def write_encoded(file_obj, stuff, encoding="utf-8"):
+def write_encoded(
+    file_obj: IO[Any],
+    stuff: _StrOrBytes,
+    encoding: str = "utf-8",
+) -> _StrOrBytes:
     """
     If a file is open in binary mode and a
     string is passed, encode and write.
@@ -2162,7 +2371,7 @@ def write_encoded(file_obj, stuff, encoding="utf-8"):
     return stuff
 
 
-def unique_id(length=12):
+def unique_id(length: int = 12) -> str:
     """
     Generate a random alphaNumber unique identifier
     using UUID logic.
@@ -2180,7 +2389,7 @@ def unique_id(length=12):
     return uuid.UUID(int=random.getrandbits(128), version=4).hex[:length]
 
 
-def generate_basis(z, epsilon=1e-12):
+def generate_basis(z: ArrayLike, epsilon: float = 1e-12) -> _MatF64:
     """
     Generate an arbitrary basis (also known as a coordinate frame)
     from a given z-axis vector.
@@ -2241,7 +2450,11 @@ def generate_basis(z, epsilon=1e-12):
     return result
 
 
-def isclose(a, b, atol: float = 1e-8):
+def isclose(
+    a: np.ndarray[_ShapeT, np.dtype[Any]],
+    b: np.ndarray[_ShapeT, np.dtype[Any]],
+    atol: float = 1e-8,
+) -> np.ndarray[_ShapeT, np.dtype[np.bool_]]:
     """
     A replacement for np.isclose that does fewer checks
     and validation and as a result is roughly 4x faster.
@@ -2264,10 +2477,13 @@ def isclose(a, b, atol: float = 1e-8):
       Per-element closeness
     """
     diff = a - b
-    return np.logical_and(diff > -atol, diff < atol)
+    return cast(
+        "np.ndarray[_ShapeT, np.dtype[np.bool_]]",
+        np.logical_and(diff > -atol, diff < atol),
+    )
 
 
-def allclose(a, b, atol: float = 1e-8):
+def allclose(a: NDArray[Any], b: NDArray[Any], atol: float = 1e-8) -> bool:
     """
     A replacement for np.allclose that does few checks
     and validation and as a result is faster.
@@ -2289,7 +2505,7 @@ def allclose(a, b, atol: float = 1e-8):
     return float(np.ptp(a - b)) < atol
 
 
-class FunctionRegistry(Mapping):
+class FunctionRegistry(Mapping[str, Callable[..., Any]]):
     """
     Non-overwritable mapping of string keys to functions.
 
@@ -2300,15 +2516,15 @@ class FunctionRegistry(Mapping):
     See trimesh.voxel.morphology for example usage.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Callable[..., Any]) -> None:
         self._dict = {}
         for k, v in kwargs.items():
             self[k] = v
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Callable[..., Any]:
         return self._dict[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Callable[..., object]) -> None:
         if not isinstance(key, str):
             raise ValueError(f"key must be a string, got {key!s}")
         if key in self:
@@ -2317,20 +2533,20 @@ class FunctionRegistry(Mapping):
             raise ValueError("Cannot set value which is not callable.")
         self._dict[key] = value
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self._dict)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._dict)
 
-    def __contains__(self, key):
+    def __contains__(self, key: object) -> bool:
         return key in self._dict
 
-    def __call__(self, key, *args, **kwargs):
+    def __call__(self, key: str, *args: object, **kwargs: object) -> Any:
         return self[key](*args, **kwargs)
 
 
-def decode_text(text, initial="utf-8"):
+def decode_text(text: str | bytes, initial: str = "utf-8") -> str:
     """
     Try to decode byte input as a string.
 
@@ -2350,11 +2566,16 @@ def decode_text(text, initial="utf-8"):
       Data as a string
     """
     # if not bytes just return input
-    if not hasattr(text, "decode"):
-        return text
+    if TYPE_CHECKING:  # workaround for the lack of `hasattr` support in type-checkers
+        if not isinstance(text, bytes):
+            return text
+    else:
+        if not hasattr(text, "decode"):
+            return text
+
     try:
         # initially guess file is UTF-8 or specified encoding
-        text = text.decode(initial)
+        return text.decode(initial)
     except UnicodeDecodeError:
         # detect different file encodings
         from charset_normalizer import detect as charset_normalizer_detect
@@ -2370,11 +2591,10 @@ def decode_text(text, initial="utf-8"):
         )
         # try to decode again ignoring errors
         # if detect returned nothing just use the initial guess
-        text = text.decode(detect["encoding"] or initial, errors="ignore")
-    return text
+        return text.decode(detect["encoding"] or initial, errors="ignore")
 
 
-def to_ascii(text):
+def to_ascii(text: Any) -> str:
     """
     Force a string or other to ASCII text ignoring errors.
 
@@ -2398,7 +2618,17 @@ def to_ascii(text):
     return str(text)
 
 
-def is_ccw(points, return_all=False):
+@overload
+def is_ccw(points: ArrayLike, return_all: Literal[False] = False) -> np.bool_: ...
+@overload
+def is_ccw(
+    points: ArrayLike,
+    return_all: Literal[True],
+) -> tuple[np.bool_, np.float64, _VecF64]: ...
+def is_ccw(
+    points: ArrayLike,
+    return_all: bool = False,
+) -> np.bool_ | tuple[np.bool_, np.float64, _VecF64]:
     """
     Check if connected 2D points are counterclockwise.
 
@@ -2442,10 +2672,10 @@ def is_ccw(points, return_all=False):
 
 
 def unique_name(
-    start: str | None,
-    contains: set | Mapping | Iterable,
-    counts: dict | None = None,
-):
+    start: str,
+    contains: Collection[str],
+    counts: dict[str, int] | None = None,
+) -> str:
     """
     Deterministically generate a unique name not
     contained in a dict, set or other grouping with

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -30,6 +30,7 @@ from typing import (
     Any,
     Final,
     Literal,
+    Protocol,
     TypeAlias,
     TypedDict,
     TypeGuard,
@@ -40,12 +41,11 @@ from typing import (
 
 if TYPE_CHECKING:
     import rtree
-    from _typeshed import SizedBuffer, SupportsLenAndGetItem, SupportsRead, SupportsWrite
+    from _typeshed import SizedBuffer, SupportsRead, SupportsWrite
     from typing_extensions import TypeIs
 
-    from trimesh.base import Trimesh
-    from trimesh.path import Path2D, Path3D
-
+    import trimesh
+    import trimesh.path
 
 import numpy as np
 
@@ -56,6 +56,7 @@ from .typed import ArrayLike, Integer, Iterable, NDArray
 
 # type variables (not to be used outside of this module)
 _T = TypeVar("_T")
+_T_co = TypeVar("_T_co", covariant=True)
 _KT = TypeVar("_KT", bound=Hashable)
 _NonSequenceT = TypeVar("_NonSequenceT", bound=str | bytes | complex)
 _StrOrBytes = TypeVar("_StrOrBytes", bound=str | bytes)
@@ -85,6 +86,12 @@ class _EncodedArrayBase64(_EncodedArray):
 
 class _EncodedArrayBinary(_EncodedArray):
     binary: bytes
+
+
+# beartype-friendly equivalents of `_typeshed` protocols
+class _SupportsLenAndGetItem(Protocol[_T_co]):
+    def __len__(self) -> int: ...
+    def __getitem__(self, k: int, /) -> _T_co: ...
 
 
 # create a default logger
@@ -269,7 +276,7 @@ def is_string(obj: object) -> "TypeIs[str]":
     return isinstance(obj, str)
 
 
-def is_sequence(obj: object) -> TypeGuard["SupportsLenAndGetItem[Any]"]:
+def is_sequence(obj: object) -> TypeGuard[_SupportsLenAndGetItem[Any]]:
     """
     Check if an object is a sequence or not.
 
@@ -301,7 +308,11 @@ def is_sequence(obj: object) -> TypeGuard["SupportsLenAndGetItem[Any]"]:
     return seq
 
 
-def is_shape(obj: NDArray[Any], shape: Sequence[int], allow_zeros: bool = False) -> bool:
+def is_shape(
+    obj: object,
+    shape: Sequence[int | tuple[int, ...]],
+    allow_zeros: bool = False,
+) -> bool:
     """
     Compare the shape of a numpy.ndarray to a target shape,
     with any value less than zero being considered a wildcard
@@ -353,6 +364,9 @@ def is_shape(obj: NDArray[Any], shape: Sequence[int], allow_zeros: bool = False)
     if not hasattr(obj, "shape") or len(obj.shape) != len(shape):
         return False
 
+    # most type-checkers (still) don't support `hasattr` type narrowing
+    obj = cast("NDArray[Any]", obj)
+
     # empty lists with any flexible dimensions match
     if len(obj) == 0 and -1 in shape:
         return True
@@ -370,7 +384,7 @@ def is_shape(obj: NDArray[Any], shape: Sequence[int], allow_zeros: bool = False)
                 return False
 
         # check if current field is a wildcard
-        if target < 0:
+        if cast(int, target) < 0:
             if i == 0 and not allow_zeros:
                 # if a dimension is 0, we don't allow
                 # that to match to a wildcard
@@ -1484,7 +1498,7 @@ def encoded_to_array(encoded: ArrayLike | dict[_StrOrBytes, Any]) -> NDArray[Any
     return array
 
 
-def is_instance_named(obj: object, name: str) -> bool:
+def is_instance_named(obj: object, name: str | list[str]) -> bool:
     """
     Given an object, if it is a member of the class 'name',
     or a subclass of 'name', return True.
@@ -1555,9 +1569,9 @@ def type_named(obj: object, name: str) -> type[Any] | None:
 
 
 def concatenate(
-    a: "Trimesh | Iterable[Trimesh]",
-    b: "Trimesh | Iterable[Trimesh] | None" = None,
-) -> "Trimesh | Path2D | Path3D":
+    a: "trimesh.Trimesh | Iterable[trimesh.Trimesh]",
+    b: "trimesh.Trimesh | Iterable[trimesh.Trimesh] | None" = None,
+) -> "trimesh.Trimesh | trimesh.path.Path2D | trimesh.path.Path3D":
     """
     Concatenate two or more meshes.
 
@@ -1694,31 +1708,31 @@ def concatenate(
 
 @overload
 def submesh(
-    mesh: "Trimesh",
+    mesh: "trimesh.Trimesh",
     faces_sequence: Iterable[int],
     repair: bool = True,
     only_watertight: bool = False,
     min_faces: Integer | None = None,
     append: Literal[False] = False,
-) -> "Trimesh": ...
+) -> "trimesh.Trimesh": ...
 @overload
 def submesh(
-    mesh: "Trimesh",
+    mesh: "trimesh.Trimesh",
     faces_sequence: Iterable[int],
     repair: bool = True,
     only_watertight: bool = False,
     min_faces: Integer | None = None,
     *,
     append: Literal[True],
-) -> list["Trimesh"]: ...
+) -> list["trimesh.Trimesh"]: ...
 def submesh(
-    mesh: "Trimesh",
+    mesh: "trimesh.Trimesh",
     faces_sequence: Iterable[int],
     repair: bool = True,
     only_watertight: bool = False,
     min_faces: Integer | None = None,
     append: bool = False,
-) -> "Trimesh | list[Trimesh]":
+) -> "trimesh.Trimesh | list[trimesh.Trimesh]":
     """
     Return a subset of a mesh.
 
@@ -2113,9 +2127,9 @@ def sigfig_int(values: ArrayLike, sigfig: ArrayLike) -> tuple[_VecI64, _VecF64]:
 
 
 def decompress(
-    file_obj: "bytes | IO[bytes]",
+    file_obj: bytes | IO[bytes] | BytesIO,  # https://github.com/beartype/beartype/issues/643
     file_type: str,
-) -> dict[str, IO[bytes] | None]:
+) -> dict[str, BytesIO] | dict[str, IO[bytes] | None]:
     """
     Given an open file object and a file type, return all components
     of the archive as open file objects in a dict.
@@ -2220,7 +2234,7 @@ def split_extension(file_name: str, special: Iterable[str] | None = None) -> str
 
 
 def triangle_strips_to_faces(
-    strips: "SupportsLenAndGetItem[NDArray[np.integer[Any]]]",
+    strips: _SupportsLenAndGetItem[NDArray[np.integer[Any]]],
 ) -> _MatI64:
     """
     Convert a sequence of triangle strips to (n, 3) faces.
@@ -2672,7 +2686,7 @@ def is_ccw(
 
 
 def unique_name(
-    start: str,
+    start: str | None,
     contains: Collection[str],
     counts: dict[str, int] | None = None,
 ) -> str:


### PR DESCRIPTION
This fixes most typing errors in `trimesh.util` (checked with pyrefly and basedpyright), and increases type coverage of this module to 100%, which in turn increases the total type coverage of `trimesh` by +3.38% (according to [typestats](https://jorenham.github.io/typestats/dashboard/report/#trimesh).

In one or two locations I made minor changes to the implementation to help type-checkers understand what's going on. These should not lead to different behavior, or at least, not when the functions in questiona re used correctly, that is. 

This also removes a `numpy.linalg.multidot`  implementation that was no longer needed, because the of the `numpy>=1.21`  requirement (see the relevant [numpy 1.21 docs](https://numpy.org/doc/1.21/reference/generated/numpy.linalg.multi_dot.html)).