### PR TITLE
Fix mesh_other returning a reflection when reflection=False

### DIFF
--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -148,6 +148,35 @@ class RegistrationTest(g.unittest.TestCase):
         _matrix, _transformed, cost = g.trimesh.registration.icp(X, m, scale=False)
         assert cost < 0.01
 
+    def test_mesh_other_no_reflection(self):
+        # regression test for #2482: `mesh_other` seeds ICP with sign-flip
+        # initial transforms, half of which are reflections. With
+        # `reflection=False` those reflected seeds could still win and return
+        # a transform with a negative determinant (i.e. a reflection).
+        a = g.get_mesh("featuretype.STL")
+
+        # build a mirrored, inside-out copy of `a`
+        b = a.copy()
+        b.apply_transform(g.trimesh.transformations.rotation_matrix(0.9, [0.3, 0.6, 0.2]))
+        b.apply_transform(g.np.diag([-1.0, -1.0, 1.0, 1.0]))
+        b.vertices[:, 1] *= -1.0
+
+        # with reflection disabled the result must be a proper rotation
+        for seed in range(3):
+            g.np.random.seed(seed)
+            matrix, _cost = g.trimesh.registration.mesh_other(
+                a, b, samples=500, reflection=False, scale=False
+            )
+            assert g.np.linalg.det(matrix[:3, :3]) > 0
+
+        # with reflection enabled it is still allowed to use a reflection
+        # to fit the mirrored mesh
+        g.np.random.seed(0)
+        matrix, _cost = g.trimesh.registration.mesh_other(
+            a, b, samples=500, reflection=True, scale=False
+        )
+        assert g.np.linalg.det(matrix[:3, :3]) < 0
+
     def test_icp_points(self):
         # see if ICP alignment works with point clouds
         # create random points in space

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -124,21 +124,25 @@ def mesh_other(
     # the principal inertia transform has arbitrary sign
     # along the 3 major axis so try all combinations of
     # 180 degree rotations with a quick first ICP pass
-    cubes = np.array(
-        [
-            np.eye(4) * np.append(diag, 1)
-            for diag in [
-                [1, 1, 1],
-                [1, 1, -1],
-                [1, -1, 1],
-                [-1, 1, 1],
-                [-1, -1, 1],
-                [-1, 1, -1],
-                [1, -1, -1],
-                [-1, -1, -1],
-            ]
-        ]
-    )
+    diagonals = [
+        [1, 1, 1],
+        [1, 1, -1],
+        [1, -1, 1],
+        [-1, 1, 1],
+        [-1, -1, 1],
+        [-1, 1, -1],
+        [1, -1, -1],
+        [-1, -1, -1],
+    ]
+    if not kwargs.get("reflection", True):
+        # Half of these sign flips have an odd number of -1 and are therefore
+        # reflections (negative determinant). ICP only refines with proper
+        # rotations, so a reflected seed can never be corrected and would
+        # produce a final transform containing a reflection even though
+        # reflection was disabled. Keep only the proper-rotation seeds
+        # (identity and the three 180 degree axis rotations). See #2482.
+        diagonals = [diag for diag in diagonals if np.prod(diag) > 0]
+    cubes = np.array([np.eye(4) * np.append(diag, 1) for diag in diagonals])
 
     # loop through permutations and run iterative closest point
     costs = np.ones(len(cubes)) * np.inf


### PR DESCRIPTION
### Summary

`registration.mesh_other(..., reflection=False)` can still return a transform
that contains a reflection (negative determinant).

Fixes #2482.

### Root cause

`mesh_other` seeds ICP with the 8 sign-flip permutations of the principal
inertia axes:

```python
for diag in [[1,1,1], [1,1,-1], [1,-1,1], [-1,1,1],
             [-1,-1,1], [-1,1,-1], [1,-1,-1], [-1,-1,-1]]:
```

Four of these have an odd number of `-1` and are therefore **reflections**
(determinant `-1`), not rotations. ICP only refines with proper rotations —
`procrustes` with `reflection=False` always yields `det = +1` — so it composes
each correction onto the seed (`total_matrix = matrix @ total_matrix`) and can
never undo a reflection baked into the initial seed. When a reflected seed wins
(e.g. registering a mesh against a mirrored, inside-out copy of itself, where
the reflective fit has near-zero cost), the returned transform has `det < 0`
even though `reflection=False` was requested.

### Fix

Only seed the proper-rotation permutations (identity + the three 180° axis
rotations) when `reflection` is not allowed; keep all eight when it is. A
reflected seed can never produce a valid proper-rotation alignment anyway, so
dropping them when reflection is disabled is strictly correct.

```python
if not kwargs.get("reflection", True):
    diagonals = [diag for diag in diagonals if np.prod(diag) > 0]
```

### Verification

Using a mirrored / inside-out copy `b` of `models/featuretype.STL`:

- Before: `mesh_other(a, b, reflection=False)` returns `det(T) = -1` for every
  random seed tried.
- After: `det(T) = +1` for `reflection=False`; `reflection=True` still returns
  `det = -1` to fit the mirror; a non-mirrored rotated copy still aligns with
  `det = +1` and ~0 cost.
- Added a regression test (`test_mesh_other_no_reflection`) that fails on `main`
  and passes with this change.
- `pytest tests/test_registration.py` passes (9 tests); `ruff check` /
  `ruff format --check` clean.
