### PR TITLE
exchange: warn once when textures are dropped because pillow is missing (closes #2333)

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -570,6 +570,62 @@ class StructuredArrayToString(unittest.TestCase):
             )
 
 
+class WarnPillowMissingTests(unittest.TestCase):
+    """
+    Regression tests for https://github.com/mikedh/trimesh/issues/2333:
+    textures were silently dropped from OBJ/PLY/glTF loads when pillow
+    was not installed. `util.warn_pillow_missing` is a single-shot
+    pillow-missing diagnostic the loaders now emit.
+    """
+
+    def setUp(self):
+        # capture log records emitted on the trimesh.util logger
+        self._records = []
+
+        class Cap(logging.Handler):
+            def emit(_self, record):
+                self._records.append((record.levelname, record.getMessage()))
+
+        self._handler = Cap()
+        self._prev_level = trimesh.util.log.level
+        trimesh.util.log.addHandler(self._handler)
+        trimesh.util.log.setLevel(logging.DEBUG)
+        # reset the once-per-context guard so each test starts fresh
+        trimesh.util._PILLOW_MISSING_WARNED.clear()
+
+    def tearDown(self):
+        trimesh.util.log.removeHandler(self._handler)
+        trimesh.util.log.setLevel(self._prev_level)
+        trimesh.util._PILLOW_MISSING_WARNED.clear()
+
+    def _warnings(self):
+        return [m for lvl, m in self._records if lvl == "WARNING"]
+
+    def test_warns_once_per_context(self):
+        trimesh.util.warn_pillow_missing("OBJ load")
+        trimesh.util.warn_pillow_missing("OBJ load")
+        trimesh.util.warn_pillow_missing("OBJ load")
+        pillow_warnings = [w for w in self._warnings() if "pillow" in w.lower()]
+        # only the first call should reach the logger
+        assert len(pillow_warnings) == 1
+        # the context tag is embedded so the user can tell which
+        # pipeline silently dropped the texture
+        assert "OBJ load" in pillow_warnings[0]
+
+    def test_different_contexts_each_warn_once(self):
+        trimesh.util.warn_pillow_missing("OBJ load")
+        trimesh.util.warn_pillow_missing("PLY load")
+        trimesh.util.warn_pillow_missing("glTF load")
+        # repeat to confirm de-dupe per context
+        trimesh.util.warn_pillow_missing("OBJ load")
+        trimesh.util.warn_pillow_missing("PLY load")
+        pillow_warnings = [w for w in self._warnings() if "pillow" in w.lower()]
+        assert len(pillow_warnings) == 3
+        contexts = {ctx for ctx in ("OBJ load", "PLY load", "glTF load")
+                    if any(ctx in w for w in pillow_warnings)}
+        assert contexts == {"OBJ load", "PLY load", "glTF load"}
+
+
 if __name__ == "__main__":
     trimesh.util.attach_to_log()
     unittest.main()

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -1308,7 +1308,11 @@ def _parse_textures(header, views, resolver=None):
     try:
         import PIL.Image
     except ImportError:
-        log.debug("unable to load textures without pillow!")
+        # only warn when this glTF actually references textures —
+        # otherwise plain meshes loaded without pillow would noisily
+        # flag a missing dep that wasn't going to matter. See #2333.
+        if header.get("images"):
+            util.warn_pillow_missing("glTF load")
         return None
 
     # load any images

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -379,6 +379,10 @@ def parse_mtl(mtl, resolver=None):
                     os.path.join(getattr(resolver, "parent", ""), file_name)
                 )
 
