### PR TITLE
base: drop faces touching non-finite vertices in remove_infinite_values (fixes #2445)

### DIFF
--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -180,6 +180,100 @@ def test_mesh_2D():
     assert len(rend) > 1
 
 
+def test_remove_infinite_values_drops_dependent_faces():
+    # Regression test for https://github.com/mikedh/trimesh/issues/2445
+    #
+    # `remove_infinite_values` was checking `np.isfinite(self.faces)` which
+    # is always all-True (face indices are int64), so faces referencing a
+    # NaN/Inf vertex were never explicitly dropped. They then sneaked
+    # through `update_vertices`, whose inverse-index map defaults to 0
+    # for removed vertices — turning each face that touched a NaN vertex
+    # into a degenerate triangle (e.g. `[0,1,2]` -> `[0,1,0]`). Those
+    # degenerate faces crashed the renderer with `IndexError` on `mesh.show`.
+    vertices = g.np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.5, 0.5, g.np.nan],
+        ],
+        dtype=g.np.float64,
+    )
+    faces = g.np.array(
+        [
+            [0, 1, 2],
+            [1, 3, 2],
+            [0, 4, 1],
+            [1, 4, 3],
+            [3, 4, 2],
+        ],
+        dtype=g.np.int64,
+    )
+    mesh = g.trimesh.Trimesh(
+        vertices=vertices.copy(), faces=faces.copy(), process=True
+    )
+
+    # the non-finite vertex is gone
+    assert g.np.isfinite(mesh.vertices).all()
+    assert len(mesh.vertices) == 4
+
+    # the three faces that touched the NaN vertex are removed; the two
+    # entirely-finite faces survive without being remapped to degenerates
+    assert len(mesh.faces) == 2
+    # every surviving face references a valid vertex
+    assert (mesh.faces < len(mesh.vertices)).all()
+    # no surviving face is degenerate (no repeated vertex index)
+    assert (mesh.faces[:, 0] != mesh.faces[:, 1]).all()
+    assert (mesh.faces[:, 1] != mesh.faces[:, 2]).all()
+    assert (mesh.faces[:, 0] != mesh.faces[:, 2]).all()
+
+    # a scene-build round-trip should work without crashing now that the
+    # mesh contains only well-formed faces
+    scene = mesh.scene()
+    assert "geometry_0" in scene.geometry
+
+
+def test_remove_infinite_values_inf_vertex_drops_face():
+    # Companion to #2445: `np.inf` vertices should be dropped along with
+    # any face referencing them — the bug fix must cover both NaN and Inf.
+    vertices = g.np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.5, 0.5, g.np.inf],
+        ],
+        dtype=g.np.float64,
+    )
+    faces = g.np.array([[0, 1, 2], [0, 3, 1]], dtype=g.np.int64)
+    mesh = g.trimesh.Trimesh(
+        vertices=vertices.copy(), faces=faces.copy(), process=True
+    )
+
+    assert g.np.isfinite(mesh.vertices).all()
+    assert len(mesh.vertices) == 3
+    # only the all-finite face survives
+    assert len(mesh.faces) == 1
+    assert (mesh.faces < len(mesh.vertices)).all()
+
+
+def test_remove_infinite_values_no_op_on_finite_mesh():
+    # Sanity: when every vertex is finite, `remove_infinite_values` must
+    # not drop anything. Guards against an over-eager fix that would
+    # touch face counts on healthy meshes.
+    vertices = g.np.random.RandomState(0).random((40, 3))
+    # random integer faces, deduped so we don't start with degenerates
+    raw = g.np.random.RandomState(1).randint(0, 40, (50, 3))
+    faces = g.np.array([f for f in raw if len(set(f)) == 3], dtype=g.np.int64)
+
+    mesh = g.trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+    n_v, n_f = len(mesh.vertices), len(mesh.faces)
+    mesh.remove_infinite_values()
+    assert len(mesh.vertices) == n_v
+    assert len(mesh.faces) == n_f
+
+
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()
     test_mesh_2D()

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1392,14 +1392,24 @@ class Trimesh(Geometry3D):
 
         Alters `self.faces` and `self.vertices`
         """
-        if util.is_shape(self.faces, (-1, 3)):
-            # (len(self.faces), ) bool, mask for faces
-            face_mask = np.isfinite(self.faces).all(axis=1)
-            self.update_faces(face_mask)
-
         if util.is_shape(self.vertices, (-1, 3)):
             # (len(self.vertices), ) bool, mask for vertices
             vertex_mask = np.isfinite(self.vertices).all(axis=1)
+            # faces referencing a non-finite vertex must be dropped BEFORE
+            # the vertex is removed. `update_vertices` reindexes faces via
+            # an inverse-array whose entries for removed vertices default
+            # to 0, so any face touching a NaN/Inf vertex would otherwise
+            # be silently rewritten to a degenerate triangle (e.g. `[0,1,2]`
+            # becomes `[0,1,0]`) that later crashes the renderer. See #2445.
+            if (
+                util.is_shape(self.faces, (-1, 3))
+                and not vertex_mask.all()
+                and len(self.faces) > 0
+            ):
+                # face is kept only if all three vertex indices are valid
+                face_mask = vertex_mask[self.faces].all(axis=1)
+                if not face_mask.all():
+                    self.update_faces(face_mask)
             self.update_vertices(vertex_mask)
 
     def unique_faces(self) -> NDArray[np.bool_]:


### PR DESCRIPTION
Fixes #2445 — meshes with NaN/Inf vertices now have their dependent faces dropped during processing, instead of being silently rewritten to degenerate triangles that crash the renderer.

## The bug

Reported in #2445:

> If I create a `trimesh.Trimesh` where a vertex's `z` component is `numpy.nan` the mesh is created, but `mesh.show()` errors with an `IndexError` at the vertex with `numpy.nan`.

```python
import numpy as np, trimesh
vertices = np.array([
    [0.0, 0.0, 0.0],   # 0
    [1.0, 0.0, 0.0],   # 1
    [0.5, 0.5, np.nan],# 2 -- bad
])
faces = np.array([[0, 1, 2]])
m = trimesh.Trimesh(vertices=vertices, faces=faces, process=True)
print(m.vertices)  # [[0,0,0],[1,0,0]]  -- NaN removed, OK
print(m.faces)     # [[0,1,0]]          -- ⚠ now degenerate
```

The NaN vertex is removed, but the face that referenced it is rewritten to `[0, 1, 0]` — a degenerate triangle reusing vertex 0. Downstream that crashes `mesh.show()` and corrupts every face-adjacency / volume / `is_watertight` calculation.

## Root cause

`Trimesh.remove_infinite_values` (in `trimesh/base.py`) had two lines:

```python
if util.is_shape(self.faces, (-1, 3)):
    face_mask = np.isfinite(self.faces).all(axis=1)   # ← always all-True
    self.update_faces(face_mask)
if util.is_shape(self.vertices, (-1, 3)):
    vertex_mask = np.isfinite(self.vertices).all(axis=1)
    self.update_vertices(vertex_mask)
```

`self.faces` is `int64`, so `np.isfinite(self.faces)` is always all-True and `face_mask` removes nothing. The faces that referenced a non-finite vertex then fall through to `update_vertices`, whose inverse-index map (`base.py:1224`) is `np.zeros(len(vertices), dtype=int64)` — the entries for removed vertices stay zero, so every face index pointing at a NaN/Inf vertex gets remapped to `0`.

Net effect: `[0,1,2]` with vertex 2 non-finite becomes `[0,1,0]`, not a removal.

## The fix

Compute the vertex-finite mask first, drop faces touching a non-finite vertex BEFORE removing the vertex, then run the usual vertex update:

```python
def remove_infinite_values(self) -> None:
    if util.is_shape(self.vertices, (-1, 3)):
        vertex_mask = np.isfinite(self.vertices).all(axis=1)
        if (
            util.is_shape(self.faces, (-1, 3))
            and not vertex_mask.all()
            and len(self.faces) > 0
        ):
            # face is kept only if all three vertex indices are valid
            face_mask = vertex_mask[self.faces].all(axis=1)
            if not face_mask.all():
                self.update_faces(face_mask)
        self.update_vertices(vertex_mask)
```

Why this is safe:

- The previous "face" mask was a no-op, so removing that block changes nothing on its own.
- The new face mask fires only when at least one vertex is non-finite — fully finite meshes hit `vertex_mask.all()` and skip the new branch entirely, preserving the existing fast path.
- Faces touching a non-finite vertex are dropped via `update_faces` (which carries face attributes / face normals correctly), so the subsequent `update_vertices` only re-indexes faces that point at survivors.
- The `update_vertices` inverse-array behavior is left alone — other callers in trimesh (post-merge re-indexing, etc.) rely on it.

## Verification

Three regression tests added to `tests/test_mesh.py`:

- `test_remove_infinite_values_drops_dependent_faces`: 5 verts (1 NaN) / 5 faces (3 touching NaN). After process: 4 finite vertices, **2** non-degenerate faces with valid indices (was 5 faces with degeneracies on main), and `mesh.scene()` builds without crashing.
- `test_remove_infinite_values_inf_vertex_drops_face`: same behavior for `np.inf`.
- `test_remove_infinite_values_no_op_on_finite_mesh`: random fully-finite mesh — vertex and face counts unchanged after `remove_infinite_values`.

```
$ pytest tests/test_mesh.py
5 passed
$ pytest tests/ --ignore=tests/test_gltf.py -k "not segmentation"
656 passed
$ pytest tests/test_gltf.py
50 passed
$ ruff check trimesh/base.py tests/test_mesh.py
All checks passed!
```

No regressions across the full unit suite.
