### PR TITLE
Add vertex_tangents for glTF normal-map export (#2494)

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -135,6 +135,45 @@ class GLTFTest(g.unittest.TestCase):
         export = mesh.export(file_type="glb", unitize_normals=True)
         validate_glb(export, "fuze.ply")
 
+    def test_tangents(self):
+        # vertex tangents are computed from UV + normals and round-trip
+        # through the glTF `TANGENT` attribute (#2494)
+        mesh = g.get_mesh("fuze.ply")
+        assert mesh.visual.uv is not None
+
+        tangents = mesh.vertex_tangents
+        # one VEC4 (xyz direction + w handedness) per vertex
+        assert tangents.shape == (len(mesh.vertices), 4)
+        direction = tangents[:, :3]
+        handed = tangents[:, 3]
+        # the direction is unit length and orthogonal to the vertex normal
+        assert g.np.allclose(g.np.linalg.norm(direction, axis=1), 1.0)
+        dot_normal = g.np.einsum("ij,ij->i", direction, mesh.vertex_normals)
+        assert g.np.abs(dot_normal).max() < 1e-6
+        # handedness is strictly +1 or -1 for this fully UV-mapped mesh
+        assert set(g.np.unique(handed).tolist()) == {-1.0, 1.0}
+
+        # exporting includes a TANGENT attribute and is a valid glTF
+        export = mesh.export(file_type="glb")
+        validate_glb(export, "fuze.ply")
+        assert b"TANGENT" in export
+
+        # and the tangents survive a round-trip through GLB unchanged
+        reloaded = g.trimesh.load(g.trimesh.util.wrap_as_stream(export), file_type="glb")
+        geom = next(iter(reloaded.geometry.values()))
+        # they were loaded from the file, not recomputed
+        assert "vertex_tangents" in geom._cache.cache
+        assert g.np.allclose(geom.vertex_tangents, tangents, atol=1e-5)
+
+    def test_tangents_no_uv(self):
+        # a mesh without UV coordinates has no defined tangent space, so
+        # the tangents are zero and no TANGENT attribute is exported
+        mesh = g.trimesh.creation.box()
+        assert g.np.allclose(mesh.vertex_tangents, 0.0)
+
+        export = mesh.export(file_type="glb")
+        assert b"TANGENT" not in export
+
     def test_cesium(self):
         # A GLTF with a multi- primitive mesh
 

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -100,6 +100,7 @@ class Trimesh(Geometry3D):
         faces: ArrayLike | None = None,
         face_normals: ArrayLike | None = None,
         vertex_normals: ArrayLike | None = None,
+        vertex_tangents: ArrayLike | None = None,
         face_colors: ArrayLike | None = None,
         vertex_colors: ArrayLike | None = None,
         face_attributes: dict[str, ArrayLike] | None = None,
@@ -127,6 +128,9 @@ class Trimesh(Geometry3D):
           Array of normal vectors corresponding to faces
         vertex_normals : (n, 3) float
           Array of normal vectors for vertices
+        vertex_tangents : (n, 4) float
+          Array of tangent vectors (xyz) and handedness (w) for vertices,
+          for example loaded from a glTF `TANGENT` attribute
         face_colors : (n, 3|4) uint8
           Array of colors for faces
         vertex_colors : (n, 3|4) uint8
@@ -214,6 +218,10 @@ class Trimesh(Geometry3D):
         # (n, 3) float of vertex normals, can be created from face normals
         if vertex_normals is not None:
             self.vertex_normals = vertex_normals
+
+        # (n, 4) float of vertex tangents, e.g. from a glTF TANGENT attribute
+        if vertex_tangents is not None:
+            self.vertex_tangents = vertex_tangents
 
         # embree is a much, much faster raytracer written by Intel
         # if you have pyembree installed you should use it
@@ -555,6 +563,56 @@ class Trimesh(Geometry3D):
                 if np.ptp(values) < tol.merge:
                     log.debug("vertex_normals are all zero!")
                 self._cache["vertex_normals"] = values
+
+    @cache_decorator
+    def vertex_tangents(self) -> NDArray[float64]:
+        """
+        The tangent vectors of the mesh, used for normal (bump) mapping.
+
+        If tangents were loaded (for example from a glTF `TANGENT`
+        attribute) and match the number of vertices they are returned
+        directly. Otherwise they are computed from the vertex normals and
+        the per-vertex UV coordinates of the mesh's texture visual; a mesh
+        without UV coordinates has no defined tangent space and returns
+        zeros.
+
+        Returns
+        ----------
+        vertex_tangents : (n, 4) float
+          Tangent direction (xyz) and basis handedness (w, either +1 or
+          -1) at each vertex, where n == len(self.vertices). The bitangent
+          is `cross(vertex_normals, vertex_tangents[:, :3]) *
+          vertex_tangents[:, 3]`.
+        """
+        uv = getattr(self.visual, "uv", None)
+        if uv is None or len(uv) != len(self.vertices):
+            # tangents are only defined for a UV-mapped mesh
+            log.debug("no UV coordinates, vertex_tangents are zero!")
+            return np.zeros((len(self.vertices), 4), dtype=float64)
+        return geometry.vertex_tangents(
+            vertices=self.vertices,
+            faces=self.faces,
+            vertex_normals=self.vertex_normals,
+            uv=uv,
+            face_angles=self.face_angles,
+        )
+
+    @vertex_tangents.setter
+    def vertex_tangents(self, values: ArrayLike) -> None:
+        """
+        Assign values to vertex tangents.
+
+        Parameters
+        -------------
+        values : (len(self.vertices), 4) float
+          Tangent vectors (xyz) and handedness (w) for each vertex
+        """
+        if values is not None:
+            values = np.asanyarray(values, order="C", dtype=float64)
+            if values.shape == (len(self.vertices), 4):
+                self._cache["vertex_tangents"] = values
+            else:
+                log.debug("passed vertex_tangents are not (n, 4)!")
 
     @cache_decorator
     def vertex_faces(self) -> NDArray[int64]:

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -921,6 +921,21 @@ def _append_mesh(
             # add the reference for UV coordinates
             current["primitives"][0]["attributes"]["TEXCOORD_0"] = acc_uv
 
+        # export vertex tangents for normal mapping if they have been
+        # computed or loaded; glTF expects a VEC4 with handedness in w
+        if has_uv and "vertex_tangents" in mesh._cache.cache:
+            # the V texture coordinate was flipped above, which flips the
+            # handedness of the tangent basis, so flip w to match
+            tangents = mesh.vertex_tangents.copy()
+            tangents[:, 3] *= -1.0
+            acc_tangent = _data_append(
+                acc=tree["accessors"],
+                buff=buffer_items,
+                blob={"componentType": 5126, "type": "VEC4", "byteOffset": 0},
+                data=tangents.astype(float32),
+            )
+            current["primitives"][0]["attributes"]["TANGENT"] = acc_tangent
+
         # reference the material
         current["primitives"][0]["material"] = current_material
 
@@ -1658,7 +1673,15 @@ def _read_buffers(
                     if "NORMAL" in attr:
                         # vertex normals are specified
                         kwargs["vertex_normals"] = access[attr["NORMAL"]]
-                        # do we have UV coordinates
+                    if "TANGENT" in attr:
+                        # vertex tangents are a VEC4 of xyz direction and w
+                        # handedness; undo the V-flip glTF applies to UVs
+                        # (see TEXCOORD_0 below) so the basis handedness
+                        # matches trimesh's UV convention
+                        tangents = np.array(access[attr["TANGENT"]], dtype=np.float64)
+                        tangents[:, 3] *= -1.0
+                        kwargs["vertex_tangents"] = tangents
+                    # do we have UV coordinates
                     visuals = None
                     if "material" in p and not skip_materials:
                         if materials is None:

--- a/trimesh/geometry.py
+++ b/trimesh/geometry.py
@@ -400,6 +400,113 @@ def weighted_vertex_normals(
     return util.unitize(summed_loop())
 
 
+def vertex_tangents(vertices, faces, vertex_normals, uv, face_angles=None):
+    """
+    Compute per-vertex tangent vectors for a UV-mapped mesh.
+
+    Tangents are required to render normal (bump) maps correctly and the
+    glTF 2.0 specification expects them to be supplied as a per-vertex
+    `VEC4` `TANGENT` attribute. This uses the per-triangle method of
+    Lengyel ("Computing Tangent Space Basis Vectors for an Arbitrary
+    Mesh", Terathon Software, 2001) which is the convention the glTF
+    ecosystem is built around. Note this is not the reference MikkTSpace
+    algorithm (which welds and splits vertices); it computes a single
+    smoothed tangent frame per existing vertex, matching how `trimesh`
+    already shares a vertex normal between adjacent faces.
+
+    The first three components of each returned row are the unit tangent
+    direction, orthonormalized against the vertex normal. The fourth
+    component is the handedness (`+1` or `-1`) of the tangent basis, so a
+    renderer can recover the bitangent as
+    `cross(normal, tangent[:3]) * tangent[3]`.
+
+    Parameters
+    -----------
+    vertices : (n, 3) float
+      The vertices of the mesh.
+    faces : (m, 3) int
+      Triangle vertex indices.
+    vertex_normals : (n, 3) float
+      Unit normal vector for each vertex.
+    uv : (n, 2) float
+      Texture coordinate for each vertex.
+    face_angles : (m, 3) float or None
+      The interior angle at each corner of every face, used to weight a
+      face's contribution to its vertices (matching how vertex normals
+      are smoothed). If None each corner is weighted equally.
+
+    Returns
+    -----------
+    vertex_tangents : (n, 4) float
+      Tangent direction (xyz) and handedness (w) for every vertex.
+      Vertices unreferenced by faces, or whose tangent is undefined (for
+      example a degenerate UV triangle), will be zero.
+    """
+    vertices = np.asanyarray(vertices, dtype=np.float64)
+    faces = np.asanyarray(faces, dtype=np.int64)
+    vertex_normals = np.asanyarray(vertex_normals, dtype=np.float64)
+    uv = np.asanyarray(uv, dtype=np.float64)
+
+    vertex_count = len(vertices)
+    if uv.shape != (vertex_count, 2):
+        raise ValueError("`uv` must be (len(vertices), 2) float")
+    if vertex_normals.shape != (vertex_count, 3):
+        raise ValueError("`vertex_normals` must be (len(vertices), 3) float")
+
+    # per-triangle edge vectors and the matching UV deltas
+    tri = vertices[faces]
+    tri_uv = uv[faces]
+    edge1 = tri[:, 1] - tri[:, 0]
+    edge2 = tri[:, 2] - tri[:, 0]
+    duv1 = tri_uv[:, 1] - tri_uv[:, 0]
+    duv2 = tri_uv[:, 2] - tri_uv[:, 0]
+
+    # the determinant of the 2x2 UV matrix; zero for a degenerate UV
+    # triangle, in which case that face simply contributes nothing
+    denom = duv1[:, 0] * duv2[:, 1] - duv2[:, 0] * duv1[:, 1]
+    reciprocal = np.zeros(len(faces), dtype=np.float64)
+    nonzero = np.abs(denom) > util.TOL_ZERO
+    reciprocal[nonzero] = 1.0 / denom[nonzero]
+
+    # solve for the per-face tangent and bitangent in object space
+    inv = reciprocal[:, None]
+    face_tangents = (edge1 * duv2[:, 1, None] - edge2 * duv1[:, 1, None]) * inv
+    face_bitangents = (edge2 * duv1[:, 0, None] - edge1 * duv2[:, 0, None]) * inv
+
+    # accumulate the face contributions onto their vertices, weighting by
+    # the corner angle so the result is smooth across shared vertices
+    if face_angles is None:
+        weights = np.ones(faces.size, dtype=np.float64)
+    else:
+        weights = np.asanyarray(face_angles, dtype=np.float64).ravel()
+    try:
+        matrix = index_sparse(vertex_count, faces, data=weights)
+        tangents = matrix.dot(face_tangents)
+        bitangents = matrix.dot(face_bitangents)
+    except BaseException:
+        log.warning("unable to use sparse matrix, falling back!", exc_info=True)
+        tangents = np.zeros((vertex_count, 3), dtype=np.float64)
+        bitangents = np.zeros((vertex_count, 3), dtype=np.float64)
+        for corner in range(faces.shape[1]):
+            np.add.at(tangents, faces[:, corner], face_tangents)
+            np.add.at(bitangents, faces[:, corner], face_bitangents)
+
+    # Gram-Schmidt: make the tangent orthogonal to the vertex normal
+    projection = np.einsum("ij,ij->i", vertex_normals, tangents)
+    orthogonal = util.unitize(tangents - vertex_normals * projection[:, None])
+
+    # handedness: sign of the triple product picks the bitangent direction
+    cross = np.cross(vertex_normals, tangents)
+    handed = np.where(np.einsum("ij,ij->i", cross, bitangents) < 0.0, -1.0, 1.0)
+    # vertices with no usable tangent stay fully zero, including handedness
+    handed[(orthogonal**2).sum(axis=1) < 0.5] = 0.0
+
+    result = np.zeros((vertex_count, 4), dtype=np.float64)
+    result[:, :3] = orthogonal
+    result[:, 3] = handed
+    return result
+
+
 def index_sparse(columns, indices, data=None, dtype=None):
     """
     Return a sparse matrix for which vertices are contained in which faces.


### PR DESCRIPTION
Resolves #2494.

Meshes with a normal (bump) map need a per-vertex tangent to render correctly, and the glTF 2.0 spec expects it as a `TANGENT` vertex attribute — a `VEC4` where `w` is the handedness of the tangent basis. Until now `trimesh` neither computed nor exported tangents, so a GLB with a normal map relied on the viewer reconstructing them (often with artifacts).

### What this adds

- **`trimesh.geometry.vertex_tangents(vertices, faces, vertex_normals, uv, face_angles=None)`** — computes per-vertex tangents from positions, normals and UVs using the per-triangle method of Lengyel (*Computing Tangent Space Basis Vectors for an Arbitrary Mesh*), which is the convention the glTF ecosystem is built around. Returns `(n, 4)`: a unit tangent orthonormalized against the vertex normal (Gram-Schmidt), plus the `±1` handedness so the bitangent is `cross(normal, tangent[:3]) * w`. It's vectorized and reuses the same angle-weighted sparse accumulation as `weighted_vertex_normals`, with a safe fallback for degenerate UV triangles.

  This is intentionally **not** the reference MikkTSpace algorithm (which welds/splits vertices); like `trimesh`'s vertex normals it produces one smoothed frame per existing vertex. Happy to revisit if you'd prefer a stricter MikkTSpace path.

- **`Trimesh.vertex_tangents`** — a cached property mirroring `vertex_normals` (with a setter and a constructor argument). Returns zeros for a mesh that has no UV coordinates.

- **glTF export/import** — the exporter writes a `TANGENT` accessor when tangents have been computed or loaded (opt-in, so it doesn't bloat every GLB); the importer reads one. glTF flips the `V` texture coordinate, which flips the basis handedness, so `w` is flipped to match on both sides — tangents round-trip unchanged and stay consistent with the exported UVs.

### Tests

`tests/test_gltf.py` gains `test_tangents` (unit length, orthogonal to the normal, `±1` handedness, a valid-GLB `TANGENT` export, and a GLB round-trip that preserves the tangents) and `test_tangents_no_uv` (no UV → zero tangents, no `TANGENT` exported). `ruff check` is clean and the existing gltf/base/texture suites pass.
