### PR TITLE
Fix spurious twist in sweep_polygon along curved 3D paths

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -175,6 +175,72 @@ def test_path_sweep():
         assert mesh.is_volume
 
 
+def test_sweep_no_twist():
+    # A polygon swept along a curving 3D path should not spuriously twist about
+    # the path when no per-vertex `angles` are requested.
+    # https://github.com/mikedh/trimesh/issues/2448
+    if len(existing_engines) == 0:
+        return
+
+    # a regular pentagon centered on the origin, so each slice's centroid is the
+    # corresponding path vertex (used by the twist metric below)
+    a = g.np.linspace(0, 2 * g.np.pi, 5, endpoint=False)
+    poly = g.Polygon(g.np.column_stack([0.1 * g.np.cos(a), 0.1 * g.np.sin(a)]))
+
+    # a path that curves in all three dimensions
+    path = g.np.array(
+        [
+            [-0.4844, 0.5410, 0.0815],
+            [-0.6675, 0.8110, 0.4648],
+            [-0.5557, 0.9077, 0.6270],
+            [-0.3574, 0.9770, 0.7230],
+            [-0.1116, 1.0010, 0.7000],
+            [0.1598, 0.9730, 0.5425],
+            [0.2084, 0.6760, 0.1472],
+        ]
+    )
+
+    mesh = g.trimesh.creation.sweep_polygon(poly, path, cap=True, connect=False)
+    assert mesh.is_volume
+
+    # plane normal of each slice, reconstructed exactly as `sweep_polygon` does
+    util = g.trimesh.util
+    tf = g.trimesh.transformations
+    vector = util.unitize(path[1:] - path[:-1])
+    vector_mean = util.unitize(vector[1:] + vector[:-1])
+    normal = g.np.concatenate([[vector[0]], vector_mean, [vector[-1]]], axis=0)
+
+    # vertices come out as one `stride`-length boundary ring per path vertex
+    stride = len(mesh.vertices) // len(path)
+    rings = mesh.vertices.reshape((len(path), stride, 3)) - path[:, None, :]
+
+    # For each consecutive pair of slices, rotate the earlier ring by the minimal
+    # rotation between their plane normals, then measure the residual rotation about
+    # the later normal. That residual is the spurious twist, which should be ~0 for
+    # a rotation-minimizing frame. Before the fix this exceeded 130 degrees.
+    total_twist = 0.0
+    for i in range(len(path) - 1):
+        axis = g.np.cross(normal[i], normal[i + 1])
+        sin_a = g.np.linalg.norm(axis)
+        cos_a = g.np.dot(normal[i], normal[i + 1])
+        if sin_a < 1e-12:
+            rotated = rings[i]
+        else:
+            matrix = tf.rotation_matrix(g.np.arctan2(sin_a, cos_a), axis / sin_a)
+            rotated = rings[i] @ matrix[:3, :3].T
+        a0 = rotated[0] / g.np.linalg.norm(rotated[0])
+        b0 = rings[i + 1][0] / g.np.linalg.norm(rings[i + 1][0])
+        total_twist += abs(
+            g.np.degrees(
+                g.np.arctan2(
+                    g.np.dot(g.np.cross(a0, b0), normal[i + 1]), g.np.dot(a0, b0)
+                )
+            )
+        )
+
+    assert total_twist < 1.0
+
+
 def test_simple_watertight():
     # create a simple polygon
     polygon = g.Polygon(((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)))

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -345,49 +345,58 @@ def sweep_polygon(
     # planes should have one unit normal and one vertex each
     assert normal.shape == path.shape
 
-    # get the spherical coordinates for the normal vectors
-    theta, phi = util.vector_to_spherical(normal).T
+    # Build a rotation-minimizing (parallel-transport) frame for each slice.
+    #
+    # Each slice's local +Z axis is its plane normal; the two in-plane axes are
+    # propagated from one slice to the next by the *minimal* rotation that carries
+    # the previous normal onto the current one. Constructing each frame
+    # independently from the normal's spherical coordinates (the previous
+    # approach) ties the in-plane roll to the normal's azimuth, so the cross
+    # section spuriously twists as the path curves out of a plane, even when no
+    # `angles` roll was requested (https://github.com/mikedh/trimesh/issues/2448).
 
-    # collect the trig values into numpy arrays we can compose into matrices
-    cos_theta, sin_theta = np.cos(theta), np.sin(theta)
-    cos_phi, sin_phi = np.cos(phi), np.sin(phi)
+    # The starting in-plane axis matches the slice-0 axis of the previous
+    # spherical-coordinate frame, so a straight (untwisted) sweep is unchanged.
+    theta_0 = util.vector_to_spherical(normal[:1])[0, 0]
+    in_plane_x = np.zeros((len(path), 3))
+    in_plane_y = np.zeros((len(path), 3))
+    in_plane_x[0] = util.unitize([np.sin(theta_0), -np.cos(theta_0), 0.0])
+    in_plane_y[0] = np.cross(normal[0], in_plane_x[0])
+
+    for i in range(1, len(path)):
+        cross = np.cross(normal[i - 1], normal[i])
+        sin_a = np.linalg.norm(cross)
+        cos_a = np.dot(normal[i - 1], normal[i])
+        if sin_a < 1e-12:
+            # consecutive normals are parallel: carry the frame through unchanged
+            rotated_x = in_plane_x[i - 1]
+        else:
+            # Rodrigues' rotation of the previous in-plane x-axis by the minimal
+            # rotation (axis `cross`, angle between the two normals)
+            rot_axis = cross / sin_a
+            angle = np.arctan2(sin_a, cos_a)
+            rotated_x = (
+                in_plane_x[i - 1] * np.cos(angle)
+                + np.cross(rot_axis, in_plane_x[i - 1]) * np.sin(angle)
+                + rot_axis * np.dot(rot_axis, in_plane_x[i - 1]) * (1.0 - np.cos(angle))
+            )
+        # re-project against the current normal to remove numerical drift
+        rotated_x = util.unitize(rotated_x - normal[i] * np.dot(rotated_x, normal[i]))
+        in_plane_x[i] = rotated_x
+        in_plane_y[i] = np.cross(normal[i], rotated_x)
+
+    # apply the optional per-slice roll about each local normal (`angles`)
     cos_roll, sin_roll = np.cos(angles), np.sin(angles)
+    axes_x = in_plane_x * cos_roll[:, None] - in_plane_y * sin_roll[:, None]
+    axes_y = in_plane_x * sin_roll[:, None] + in_plane_y * cos_roll[:, None]
 
-    # we want a rotation which will be the identity for a Z+ vector
-    # this was constructed and unrolled from the following sympy block
-    # theta, phi, roll = sp.symbols("theta phi roll")
-    # matrix = (
-    #     tf.rotation_matrix(roll, [0, 0, 1]) @
-    #     tf.rotation_matrix(phi, [1, 0, 0]) @
-    #     tf.rotation_matrix((sp.pi / 2) - theta, [0, 0, 1])
-    # ).inv()
-    # matrix.simplify()
-
-    # shorthand for stacking
-    zeros = np.zeros(len(theta))
-    ones = np.ones(len(theta))
-
-    # stack initially as one unrolled matrix per row
-    transforms = np.column_stack(
-        [
-            -sin_roll * cos_phi * cos_theta + sin_theta * cos_roll,
-            sin_roll * sin_theta + cos_phi * cos_roll * cos_theta,
-            sin_phi * cos_theta,
-            path[:, 0],
-            -sin_roll * sin_theta * cos_phi - cos_roll * cos_theta,
-            -sin_roll * cos_theta + sin_theta * cos_phi * cos_roll,
-            sin_phi * sin_theta,
-            path[:, 1],
-            sin_phi * sin_roll,
-            -sin_phi * cos_roll,
-            cos_phi,
-            path[:, 2],
-            zeros,
-            zeros,
-            zeros,
-            ones,
-        ]
-    ).reshape((-1, 4, 4))
+    # assemble one homogeneous transform per slice with columns [x, y, normal, origin]
+    transforms = np.zeros((len(path), 4, 4))
+    transforms[:, :3, 0] = axes_x
+    transforms[:, :3, 1] = axes_y
+    transforms[:, :3, 2] = normal
+    transforms[:, :3, 3] = path
+    transforms[:, 3, 3] = 1.0
 
     if tol.strict:
         # make sure that each transform moves the Z+ vector to the requested normal


### PR DESCRIPTION
## Summary

Fixes #2448: `trimesh.creation.sweep_polygon` produced a mesh whose cross section spuriously **twists** about the path when sweeping along a curved 3D path, even with no per-vertex `angles` requested — leading to distorted / self-intersecting geometry.

## Root cause

Each slice's coordinate frame was built **independently** from its plane normal via spherical coordinates:

```python
theta, phi = util.vector_to_spherical(normal).T
# ... frame assembled from (theta, phi, roll) ...
```

This ties the in-plane roll of the frame to the normal's azimuth `theta`. As the path curves out of a plane (so the normal's polar angle `phi` also changes), the spherical parametrization rotates the cross section about the path — a classic non-rotation-minimizing frame. (Note: for a *planar* path `phi` is constant, so the twist doesn't appear there, which is why simple in-plane test paths looked fine.)

## Fix

Replace the per-slice spherical frame with a **rotation-minimizing (parallel-transport) frame**: each slice's in-plane axes are propagated from the previous slice by the *minimal* rotation that carries the previous normal onto the current one (Rodrigues' rotation about `normal[i-1] × normal[i]`). This is the standard way to sweep a profile without introducing twist.

- The starting in-plane axis is initialized to match the previous frame's **slice 0**, so a straight / untwisted sweep is unchanged.
- The optional per-vertex `angles` roll is applied on top of the propagated frame, with the same sign convention as before.
- The frame still maps local `+Z` onto each slice normal, so the existing `tol.strict` assertions and face winding are preserved.

## Verification

A direct, implementation-independent twist metric on the `#2448` repro path (rotate each slice's boundary ring by the minimal rotation to the next slice's normal, then measure the residual rotation about that normal):

| | total inter-slice twist |
|---|---|
| before | **138.6°** |
| after | **0.0°** |

The output mesh remains watertight, winding-consistent, and a valid volume; existing open and closed sweeps (`tests/test_creation.py::test_path_sweep`) still pass, including under `trimesh.tol.strict = True`.

Adds `tests/test_creation.py::test_sweep_no_twist`, which asserts the residual twist along a curving 3D path is `< 1°` (fails on `main` at ~139°, passes with this change). Full `test_creation.py`: 18 passed. `ruff check` / `ruff format` clean on both changed files.

Closes #2448.
