### PR TITLE
Preserve user-assigned normals through Scene.to_mesh / load_mesh (fixes #2390)

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -206,6 +206,63 @@ class UtilTests(unittest.TestCase):
         c = g.trimesh.util.concatenate([a, b])
         assert "face_normals" in c._cache
 
+    def test_concat_single_preserves_normals(self):
+        # regression for issue #2390: when `concatenate` is called with a
+        # single mesh (e.g. through `Scene.to_mesh` / `trimesh.load_mesh`)
+        # any user-supplied vertex or face normals were silently dropped
+        # because the single-mesh early return called `.copy()` without
+        # `include_cache=True`.
+        a = g.trimesh.creation.icosphere()
+
+        rando_vn = g.trimesh.unitize(g.random(a.vertices.shape))
+        a.vertex_normals = rando_vn
+        # `face_normals` are validated against actual triangles in the
+        # setter, so populate the cache via the property instead.
+        original_fn = a.face_normals.copy()
+        assert "face_normals" in a._cache
+
+        # direct single-mesh `concatenate` path
+        c = g.trimesh.util.concatenate([a])
+        assert "vertex_normals" in c._cache
+        assert g.np.allclose(c.vertex_normals, rando_vn)
+        assert "face_normals" in c._cache
+        assert g.np.allclose(c.face_normals, original_fn)
+
+    def test_scene_to_mesh_preserves_normals(self):
+        # regression for issue #2390: the full path is
+        # `Scene.to_mesh` -> `Scene.dump` (which copies geometry, then
+        # `apply_transform`) -> `util.concatenate`.  Before #2390 was
+        # fixed, `Scene.dump` dropped the cache and `apply_transform`
+        # therefore had nothing to rotate, so `to_mesh` returned a
+        # mesh with stale auto-computed normals.
+        a = g.trimesh.creation.icosphere()
+        rando_vn = g.trimesh.unitize(g.random(a.vertices.shape))
+        a.vertex_normals = rando_vn
+
+        # single-geometry scene with identity transform
+        s = g.trimesh.Scene(a)
+        m = s.to_mesh()
+        assert g.np.allclose(m.vertex_normals, rando_vn)
+
+        # single-geometry scene with rotation: normals must be rotated
+        T = g.trimesh.transformations.rotation_matrix(g.np.pi / 3.0, [0, 1, 0])
+        s = g.trimesh.Scene()
+        s.add_geometry(a, transform=T)
+        m = s.to_mesh()
+        expected = g.trimesh.util.unitize(
+            g.trimesh.transformations.transform_points(
+                rando_vn, T, translate=False
+            )
+        )
+        assert g.np.allclose(m.vertex_normals, expected)
+
+        # accessing `Scene.dump` / `to_mesh` must not mutate the
+        # original mesh sitting in `Scene.geometry`.
+        hsh = a.__hash__()
+        _ = g.trimesh.Scene(a).to_mesh()
+        assert a.__hash__() == hsh
+        assert g.np.allclose(a.vertex_normals, rando_vn)
+
     def test_unique_id(self):
         num_ids = 10000
 

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -920,7 +920,17 @@ class Scene(Geometry3D):
         for node_name in self.graph.nodes_geometry:
             transform, geometry_name = self.graph[node_name]
             # get a copy of the geometry
-            current = self.geometry[geometry_name].copy()
+            # `include_cache=True` lets us bring along any user-assigned
+            # `vertex_normals` / `face_normals` (which live only in
+            # `_cache`) so that `apply_transform` can rotate them and
+            # downstream consumers like `Scene.to_mesh` don't silently
+            # recompute them from the bare geometry (see issue #2390).
+            try:
+                current = self.geometry[geometry_name].copy(include_cache=True)
+            except TypeError:
+                # not every geometry's `copy` supports include_cache,
+                # e.g. Path2D/Path3D and PointCloud
+                current = self.geometry[geometry_name].copy()
 
             # if the geometry is 2D see if we have to upgrade to 3D
             if hasattr(current, "to_3D"):

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1448,7 +1448,13 @@ def concatenate(
 
     if len(dump) == 1:
         # if there is only one geometry just return the first
-        return dump[0].copy()
+        # `include_cache=True` preserves user-assigned `vertex_normals`
+        # / `face_normals` for Trimesh inputs (see issue #2390); other
+        # geometries don't accept the keyword so fall back gracefully.
+        try:
+            return dump[0].copy(include_cache=True)
+        except TypeError:
+            return dump[0].copy()
     elif len(dump) == 0:
         # if there are no meshes return an empty mesh
         from .base import Trimesh


### PR DESCRIPTION
Fixes #2390.

After the 4.6 loader refactor, `trimesh.load_mesh(path)` (and the
`trimesh.load(path, force="mesh")` compatibility wrapper) silently
drop any `vertex_normals` / `face_normals` that the loader had
stored on the mesh.  The user-visible symptom in #2390 is a PLY
whose `nx/ny/nz` are present on disk but absent after load.

## Reproducer

```python
import tempfile, numpy as np, trimesh

m = trimesh.creation.icosphere(subdivisions=2)
custom_vn = trimesh.unitize(np.random.RandomState(0).rand(*m.vertices.shape))
m.vertex_normals = custom_vn

with tempfile.NamedTemporaryFile(suffix=".ply", delete=False) as tmp:
    m.export(tmp.name)
    path = tmp.name

m_default   = trimesh.load(path)              # works
m_force     = trimesh.load(path, force="mesh") # ❌ before this PR
m_loadmesh  = trimesh.load_mesh(path)          # ❌ before this PR

print(np.allclose(m_default.vertex_normals,  custom_vn))  # True
print(np.allclose(m_force.vertex_normals,    custom_vn))  # False -> True after fix
print(np.allclose(m_loadmesh.vertex_normals, custom_vn))  # False -> True after fix
```

## Root cause

The pipeline is

`load_mesh` → `Scene.to_mesh` → `Scene.dump` → `util.concatenate`

The cache that holds the normals was being thrown away at two places:

1. `Scene.dump` copies each geometry with the default `include_cache=False`,
   so the `_cache` entries that hold `vertex_normals` / `face_normals` are
   already gone before `apply_transform` ever runs.
2. `util.concatenate` short-circuits on a single mesh with another bare
   `.copy()`, dropping the cache a second time.

`Trimesh.apply_transform` already rotates cached `face_normals` /
`vertex_normals` (and clears every other cache entry), so once the cache
survives the copy in `Scene.dump`, normals propagate correctly through
arbitrary scene-graph transforms.

## Fix

Switch both call sites to `copy(include_cache=True)` with a `TypeError`
fallback for path/point-cloud geometries whose `copy` does not accept the
keyword.  No other call site of `Trimesh.copy` is affected.

## Tests

Two regression tests in `tests/test_util.py` that fail on `main` and
pass with this change:

- `test_concat_single_preserves_normals` — single-mesh
  `util.concatenate` path (catches regression 2).
- `test_scene_to_mesh_preserves_normals` — full `Scene.to_mesh` path,
  including a rotated transform (normals must be **rotated**, not just
  copied) and an immutability check confirming `Scene.geometry` is not
  mutated by `to_mesh()` (catches regression 1).

Local suite: `tests/test_util.py`, `tests/test_scene.py`,
`tests/test_mesh.py`, `tests/test_ply.py`, `tests/test_gltf.py`,
`tests/test_collision.py` all pass (131 tests).

