### PR TITLE
gltf: emit BLEND material for ColorVisuals with transparency (fixes #2436)

### DIFF
--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -1159,7 +1159,7 @@ class GLTFTest(g.unittest.TestCase):
         # channel and the mesh rendered as solid. Verify the exporter now
         # emits a `BLEND` material so per-vertex/per-face alpha is honored.
         mesh = g.trimesh.creation.cylinder(1.0, 1.0)
-        mesh.visual.face_colors = (255, 0, 0, 100)
+        mesh.visual.face_colors = [255, 0, 0, 100]
         # base sanity: this is a ColorVisuals, so no PBR material attribute
         assert not hasattr(mesh.visual, "material")
 
@@ -1191,7 +1191,7 @@ class GLTFTest(g.unittest.TestCase):
         # the default-material behavior) — the transparency workaround above
         # must not fire for `alpha == 255` colors.
         mesh = g.trimesh.creation.cylinder(1.0, 1.0)
-        mesh.visual.face_colors = (200, 50, 50, 255)
+        mesh.visual.face_colors = [200, 50, 50, 255]
         tree = g.json.loads(mesh.export(file_type="gltf")["model.gltf"].decode("utf-8"))
 
         # no material is emitted: opaque ColorVisuals continues to use the
@@ -1208,9 +1208,9 @@ class GLTFTest(g.unittest.TestCase):
         # one per primitive — the lookup-then-append branch must dedupe.
         scene = g.trimesh.Scene()
         a = g.trimesh.creation.box()
-        a.visual.face_colors = (255, 0, 0, 100)
+        a.visual.face_colors = [255, 0, 0, 100]
         b = g.trimesh.creation.box()
-        b.visual.face_colors = (0, 255, 0, 100)
+        b.visual.face_colors = [0, 255, 0, 100]
         scene.add_geometry(a, "a")
         scene.add_geometry(b, "b")
         tree = g.json.loads(scene.export(file_type="gltf")["model.gltf"].decode("utf-8"))

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -1151,6 +1151,76 @@ class GLTFTest(g.unittest.TestCase):
         mean_squared_error = ((a - b) ** 2).sum() / g.np.prod(a.shape)
         assert mean_squared_error < 10.0
 
+    def test_color_visuals_transparency_export(self):
+        # https://github.com/mikedh/trimesh/issues/2436
+        # ColorVisuals meshes with `alpha < 255` previously exported with no
+        # material at all, leaving renderers to fall back to the glTF default
+        # material whose `alphaMode` is `OPAQUE`. That swallowed the alpha
+        # channel and the mesh rendered as solid. Verify the exporter now
+        # emits a `BLEND` material so per-vertex/per-face alpha is honored.
+        mesh = g.trimesh.creation.cylinder(1.0, 1.0)
+        mesh.visual.face_colors = (255, 0, 0, 100)
+        # base sanity: this is a ColorVisuals, so no PBR material attribute
+        assert not hasattr(mesh.visual, "material")
+
+        tree = g.json.loads(mesh.export(file_type="gltf")["model.gltf"].decode("utf-8"))
+
+        # a material should now exist and be referenced by the primitive
+        materials = tree.get("materials") or []
+        assert len(materials) == 1
+        assert materials[0]["alphaMode"] == "BLEND"
+        # transparent meshes should default to double-sided for correct rendering
+        assert materials[0].get("doubleSided") is True
+        primitive = tree["meshes"][0]["primitives"][0]
+        assert primitive.get("material") == 0
+        # COLOR_0 must still be written so per-vertex alpha is available
+        assert "COLOR_0" in primitive["attributes"]
+
+        # GLB roundtrip should preserve `alphaMode = BLEND` on the material
+        export = mesh.export(file_type="glb")
+        validate_glb(export)
+        reloaded = g.trimesh.load(
+            g.trimesh.util.wrap_as_stream(export), file_type="glb", force="mesh"
+        )
+        assert reloaded.visual.material.alphaMode == "BLEND"
+        assert getattr(reloaded.visual.material, "doubleSided", False) is True
+
+    def test_color_visuals_opaque_no_extra_material(self):
+        # https://github.com/mikedh/trimesh/issues/2436
+        # Fully opaque ColorVisuals should still emit no material (preserving
+        # the default-material behavior) — the transparency workaround above
+        # must not fire for `alpha == 255` colors.
+        mesh = g.trimesh.creation.cylinder(1.0, 1.0)
+        mesh.visual.face_colors = (200, 50, 50, 255)
+        tree = g.json.loads(mesh.export(file_type="gltf")["model.gltf"].decode("utf-8"))
+
+        # no material is emitted: opaque ColorVisuals continues to use the
+        # implicit glTF default material rather than allocating an explicit one
+        assert not tree.get("materials")
+        primitive = tree["meshes"][0]["primitives"][0]
+        assert "material" not in primitive
+        assert "COLOR_0" in primitive["attributes"]
+
+    def test_color_visuals_transparency_dedupes_material(self):
+        # https://github.com/mikedh/trimesh/issues/2436
+        # Multiple ColorVisuals meshes sharing the same transparency profile
+        # should reuse a single `BLEND` material rather than allocating
+        # one per primitive — the lookup-then-append branch must dedupe.
+        scene = g.trimesh.Scene()
+        a = g.trimesh.creation.box()
+        a.visual.face_colors = (255, 0, 0, 100)
+        b = g.trimesh.creation.box()
+        b.visual.face_colors = (0, 255, 0, 100)
+        scene.add_geometry(a, "a")
+        scene.add_geometry(b, "b")
+        tree = g.json.loads(scene.export(file_type="gltf")["model.gltf"].decode("utf-8"))
+        # a single shared transparent material reused by both primitives
+        materials = tree.get("materials") or []
+        assert len(materials) == 1
+        assert materials[0]["alphaMode"] == "BLEND"
+        for mesh_entry in tree["meshes"]:
+            assert mesh_entry["primitives"][0].get("material") == 0
+
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -887,6 +887,39 @@ def _append_mesh(
                 "Vertex colors have different length than mesh vertices, dropping!"
             )
 
+    if not hasattr(mesh.visual, "material") and vertex_colors is not None:
+        # `ColorVisuals` carries vertex/face colors but has no `material` attribute,
+        # so without explicit help the primitive references the glTF default material,
+        # which has `alphaMode: "OPAQUE"`. With OPAQUE the alpha channel of COLOR_0
+        # is discarded by spec-compliant renderers (three.js, Babylon, model-viewer)
+        # and meshes with semi-transparent vertex/face colors render as solid.
+        # If any color has alpha < 255 add a material with `alphaMode: "BLEND"`
+        # and `doubleSided: True` so the per-vertex alpha is honored.
+        # See: https://github.com/mikedh/trimesh/issues/2436
+        try:
+            alpha = np.asarray(vertex_colors)
+            has_alpha = (
+                alpha.ndim == 2 and alpha.shape[1] == 4 and (alpha[:, 3] < 255).any()
+            )
+        except BaseException:
+            has_alpha = False
+        if has_alpha:
+            transparent_material = {
+                "pbrMetallicRoughness": {
+                    "baseColorFactor": [1, 1, 1, 1],
+                    "metallicFactor": 0,
+                    "roughnessFactor": 0,
+                },
+                "alphaMode": "BLEND",
+                "doubleSided": True,
+            }
+            try:
+                material_idx = tree["materials"].index(transparent_material)
+            except ValueError:
+                material_idx = len(tree["materials"])
+                tree["materials"].append(transparent_material)
+            current["primitives"][0]["material"] = material_idx
+
     if hasattr(mesh.visual, "material"):
         # append the material and then set from returned index
         current_material = _append_material(


### PR DESCRIPTION
Fixes #2436 (and almost certainly the same root cause as #2477 — the notebook viewer round-trips through GLB export, so the BLEND material is what unblocks the embedded three.js viewer there too) — `glTF` export with `ColorVisuals` and `alpha < 255` now produces a `BLEND` material so semi-transparent vertex/face colors actually render as transparent.

## The bug

Reported in #2436:

```python
import trimesh
mesh = trimesh.creation.cylinder(1.0, 1.0)
mesh.visual.face_colors = (255, 0, 0, 100)  # alpha = 100, semi-transparent
mesh.export("mesh.gltf")  # Transparency broken.
```

Three.js / Babylon.js / model-viewer render this as fully opaque red.

The exported tree had **no materials at all** and the primitive carried no `material` index:

```json
{
  "meshes": [{
    "primitives": [{
      "attributes": {"POSITION": 1, "COLOR_0": 2},
      "indices": 0, "mode": 4
    }]
  }],
  "materials": null
}
```

Per [glTF 2.0 §3.9.2](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#default-material), primitives without a material use the default material, whose `alphaMode` is `OPAQUE`. With `OPAQUE` spec-compliant renderers ignore the `COLOR_0` alpha channel.

## Root cause

`_append_mesh` in `trimesh/exchange/gltf/__init__.py` only attaches a material when `mesh.visual` has a `material` attribute (i.e. `TextureVisuals` / `PBRMaterial`). `ColorVisuals` carries only RGBA per-vertex/face colors and has no `material` attribute, so the primitive falls through with no material reference — and the alpha bytes in `COLOR_0` get silently dropped at render time.

## The fix

When the mesh has `ColorVisuals` and any vertex color has `alpha < 255`, append a tiny PBR material and reference it:

```python
{
    "pbrMetallicRoughness": {
        "baseColorFactor": [1, 1, 1, 1],
        "metallicFactor": 0,
        "roughnessFactor": 0,
    },
    "alphaMode": "BLEND",
    "doubleSided": True,
}
```

- `baseColorFactor = [1,1,1,1]` keeps `COLOR_0 × baseColorFactor` equal to `COLOR_0`, so the user's RGBA wins.
- `alphaMode = "BLEND"` tells renderers to actually composite the alpha channel.
- `doubleSided = True` is the conventional default for transparent meshes since back-faces should not be culled when you can see through the geometry.

The branch only fires when:
1. `mesh.visual` has no `material` attribute (i.e. `ColorVisuals` — texture materials already handle `alphaMode` via `PBRMaterial.alphaMode`), AND
2. `vertex_colors` is RGBA (`shape[1] == 4`) AND
3. at least one alpha byte is `< 255`.

Opaque `ColorVisuals` still emits no material — preserving the implicit-default behavior so existing exports are unchanged. Multiple transparent meshes share a single material entry via the existing list-index dedupe.

## Verification

Three regression tests in `tests/test_gltf.py` (`test_color_visuals_transparency_export`, `test_color_visuals_opaque_no_extra_material`, `test_color_visuals_transparency_dedupes_material`):

- Transparent `ColorVisuals` cylinder → exported tree now has one `BLEND` material referenced by the primitive, and a GLB roundtrip preserves `alphaMode = "BLEND"` and `doubleSided = True`.
- Opaque `ColorVisuals` cylinder → exported tree still has no materials and the primitive has no `material` key.
- Two transparent `ColorVisuals` boxes in a scene → only **one** material entry, both primitives reference index `0`.

```
$ python -m pytest tests/test_gltf.py
50 passed
```

All 47 pre-existing gltf tests still pass (no regressions in CesiumMilkTruck, AlphaBlendModeTest, fuze.ply texture export, `test_buffer_dedupe`, etc.).

## Scope notes

- `Path2D/Path3D` and `PointCloud` already explicitly append `_default_material` (`OPAQUE`); they are out of scope here since their `COLOR_0` alpha was already discarded by the same mechanism but isn't reported in #2436.
- `TextureVisuals` is unchanged — `_append_material` already routes through `PBRMaterial.alphaMode` and `PBRMaterial.alphaCutoff`.
