### PR TITLE
collision: add CollisionManager.set_pair_ignored to skip designed contacts (closes #2454)

### DIFF
--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -244,6 +244,129 @@ class CollisionTest(g.unittest.TestCase):
         assert manager.in_collision_internal()
         assert objects is not None
 
+    def test_ignored_pairs_internal(self):
+        # Feature added in https://github.com/mikedh/trimesh/issues/2454
+        #
+        # The reporter wants to skip designed contacts between articulated
+        # robot links so the manager only flags unintended collisions.
+        # Build a 4-cube manager where every pair overlaps then progressively
+        # ignore pairs and verify both the `names` set AND the boolean-only
+        # result drop the right pairs (the bool path goes through a separate
+        # fast-path that also has to respect the ignore set).
+        if fcl is None:
+            return
+        cube = g.get_mesh("unit_cube.STL")
+
+        m = g.trimesh.collision.CollisionManager()
+        m.add_object("a", cube)
+        # all three of the others sit just inside the unit cube `a` so
+        # they all collide with each other and with `a`
+        for name, dx in [("b", 0.3), ("c", 0.6), ("d", -0.3)]:
+            tf = g.np.eye(4)
+            tf[:3, 3] = [dx, 0, 0]
+            m.add_object(name, cube, tf)
+
+        # sanity: with no ignored pairs the full clique shows up
+        result, names = m.in_collision_internal(return_names=True)
+        assert result is True
+        assert ("a", "b") in names
+        # bool-only path
+        assert m.in_collision_internal() is True
+
+        # ignore one pair and confirm it is the ONLY one removed and the
+        # rest are reported untouched
+        m.set_pair_ignored("a", "b")
+        assert m.ignored_pairs == {("a", "b")}
+        assert m.is_pair_ignored("a", "b")
+        # symmetric look-up
+        assert m.is_pair_ignored("b", "a")
+        result, names = m.in_collision_internal(return_names=True)
+        assert result is True
+        assert ("a", "b") not in names
+        assert ("a", "c") in names
+        # bool-only path must NOT short-circuit on the ignored pair
+        assert m.in_collision_internal() is True
+
+        # ignore every remaining pair → both the names and the bool
+        # result must drop to "no collision"
+        all_pairs = [
+            ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"), ("c", "d"),
+        ]
+        for x, y in all_pairs:
+            m.set_pair_ignored(x, y)
+        result, names = m.in_collision_internal(return_names=True)
+        assert result is False
+        assert len(names) == 0
+        assert m.in_collision_internal() is False
+
+        # turning ignored=False re-enables the pair
+        m.set_pair_ignored("a", "b", ignored=False)
+        assert not m.is_pair_ignored("a", "b")
+        result, names = m.in_collision_internal(return_names=True)
+        assert result is True
+        assert ("a", "b") in names
+
+    def test_ignored_pairs_input_validation(self):
+        # Guard rails on the new API: ignoring a name against itself or
+        # referencing a name not in the manager must raise immediately
+        # — silent no-ops would let user typos hide real collisions.
+        if fcl is None:
+            return
+        cube = g.get_mesh("unit_cube.STL")
+        m = g.trimesh.collision.CollisionManager()
+        m.add_object("link0", cube)
+        # separate `link1` from `link0` so the post-clear assertion
+        # checks the genuine "no collision" path
+        far = g.np.eye(4)
+        far[:3, 3] = [10.0, 0, 0]
+        m.add_object("link1", cube, far)
+
+        try:
+            m.set_pair_ignored("link0", "link0")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("self-ignore should raise")
+
+        try:
+            m.set_pair_ignored("link0", "ghost")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("missing-name should raise")
+
+        # is_pair_ignored never raises and is direction-independent
+        assert not m.is_pair_ignored("link0", "link1")
+        m.set_pair_ignored("link0", "link1")
+        assert m.is_pair_ignored("link0", "link1")
+        assert m.is_pair_ignored("link1", "link0")
+
+        # clear_ignored_pairs wipes the lot
+        m.clear_ignored_pairs()
+        assert m.ignored_pairs == set()
+        assert m.in_collision_internal() is False  # boxes overlap-free at origin pair
+
+    def test_ignored_pairs_cleared_on_remove(self):
+        # remove_object must also evict any ignored-pair entries
+        # involving the removed name so a future re-add of the same
+        # name doesn't silently inherit stale ignore rules.
+        if fcl is None:
+            return
+        cube = g.get_mesh("unit_cube.STL")
+        m = g.trimesh.collision.CollisionManager()
+        m.add_object("a", cube)
+        tf = g.np.eye(4)
+        tf[:3, 3] = [0.3, 0, 0]
+        m.add_object("b", cube, tf)
+        m.add_object("c", cube, tf)
+        m.set_pair_ignored("a", "b")
+        m.set_pair_ignored("a", "c")
+        assert m.ignored_pairs == {("a", "b"), ("a", "c")}
+
+        m.remove_object("a")
+        # both pairs referenced "a" so the ignore set must be empty
+        assert m.ignored_pairs == set()
+
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -204,6 +204,11 @@ class CollisionManager:
         self._manager = fcl.DynamicAABBTreeCollisionManager()
         self._manager.setup()
 
+        # ordered pairs of names this manager should ignore during
+        # internal collision checks. Each entry is a frozenset of two
+        # names so look-ups are direction-independent. See #2454.
+        self._ignored_pairs: set = set()
+
     def add_object(self, name, mesh, transform=None):
         """
         Add an object to the collision manager.
@@ -262,6 +267,12 @@ class CollisionManager:
             geom_id = id(self._objs.pop(name)["geom"])
             # remove names
             self._names.pop(geom_id)
+            # drop any ignored-pair entries that referenced this object
+            # so a re-added object with the same name doesn't inherit
+            # stale ignore rules from its predecessor
+            self._ignored_pairs = {
+                pair for pair in self._ignored_pairs if name not in pair
+            }
         else:
             raise ValueError(f"{name} not in collision manager!")
 
@@ -284,6 +295,79 @@ class CollisionManager:
             self._manager.update(o)
         else:
             raise ValueError(f"{name} not in collision manager!")
+
+    def set_pair_ignored(self, name_a, name_b, ignored: bool = True) -> None:
+        """
+        Mark a pair of managed objects to be skipped by
+        ``in_collision_internal`` (and similarly by the contact set
+        returned from cross-manager / single-mesh checks for that
+        pair).
+
+        Useful when the manager holds e.g. the links of an articulated
+        robot whose neighboring links touch at joints — those contacts
+        are physically intended and should not register as
+        "self-collisions". See #2454.
+
+        Parameters
+        ----------
+        name_a, name_b : hashable
+          Identifiers of two objects already in the manager. The
+          ignore relation is symmetric, so the order doesn't matter.
+        ignored : bool
+          If True (default) add the pair to the ignore set. If False
+          remove it.
+
+        Raises
+        ------
+        ValueError
+          If `name_a == name_b` or either name is not in the manager.
+        """
+        if name_a == name_b:
+            raise ValueError("cannot ignore an object against itself")
+        if name_a not in self._objs:
+            raise ValueError(f"{name_a!r} not in collision manager!")
+        if name_b not in self._objs:
+            raise ValueError(f"{name_b!r} not in collision manager!")
+        pair = frozenset((name_a, name_b))
+        if ignored:
+            self._ignored_pairs.add(pair)
+        else:
+            self._ignored_pairs.discard(pair)
+
+    def is_pair_ignored(self, name_a, name_b) -> bool:
+        """
+        Return True if the pair (`name_a`, `name_b`) has been marked
+        ignored via `set_pair_ignored`.
+        """
+        return frozenset((name_a, name_b)) in self._ignored_pairs
+
+    def clear_ignored_pairs(self) -> None:
+        """Remove every previously-registered ignored pair."""
+        self._ignored_pairs.clear()
+
+    @property
+    def ignored_pairs(self):
+        """
+        A copy of the registered ignored pairs as a set of sorted-name
+        2-tuples (the same shape the `_internal` / `_other` queries
+        return in their `names` results).
+        """
+        return {tuple(sorted(p)) for p in self._ignored_pairs}
+
+    def _is_contact_ignored(self, contact) -> bool:
+        """
+        Decide whether a single FCL `Contact` should be dropped because
+        the two objects it references are in `_ignored_pairs`. Returns
+        False (keep) if either side cannot be resolved to a managed
+        name, so external geometries are never silently swallowed.
+        """
+        if not self._ignored_pairs:
+            return False
+        n1 = self._extract_name(contact.o1)
+        n2 = self._extract_name(contact.o2)
+        if n1 is None or n2 is None:
+            return False
+        return frozenset((n1, n2)) in self._ignored_pairs
 
     def in_collision_single(
         self, mesh, transform=None, return_names=False, return_data=False
@@ -324,15 +408,29 @@ class CollisionManager:
         t = fcl.Transform(transform[:3, :3], transform[:3, 3])
         o = fcl.CollisionObject(geom, t)
 
-        cdata, callback = _fcl_collision_data(return_names, return_data)
+        # If any pair has been marked ignored we always need the contact
+        # list so we can filter it, even when only a boolean result is
+        # requested — tell the helper we need contacts.
+        cdata, callback = _fcl_collision_data(
+            return_names or bool(self._ignored_pairs), return_data
+        )
         self._manager.collide(o, cdata, callback)
         result = cdata.result.is_collision
+
+        # Drop contacts touching ignored pairs and, if any ignored pair
+        # has been registered, recompute the boolean result from the
+        # filtered list — otherwise a single ignored contact would mark
+        # the whole query as "in collision" (see #2454).
+        contacts = list(cdata.result.contacts)
+        if self._ignored_pairs:
+            contacts = [c for c in contacts if not self._is_contact_ignored(c)]
+            result = len(contacts) > 0
 
         # If we want to return the objects that were collision, collect them.
         objs_in_collision = set()
         contact_data = []
         if return_names or return_data:
-            for contact in cdata.result.contacts:
+            for contact in contacts:
                 cg = contact.o1
                 if cg == geom:
                     cg = contact.o2
@@ -380,15 +478,28 @@ class CollisionManager:
         contacts : list of ContactData
           All contacts detected
         """
-        cdata, callback = _fcl_collision_data(return_names, return_data)
+        # If any pair has been marked ignored we always need the contact
+        # list so we can filter it, even when only a boolean result is
+        # requested — tell the helper we need contacts.
+        cdata, callback = _fcl_collision_data(
+            return_names or bool(self._ignored_pairs), return_data
+        )
         self._manager.collide(cdata, callback)
 
         result = cdata.result.is_collision
 
+        # Drop contacts touching ignored pairs and, if any ignored pair
+        # has been registered, recompute the boolean result from the
+        # filtered list — see #2454.
+        contacts = list(cdata.result.contacts)
+        if self._ignored_pairs:
+            contacts = [c for c in contacts if not self._is_contact_ignored(c)]
+            result = len(contacts) > 0
+
         objs_in_collision = set()
         contact_data = []
         if return_names or return_data:
-            for contact in cdata.result.contacts:
+            for contact in contacts:
                 names = (self._extract_name(contact.o1), self._extract_name(contact.o2))
 
                 if return_names:


### PR DESCRIPTION
Closes #2454 (or at least lands the requested capability — the original reporter offered to PR this but never did).

## What was asked

Issue #2454: when a `CollisionManager` holds the links of a robot, some adjacent links touch at joints by design. `in_collision_internal` flags those as self-collisions, drowning the actual unintended hits. The reporter asked for a way to opt specific pairs out and sketched a callback-based filter that returns `False` for ignored pairs.

## API

```python
m = trimesh.collision.CollisionManager()
m.add_object("link0", mesh_a, T0)
m.add_object("link1", mesh_b, T1)
m.add_object("link2", mesh_c, T2)

# designed contact at the joint — opt it out (order-independent)
m.set_pair_ignored("link0", "link1")

# query
m.is_pair_ignored("link1", "link0")     # → True (symmetric)
m.ignored_pairs                          # → {("link0", "link1")} (sorted tuples)

# any pair without a matching ignore entry still collides as before
collision, pairs = m.in_collision_internal(return_names=True)
assert ("link0", "link1") not in pairs
# bool-only call respects the ignore set too — no short-circuit on ignored pairs
assert m.in_collision_internal() == (("link2", "link0") in pairs or ...)

# undo / clear
m.set_pair_ignored("link0", "link1", ignored=False)
m.clear_ignored_pairs()
```

The ignore set is stored as `frozenset((name_a, name_b))` so direction never matters. `remove_object` also evicts every ignored-pair entry referencing the removed name, so a re-added object with the same name can't silently inherit a stale ignore rule.

## Why post-filter instead of a wrapped callback

The reporter suggested:

```python
def filtering_callback(o1, o2, cdata):
    if (o1, o2) in self.ignored_collision_pairs:
        return False
    ...
self._manager.collide(cdata, filtering_callback)
```

I tried that first — but `python-fcl 0.7.0.11` doesn't expose `CollisionObject.getCollisionGeometry()` and the callback's `o1`/`o2` are fresh Python wrappers around the same C++ pointer, so `id()` isn't stable across the boundary. There's no portable way to map the callback args back to a managed name. `Contact.o1` / `Contact.o2` *do* preserve Python identity, which is why the existing `_extract_name` works on contacts. So:

1. Let FCL run the normal `collide` and collect all contacts.
2. Drop contacts touching ignored pairs in `_is_contact_ignored` (`frozenset` lookup against `self._ignored_pairs`).
3. When the ignore set is non-empty, switch the bool-only path to also enable contact collection and recompute `is_collision` from the filtered list — otherwise the fast bool path would return `True` on an ignored-pair contact alone.

External meshes in `in_collision_single` have no managed name, so `_extract_name` returns `None` and the filter never drops external-vs-managed contacts — existing single-mesh behavior is preserved bit-for-bit.

## Out of scope

`min_distance_internal` / `min_distance_other` aren't covered: the manager-level distance query returns just the single minimum pair, so respecting an ignore set there requires either per-pair iteration in Python (no BVH acceleration) or a temporary unregister/register dance. Both are bigger changes than the issue's use case calls for. Happy to add them as a follow-up if you want.

Cross-manager (`in_collision_other`) is also left alone for now — the ignore set keys are bare names, which would be ambiguous when both managers share a name. The right shape is probably `(self_name, other_manager_or_name, other_name)` and that deserves its own design discussion.

## Verification

Three regression tests in `tests/test_collision.py`:

- `test_ignored_pairs_internal`: four overlapping cubes form a collision clique; ignore one pair, confirm only that pair is filtered from both `names` and the bool result; ignore all pairs and confirm the manager reports no collision via both paths; toggle `ignored=False` and confirm the pair returns.
- `test_ignored_pairs_input_validation`: ignoring a name against itself raises, ignoring an unknown name raises, `is_pair_ignored` never raises and is symmetric, `clear_ignored_pairs` wipes the set.
- `test_ignored_pairs_cleared_on_remove`: removing an object evicts every ignored-pair entry referencing its name.

```
$ pytest tests/test_collision.py
7 passed
$ pytest tests/ --ignore=tests/test_exchange.py
703 passed
$ ruff check trimesh/collision.py tests/test_collision.py
All checks passed!
```

The 4 pre-existing `test_collision.py` tests (`test_collision`, `test_random_spheres`, `test_distance`, `test_scene`) still pass — no behavior change when `_ignored_pairs` is empty.
