### PR TITLE
Fix Box(bounds=...) center when corners are not min-first

### DIFF
--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -305,6 +305,17 @@ def test_box_bounds_constructor():
     # bounds should match requesta
     assert g.np.allclose(prim.bounds, bounds)
 
+    # the resulting AABB must not depend on the order the two corners are
+    # passed in: regression test for the center being computed from
+    # `bounds[0]` rather than the min corner (issue #2523)
+    expected = [[0, 0, 0], [1, 1, 1]]
+    for corners in (
+        [[0, 0, 0], [1, 1, 1]],
+        [[0, 1, 0], [1, 0, 1]],
+        [[1, 1, 1], [0, 0, 0]],
+    ):
+        assert g.np.allclose(g.trimesh.primitives.Box(bounds=corners).bounds, expected)
+
     try:
         # should raise a ValueError
         g.trimesh.primitives.Box(extents=bounds[0], bounds=bounds)

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -774,8 +774,10 @@ class Box(Primitive):
             # create extents from AABB
             extents = np.ptp(bounds, axis=0)
             # translate to the center of the box
+            # use the min corner (not `bounds[0]`) so the result is
+            # independent of the order the two corners are passed in
             transform = np.eye(4)
-            transform[:3, 3] = bounds[0] + extents / 2.0
+            transform[:3, 3] = np.min(bounds, axis=0) + extents / 2.0
 
         self.primitive = PrimitiveAttributes(
             self,


### PR DESCRIPTION
### Summary

`Box(bounds=...)` places the box at the wrong location when the two corners of
the AABB are not given "min-first".

Fixes #2523.

### The bug

`trimesh/primitives.py` derives the box center from the bounds as:

```python
extents = np.ptp(bounds, axis=0)
transform[:3, 3] = bounds[0] + extents / 2.0
```

`np.ptp` is order-independent, but `bounds[0] + extents / 2` assumes `bounds[0]`
is the axis-wise minimum corner. If it isn't, the center is offset along the
flipped axes:

```python
import trimesh
trimesh.primitives.Box(bounds=[[0, 0, 0], [1, 1, 1]]).bounds
# [[0, 0, 0], [1, 1, 1]]
trimesh.primitives.Box(bounds=[[0, 1, 0], [1, 0, 1]]).bounds   # same AABB
# [[0, 1, 0], [1, 2, 1]]   <-- wrong, shifted by +1 in y
```

### The fix

Use the min corner so the center is the AABB midpoint regardless of corner
order:

```python
transform[:3, 3] = np.min(bounds, axis=0) + extents / 2.0
```

### Verification

- Both reproductions above now return `[[0, 0, 0], [1, 1, 1]]`; reversed and
  swapped corner orders all give the same AABB.
- Extended `test_box_bounds_constructor` with an order-independence regression
  test (fails on `main`, passes with this fix).
- `pytest tests/test_primitives.py` passes (14 tests); `ruff check` and
  `ruff format --check` are clean on the changed files.
