### PR TITLE
ply: export vertex_attributes['color'] as standard RGB/RGBA properties (continues #2419)

### DIFF
--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -19,6 +19,73 @@ class PlyTest(g.unittest.TestCase):
         assert len(m.vertex_attributes["color"]) == len(m.vertices)
         assert len(m.visual.uv) == len(m.vertices)
 
+    def test_multi_roundtrip_preserves_uv_and_vertex_colors(self):
+        # Regression test for https://github.com/mikedh/trimesh/issues/2419
+        #
+        # `models/multi.ply` is the fixture from the original report — a
+        # textured mesh that also carries per-vertex `red green blue`.
+        # The load side was fixed in 72016ad5 (constructor stores
+        # `vertex_colors` as `vertex_attributes["color"]` when `visual`
+        # is also passed), but the PLY exporter then wrote the array via
+        # the generic vertex-attribute path as `property list uchar uchar
+        # color`. That list-typed property is not standard PLY color
+        # encoding and the importer (and every other PLY reader) does not
+        # recover it as colors, silently losing the data on round-trip.
+        m = g.get_mesh("multi.ply")
+        # sanity: load preserves both
+        assert m.visual.kind == "texture"
+        assert m.visual.uv.shape == (len(m.vertices), 2)
+        assert m.vertex_attributes["color"].shape[0] == len(m.vertices)
+
+        # export to PLY and verify the header uses standard color properties
+        export = m.export(file_type="ply")
+        header = export.split(b"end_header")[0].decode("utf-8")
+        assert "property uchar red" in header
+        assert "property uchar green" in header
+        assert "property uchar blue" in header
+        assert "property uchar alpha" in header
+        # texture coords still written
+        assert "property double s" in header or "property float s" in header
+        # the malformed list-typed `color` property must NOT appear
+        assert "property list uchar uchar color" not in header
+        assert "property list uchar uint8 color" not in header
+
+        # round-trip back to a Trimesh and confirm both visual.uv AND
+        # vertex_attributes["color"] survive
+        reloaded = g.roundtrip(export, file_type="ply")
+        assert hasattr(reloaded.visual, "uv")
+        assert reloaded.visual.uv.shape == (len(reloaded.vertices), 2)
+        assert "color" in reloaded.vertex_attributes
+        reloaded_colors = g.np.asarray(reloaded.vertex_attributes["color"])
+        assert reloaded_colors.shape == (len(reloaded.vertices), 4)
+        # the RGB channels match the original (alpha is padded to 255
+        # since the source PLY had only red/green/blue, which is the
+        # standard PLY convention for opaque)
+        orig_colors = g.np.asarray(m.vertex_attributes["color"])
+        if orig_colors.shape[1] == 3:
+            assert g.np.array_equal(reloaded_colors[:, :3], orig_colors)
+            assert (reloaded_colors[:, 3] == 255).all()
+        else:
+            assert g.np.array_equal(reloaded_colors, orig_colors)
+
+    def test_ply_export_color_only_when_rgb_shape(self):
+        # Regression guard for #2419: the standard-color shortcut must
+        # ONLY fire for shape-(n, 3 or 4) arrays. Non-color `color` keys
+        # (e.g. a per-vertex scalar accidentally named "color", or an
+        # exotic (n, 5) array) must keep falling through to the generic
+        # vertex-attribute writer rather than being coerced into RGBA.
+        box = g.trimesh.creation.box()
+        # scalar attribute confusingly named "color" but shaped (n,)
+        box.vertex_attributes["color"] = g.np.arange(
+            len(box.vertices), dtype=g.np.float32
+        )
+        export = box.export(file_type="ply")
+        header = export.split(b"end_header")[0].decode("utf-8")
+        # since the array is 1-D it is exported as a normal scalar
+        # `property float color`, not as RGBA channels
+        assert "property uchar red" not in header
+        assert "property float color" in header
+
     def test_ply(self):
         m = g.get_mesh("machinist.XAML")
 

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -363,6 +363,45 @@ def export_ply(
             and mesh.visual.kind == "vertex"
             and len(mesh.visual.vertex_colors) == len(mesh.vertices)
         )
+        # the source array packed into the `rgba` field if we end up
+        # writing standard `red/green/blue/alpha` color properties below
+        vertex_color_source = (
+            mesh.visual.vertex_colors if vertex_color else None
+        )
+
+        # ColorVisuals carries colors directly via `mesh.visual.vertex_colors`
+        # and we just handled that. A TextureVisuals mesh that ALSO loaded
+        # per-vertex colors (PLY/OBJ with both UV and red/green/blue, see
+        # issue #2419) instead stashes them in `mesh.vertex_attributes["color"]`.
+        # Without special handling, the generic vertex-attribute exporter would
+        # serialize them as a `property list uchar uchar color` row — a
+        # malformed list-typed property that no standard PLY reader (including
+        # ours) recovers as colors, silently losing the data on round-trip.
+        # Detect that case and write standard red/green/blue/alpha properties
+        # so the file stays interoperable and our own import preserves them.
+        attr_color = None
+        if (
+            not vertex_color
+            and hasattr(mesh, "vertex_attributes")
+            and "color" in mesh.vertex_attributes
+        ):
+            candidate = np.asanyarray(mesh.vertex_attributes["color"])
+            if (
+                candidate.ndim == 2
+                and candidate.shape[0] == len(mesh.vertices)
+                and candidate.shape[1] in (3, 4)
+            ):
+                # promote to 4-channel uint8 RGBA to match the color template
+                rgba = np.asarray(candidate, dtype=np.uint8)
+                if rgba.shape[1] == 3:
+                    rgba = np.column_stack(
+                        (rgba, np.full(rgba.shape[0], 255, dtype=np.uint8))
+                    )
+                vertex_color = True
+                vertex_color_source = rgba
+                # remember the key so we can skip the generic export below
+                attr_color = "color"
+
         if vertex_color:
             header.append(templates["color"])
             dtype_vertex.append(dtype_color)
@@ -373,7 +412,11 @@ def export_ply(
                 vertex_attributes = {
                     k: v
                     for k, v in mesh.vertex_attributes.items()
-                    if hasattr(v, "__len__") and len(v) == vertex_count
+                    # do not double-export the color we just hoisted into
+                    # standard `red/green/blue/alpha` properties above
+                    if k != attr_color
+                    and hasattr(v, "__len__")
+                    and len(v) == vertex_count
                 }
                 _add_attributes_to_header(header, vertex_attributes)
                 _add_attributes_to_dtype(dtype_vertex, vertex_attributes)
@@ -386,7 +429,7 @@ def export_ply(
         if vertex_normal:
             pack_vertex["normals"] = mesh.vertex_normals
         if vertex_color:
-            pack_vertex["rgba"] = mesh.visual.vertex_colors
+            pack_vertex["rgba"] = vertex_color_source
 
         if include_attributes and vertex_attributes is not None:
             _add_attributes_to_data_array(pack_vertex, vertex_attributes)


### PR DESCRIPTION
Continues #2419 — PLY export now writes `vertex_attributes['color']` using the standard `red/green/blue/alpha` properties so textured meshes that also carry per-vertex colors survive a round-trip through PLY.

## Status before this PR

Issue #2419 was partially resolved by the maintainer in commit 72016ad5 (in PR #2430), which moved the `vertex_attributes` init above the `visual` setup in `Trimesh.__init__` so that the constructor no longer threw away `vertex_colors` when a `visual` kwarg was also passed. That covers the load side — `trimesh.load("multi.ply")` now correctly populates both `m.visual.uv` and `m.vertex_attributes["color"]`. The original reporter accepted that fix.

But the export side was still broken — and that breakage round-tripped the colors right back out of existence.

## The remaining bug

```python
import trimesh, io
m = trimesh.load("models/multi.ply")
print(m.visual.kind)                          # texture
print(m.vertex_attributes["color"].shape)     # (4, 3)  ✓
out = m.export(file_type="ply")
print(out.decode().split("end_header")[0])
```

```
element vertex 4
property float x
property float y
property float z
property list uchar uchar color   ← ⚠ malformed list-typed color property
property double s
property double t
```

`property list uchar uchar color` is **not** how PLY encodes per-vertex color (the standard is `property uchar red` / `green` / `blue` / `alpha`). No spec-compliant reader recovers it as colors — MeshLab, Open3D, the three.js loader, and trimesh's own `_element_colors` all key off `red/green/blue/alpha`. So:

```python
reloaded = trimesh.load(io.BytesIO(out), file_type="ply")
print(reloaded.vertex_attributes)             # {} — colors silently lost
```

## Root cause

`Trimesh` carries vertex colors in two different places depending on which visual it has:

- `ColorVisuals` → `mesh.visual.vertex_colors` → exporter `vertex_color = True` path → emits standard `red/green/blue/alpha`.
- `TextureVisuals` (PLY/OBJ files with both UV and `red/green/blue`) → `mesh.vertex_attributes["color"]` (per the 72016ad5 constructor fix) → exporter generic vertex-attribute path → emits `property list uchar uchar color`.

The exporter only knew about the first slot.

## The fix

In `export_ply` (`trimesh/exchange/ply.py`), after the existing `vertex_color = (mesh.visual.kind == "vertex" and ...)` detection, also check whether `mesh.vertex_attributes["color"]` is a shape-`(n, 3 | 4)` array. If so, hoist it into the canonical color path — promote to `uint8` RGBA (pad alpha to 255 for RGB-only input), add the `templates["color"]` header line, and pack into the `rgba` field of the structured vertex array. The key is then excluded from the generic `vertex_attributes` writer so it is not emitted twice.

```python
attr_color = None
if (
    not vertex_color
    and hasattr(mesh, "vertex_attributes")
    and "color" in mesh.vertex_attributes
):
    candidate = np.asanyarray(mesh.vertex_attributes["color"])
    if (
        candidate.ndim == 2
        and candidate.shape[0] == len(mesh.vertices)
        and candidate.shape[1] in (3, 4)
    ):
        rgba = np.asarray(candidate, dtype=np.uint8)
        if rgba.shape[1] == 3:
            rgba = np.column_stack(
                (rgba, np.full(rgba.shape[0], 255, dtype=np.uint8))
            )
        vertex_color = True
        vertex_color_source = rgba
        attr_color = "color"
```

The shape predicate is deliberately strict — a 1-D scalar attribute confusingly named `color`, or an exotic `(n, 5)` row, keeps falling through to the generic exporter unchanged. The new test `test_ply_export_color_only_when_rgb_shape` guards that.

## Verification

After the fix, the same export now produces:

```
element vertex 4
property float x
property float y
property float z
property uchar red
property uchar green
property uchar blue
property uchar alpha       ← ✓ standard color encoding
property double s
property double t
```

```python
reloaded = trimesh.load(io.BytesIO(out), file_type="ply")
print(reloaded.vertex_attributes["color"])
# [[255   0   0 255]
#  [  0 255   0 255]
#  [  0   0 255 255]
#  [255 255 255 255]]
```

Both `reloaded.visual.uv` and `reloaded.vertex_attributes["color"]` survive.

## Tests

Two regression tests in `tests/test_ply.py`:

- `test_multi_roundtrip_preserves_uv_and_vertex_colors`: exports `models/multi.ply`, asserts the header contains `property uchar {red,green,blue,alpha}` and lacks `property list uchar uchar color`, round-trips back through `trimesh.load`, confirms `visual.uv` is `(n, 2)` AND `vertex_attributes["color"]` matches the original RGB with alpha padded to 255.
- `test_ply_export_color_only_when_rgb_shape`: writes a 1-D scalar attribute named `color` to a box, confirms the header emits `property float color` (generic path) and NOT `property uchar red` — guarding against an over-eager match.

```
$ pytest tests/test_ply.py
19 passed
$ pytest tests/ --ignore=tests/test_exchange.py
700 passed
$ ruff check trimesh/exchange/ply.py tests/test_ply.py
All checks passed!
```

Existing PLY tests (binary export, ASCII export, machinist.XAML face colors, reference.ply vertex colors, etc.) still pass, including the load-side `test_multi` added in 72016ad5.

## Scope notes

- OBJ export is out of scope: OBJ has no portable per-vertex color spec — the in-tree exporter at `obj.py:893-898` only handles `ColorVisuals` and hstacks the colors onto the position line in a Blender-specific extension. That deserves its own discussion.
- Face attributes are similarly hoistable but `face_attributes["color"]` is not produced by the current loader/constructor path, so this PR leaves the face side unchanged.