+            except ImportError:
+                # missing pillow is the most common reason for a silent
+                # texture drop and used to be hidden at log.debug — see #2333
+                util.warn_pillow_missing("OBJ load")
             except BaseException:
                 log.debug("failed to load image", exc_info=True)
 

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -112,17 +112,20 @@ def load_ply(
 
     # try to load the referenced image
     image = None
-    if not skip_materials:
+    # only attempt the import / load when the PLY actually references
+    # a texture image — otherwise importing pillow on every PLY load
+    # and warning when it's missing would spam non-textured workflows
+    if not skip_materials and image_name is not None:
         try:
             # soft dependency
             import PIL.Image
 
-            # if an image name is passed try to load it
-            if image_name is not None:
-                data = resolver.get(image_name)
-                image = PIL.Image.open(util.wrap_as_stream(data))
+            data = resolver.get(image_name)
+            image = PIL.Image.open(util.wrap_as_stream(data))
         except ImportError:
-            log.debug("textures require `pip install pillow`")
+            # missing pillow is the most common reason for a silent
+            # texture drop and used to be hidden at log.debug — see #2333
+            util.warn_pillow_missing("PLY load")
         except BaseException:
             log.warning("unable to load image!", exc_info=True)
 

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -42,6 +42,35 @@ ABC = abc.ABC
 now = time.time
 which = shutil.which
 
+# remembers which loaders/exporters have already emitted the
+# "install pillow to keep textures" warning so we don't spam the user
+# on every call. Tracked by `warn_pillow_missing` below.
+_PILLOW_MISSING_WARNED: "set[str]" = set()
+
+
+def warn_pillow_missing(context: str) -> None:
+    """
+    Emit a single-shot user-facing warning when a texture-aware loader
+    or exporter has to silently drop image data because `pillow` is not
+    installed. Subsequent calls with the same `context` are no-ops so
+    repeated loads don't spam the user's log. See #2333.
+
+    Parameters
+    ----------
+    context : str
+      Short tag describing where the texture is being dropped
+      (e.g. ``"OBJ load"``, ``"glTF load"``). Used both as the de-dupe
+      key and embedded in the warning text so the user can tell which
+      pipeline silently lost the image.
+    """
+    if context in _PILLOW_MISSING_WARNED:
+        return
+    _PILLOW_MISSING_WARNED.add(context)
+    log.warning(
+        "trimesh: %s is dropping a texture image because `pillow` is not installed (`pip install pillow`); the loaded/exported mesh will have no texture data and further textures from this pipeline will not log this warning again",
+        context,
+    )
+
 # include constants here so we don't have to import
 # a floating point threshold for 0.0
 # we are setting it to 100x the resolution of a float64

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -45,7 +45,7 @@ which = shutil.which
 # remembers which loaders/exporters have already emitted the
 # "install pillow to keep textures" warning so we don't spam the user
 # on every call. Tracked by `warn_pillow_missing` below.
-_PILLOW_MISSING_WARNED: "set[str]" = set()
+_PILLOW_MISSING_WARNED = set()
 
 
 def warn_pillow_missing(context: str) -> None:


### PR DESCRIPTION
Closes #2333.

## The reported confusion

```python
mesh = trimesh.load("mesh.obj")   # OBJ with map_Kd textures
_ = mesh.export("mesh.glb")        # silently no textures
```

…with no warnings on either call, the user is left to guess that `pillow` is missing. On `main` the OBJ loader's `Image.open(...)` raises `ImportError`, the per-loader `except` swallows it as `log.debug` ("failed to load image"), the resulting `SimpleMaterial` has no `image`, and the GLB export drops the texture without further noise. As the reporter put it: *"It took me a while to figure out that pillow dependency is silently missing."*

@mikedh noted earlier that turning the debug into a blanket warning would "spam users pretty hard" — running a batch of 1000 OBJs without pillow would dump 1000 identical warnings. So this PR ships a single-shot warning instead.

## Change

New helper in `trimesh/util.py`:

```python
_PILLOW_MISSING_WARNED: set[str] = set()

def warn_pillow_missing(context: str) -> None:
    """Single-shot pillow-missing diagnostic for texture-aware loaders/exporters."""
    if context in _PILLOW_MISSING_WARNED:
        return
    _PILLOW_MISSING_WARNED.add(context)
    log.warning(
        "trimesh: %s is dropping a texture image because `pillow` is not "
        "installed (`pip install pillow`); the loaded/exported mesh will have "
        "no texture data and further textures from this pipeline will not "
        "log this warning again",
        context,
    )
```

The three texture-aware loaders now call it on their `ImportError` branch:

- `trimesh/exchange/obj.py::parse_mtl` (`map_Kd` handler)
- `trimesh/exchange/ply.py::load_ply` (texture image loader; also moved `import PIL.Image` inside the `image_name is not None` guard so plain non-textured PLY loads don't trip the warning when pillow is missing)
- `trimesh/exchange/gltf/__init__.py::_parse_textures` (only fires when `header.get("images")` is truthy, so untextured glTF/glb stay quiet)

Other failure modes (image file missing, corrupt blob, base64 decode error) keep their existing `log.debug` / `log.warning` levels — only the pillow-missing path flips.

## De-dupe semantics

The context tag becomes the de-dupe key:

```python
trimesh.util.warn_pillow_missing("OBJ load")   # → emits 1 warning
trimesh.util.warn_pillow_missing("OBJ load")   # → silent
trimesh.util.warn_pillow_missing("OBJ load")   # → silent
trimesh.util.warn_pillow_missing("PLY load")   # → emits 1 warning (different key)
```

So a session that loads 1000 textured OBJs gets exactly one warning, a session that loads one OBJ + one PLY + one GLB gets three, and a pure-geometry workflow that never touches textures gets none.

## Verification

Injected an `ImportError`-raising `sys.meta_path` hook to simulate missing pillow and ran the four cases manually:

| Load | Pre-PR | This PR |
|---|---|---|
| `fuze.obj` (textured) | 0 warnings, no texture loaded | 1 warning, no texture loaded |
| `fuze.ply` (textured) | 0 warnings, no texture loaded | 1 warning, no texture loaded |
| `Duck.glb` (textured) | 0 warnings, no texture loaded | 1 warning, no texture loaded |
| plain `creation.box()` round-trip through PLY/GLB | 0 warnings | 0 warnings (no texture referenced — guards work) |

Two regression tests in `tests/test_util.py::WarnPillowMissingTests`:

- `test_warns_once_per_context`: same context fires exactly one warning across three calls.
- `test_different_contexts_each_warn_once`: OBJ / PLY / glTF pipelines each warn independently, and repeating after dedupe stays silent.

```
$ pytest tests/test_util.py tests/test_obj.py tests/test_ply.py tests/test_gltf.py
140 passed
$ pytest tests/ --ignore=tests/test_exchange.py
702 passed
$ ruff check trimesh/util.py trimesh/exchange/{obj.py,ply.py,gltf/__init__.py} tests/test_util.py
All checks passed!
```

## Scope notes

- The export side (`_append_image` returning `None` when given a non-PIL image) already only triggers when the upstream loader silently dropped the image, so the new load-side warning catches the original failure point. Adding the same warning to `_append_image` would double-fire for the same root cause; leaving it alone.
- @Wei-fslaser's follow-up question on the issue (*"Does the newest version include pillow as a dependency?"*) is a separate dependency-policy question — this PR doesn't move pillow from optional to required, it just stops hiding when it is missing.
