### PR TITLE
Resolve OBJ negative face indices against running vertex count (fixes #2364)

### DIFF
--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -93,6 +93,139 @@ def test_obj_negative_indices():
     assert mesh.vertices.shape == (8, 3)
 
 
+def test_obj_negative_indices_interleaved():
+    # regression for issue #2364: OBJ files that interleave `v` and `f`
+    # declarations together with negative face indices were silently
+    # mis-loaded because the loader bulk-collected every `v` up-front
+    # so negative indices were resolved against the file's *final*
+    # vertex list rather than the running count at each face line.
+    #
+    # synthesize two axis-aligned unit cubes declared in two passes;
+    # each block uses `f -8 .. -1` referencing only the eight vertices
+    # that immediately precede it, like the OBJ in the bug report.
+
+    def cube_block(origin):
+        ox, oy, oz = origin
+        # 8 unit cube vertices in canonical order
+        verts = [
+            (ox, oy, oz),
+            (ox + 1, oy, oz),
+            (ox + 1, oy + 1, oz),
+            (ox, oy + 1, oz),
+            (ox, oy, oz + 1),
+            (ox + 1, oy, oz + 1),
+            (ox + 1, oy + 1, oz + 1),
+            (ox, oy + 1, oz + 1),
+        ]
+        lines = [f"v {x} {y} {z}" for x, y, z in verts]
+        # six quad faces, all using the negative offset -1..-8
+        # which under the spec refers to the 8 vertices just above.
+        # winding chosen for consistent outward normals.  the verts
+        # are indexed -8..-1 == v0..v7 with:
+        #   v0=(0,0,0), v1=(1,0,0), v2=(1,1,0), v3=(0,1,0)
+        #   v4=(0,0,1), v5=(1,0,1), v6=(1,1,1), v7=(0,1,1)
+        # (with `origin` added to each).
+        lines.extend([
+            "f -8 -5 -6 -7",  # bottom z = oz       (-z): v0 v3 v2 v1
+            "f -4 -3 -2 -1",  # top    z = oz + 1   (+z): v4 v5 v6 v7
+            "f -8 -7 -3 -4",  # front  y = oy       (-y): v0 v1 v5 v4
+            "f -6 -5 -1 -2",  # back   y = oy + 1   (+y): v2 v3 v7 v6
+            "f -8 -4 -1 -5",  # left   x = ox       (-x): v0 v4 v7 v3
+            "f -7 -6 -2 -3",  # right  x = ox + 1   (+x): v1 v2 v6 v5
+        ])
+        return "\n".join(lines)
+
+    obj_text = "\n".join([
+        "o cube_a",
+        cube_block((0, 0, 0)),
+        "o cube_b",
+        cube_block((10, 0, 0)),
+        "",
+    ])
+
+    scene = g.trimesh.load(
+        g.io.StringIO(obj_text),
+        file_type="obj",
+        split_objects=True,
+        group_material=False,
+    )
+
+    # bulk-load should have produced two distinct cubes
+    assert len(scene.geometry) == 2
+    cubes = list(scene.geometry.values())
+
+    # before #2364 was fixed each "cube" inherited vertices from the
+    # other one (negative indices resolved against the global list);
+    # geometry is now correctly split.  geometry iteration order
+    # isn't part of the loader's contract so sort by x to match.
+    cubes.sort(key=lambda m: m.vertices[:, 0].min())
+    cube_a, cube_b = cubes
+    assert cube_a.vertices.shape == (8, 3)
+    assert cube_b.vertices.shape == (8, 3)
+    # outer-bounds split cleanly along x
+    assert cube_a.vertices[:, 0].max() <= 1.0 + 1e-9
+    assert cube_b.vertices[:, 0].min() >= 10.0 - 1e-9
+
+    # `load_mesh` concatenates: total 16 unique vertices, two unit
+    # cubes' worth of volume.  also verify the concatenated mesh is
+    # a real solid (would not be if indices were tangled).
+    merged = g.trimesh.load_mesh(
+        g.io.StringIO(obj_text), file_type="obj", group_material=False
+    )
+    assert merged.vertices.shape == (16, 3)
+    assert merged.is_volume
+    assert g.np.isclose(merged.volume, 2.0)
+
+
+def test_obj_negative_indices_normalizer_noop_on_positive_file():
+    # the negative-index normalization pass added in #2364 must be a
+    # textual no-op on OBJ files whose face lines only use positive
+    # indices, regardless of any unrelated negative numbers (e.g.
+    # negative vertex coordinates) in the file.
+    from trimesh.exchange.obj import _resolve_negative_face_indices
+
+    text = "\n".join([
+        "v -1 -1 -1",
+        "v  1 -1 -1",
+        "v  1  1 -1",
+        "v -1  1 -1",
+        "f 1 2 3",
+        "f 1 3 4",
+        "",
+    ])
+    assert _resolve_negative_face_indices(text) == text
+
+
+def test_obj_negative_indices_normalizer_mixed_slash_layouts():
+    # `f v/vt/vn`, `f v//vn` and `f v/vt` layouts must each have their
+    # negative components resolved (regression for #2364).
+    from trimesh.exchange.obj import _resolve_negative_face_indices
+
+    text = "\n".join([
+        "v 0 0 0",
+        "v 1 0 0",
+        "v 0 1 0",
+        "vt 0 0",
+        "vt 1 0",
+        "vt 0 1",
+        "vn 0 0 1",
+        "f -3/-3/-1 -2/-2/-1 -1/-1/-1",
+        "f -3//-1 -2//-1 -1//-1",
+        "f -3/-3 -2/-2 -1/-1",
+        "",
+    ])
+    out = _resolve_negative_face_indices(text)
+    # at the point of every face line, v_count = vt_count = 3 and
+    # vn_count = 1 — so every -k should resolve to (count - k + 1).
+    expected_face_lines = [
+        "f 1/1/1 2/2/1 3/3/1",
+        "f 1//1 2//1 3//1",
+        "f 1/1 2/2 3/3",
+    ]
+    out_face_lines = [L for L in out.split("\n") if L.startswith("f ")]
+    assert out_face_lines == expected_face_lines
+
+
 def test_obj_quad():
     mesh = g.get_mesh("quadknot.obj", merge_tex=True)
     # make sure some data got loaded

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -83,6 +83,17 @@ def load_obj(
     # line
     text = text.replace("\\\n", "")
 
+    # the OBJ spec allows negative face vertex/texture/normal indices,
+    # which refer to the k-th most recently declared element BEFORE the
+    # face line.  the rest of this loader bulk-collects every `v`, `vt`
+    # and `vn` up-front before processing faces, so leaving negative
+    # indices in place silently re-indexes them against the file's
+    # *final* element list.  for OBJ files that interleave vertex and
+    # face declarations (issue #2364) that resolves wrong.  rewrite
+    # negative indices into their absolute 1-based positive form here
+    # so downstream parsing remains correct in either layout.
+    text = _resolve_negative_face_indices(text)
+
     # Load Materials
     materials = {}
     mtl_position = text.find("mtllib")
@@ -555,6 +566,79 @@ def _parse_faces_fallback(lines):
         normals[normals > 0] -= 1
 
     return faces, faces_tex, normals
+
+
+def _resolve_negative_face_indices(text):
+    """
+    Rewrite negative face vertex / texture / normal indices in OBJ text
+    into their absolute 1-based positive form.
+
+    Per the OBJ spec a negative face element index `-k` refers to the
+    k-th most recently declared element BEFORE that face line, where
+    each of `v`, `vt`, `vn` is counted in its own list.  trimesh's OBJ
+    loader bulk-collects every `v`, `vt`, `vn` up-front before
+    processing faces (see `_parse_vertices`), so negative indices left
+    in the text get re-indexed against the file's *final* element
+    list.  For OBJ files that interleave vertex and face declarations
+    (issue #2364) that produces silently-wrong meshes.
+
+    This function walks the file once, tracks the running count of
+    `v` / `vt` / `vn` declarations, and on each face line rewrites any
+    `-k` index into `(running_count - k + 1)` (1-based positive form).
+    Files without negative face indices are returned unchanged.
+
+    Parameters
+    -------------
+    text : str
+      Full text of an OBJ file (already line-normalized).
+
+    Returns
+    -------------
+    text : str
+      Either the input (no negatives found) or a rewritten copy.
+    """
+    # cheap rejection: only spend time walking the file if some face
+    # line actually contains a negative.  this single regex scan is
+    # much cheaper than the line-by-line walk below.
+    if re.search(r"(?m)^f[^\n]*-\d", text) is None:
+        return text
+
+    v_count = vt_count = vn_count = 0
+
+    lines = text.split("\n")
+    for i, line in enumerate(lines):
+        # avoid a full strip() per line; OBJ directives sit at column 0
+        # except for the synthetic leading newline added by the caller,
+        # so a single leading-character classification is enough.
+        if not line:
+            continue
+        head = line[:3]
+        if head.startswith("v "):
+            v_count += 1
+        elif head.startswith("vt "):
+            vt_count += 1
+        elif head.startswith("vn "):
+            vn_count += 1
+        elif head.startswith("f ") and "-" in line:
+            # rewrite each whitespace-separated token of the face line.
+            # token layout: "v", "v/vt", "v//vn", or "v/vt/vn".
+            parts = line.split()
+            # parts[0] is "f"
+            for j in range(1, len(parts)):
+                fields = parts[j].split("/")
+                # field 0: vertex index
+                if fields[0] and fields[0].startswith("-"):
+                    fields[0] = str(v_count + int(fields[0]) + 1)
+                # field 1: optional vt index
+                if len(fields) > 1 and fields[1] and fields[1].startswith("-"):
+                    fields[1] = str(vt_count + int(fields[1]) + 1)
+                # field 2: optional vn index
+                if len(fields) > 2 and fields[2] and fields[2].startswith("-"):
+                    fields[2] = str(vn_count + int(fields[2]) + 1)
+                parts[j] = "/".join(fields)
+            lines[i] = " ".join(parts)
+
+    return "\n".join(lines)
 
 
 def _parse_vertices(text):


### PR DESCRIPTION
Fixes #2364.

The OBJ spec allows interleaving `v` / `vt` / `vn` and `f`
declarations.  A negative face index `-k` refers to the k-th most
recently declared element BEFORE that face line — each of
`v`, `vt`, `vn` counted in its own list.

trimesh's loader bulk-collects every `v` / `vt` / `vn` up-front via
`_parse_vertices` before processing faces, so the existing
`array[array > 0] -= 1` line in `load_obj` left negatives alone
and they were silently resolved by numpy's negative-indexing
against the file's *final* element list.  For the common "all v
then all f" layout the running count at each face line equals the
total count, so it worked by accident — but the converter that
produced the OBJ in #2364 emits each primitive as a
`v…v…f -1..-N` block, and the loader returned a 24-vertex tangle
where MeshLab returns 40 vertices and three clean solid primitives.

## Reproducer

The file from #2364 (`bug_report.obj`, 40 `v`, 26 `f`, all faces
use negative indices) loads as:

| | trimesh main | this PR | MeshLab |
|---|---|---|---|
| vertices | 24 | **40** | 40 |
| `is_volume` | False | **True** | (n/a) |
| bbox (z) | `[-0.31, 0.31]` (wrong) | **`[-0.37, 0.31]`** (correct) | — |

## Fix

Add `_resolve_negative_face_indices` (new module-private helper in
`trimesh/exchange/obj.py`) that walks the OBJ text once, tracks the
running count of `v` / `vt` / `vn` declarations, and rewrites every
negative face index into its absolute 1-based positive form on each
face line.

- Cheap regex pre-check (`(?m)^f[^\n]*-\d`) short-circuits the pass
  for files without negative face indices — there is no cost for
  the common case.
- On files that DO use negatives in the "normal" layout (all v then
  all f), the rewrite is a semantic no-op because running_count ==
  total_count at every face line.  The pre-existing
  `test_obj_negative_indices` test (which uses such a file) keeps
  passing unchanged.

## Tests

Three new tests in `tests/test_obj.py`:

- `test_obj_negative_indices_interleaved` — synthesizes two
  axis-aligned unit cubes declared in two interleaved
  `v…v…f -8..-1` blocks (same shape as the bug report).  Before
  the fix the loader produced a single 8-vertex tangle; after the
  fix the scene contains two distinct 8-vertex cubes that
  concatenate to a 16-vertex, volume-2 mesh.
- `test_obj_negative_indices_normalizer_noop_on_positive_file` —
  asserts that files whose face lines use only positive indices
  are returned bit-identical, even when vertex *coordinates* are
  negative.
- `test_obj_negative_indices_normalizer_mixed_slash_layouts` —
  covers all three token layouts: `v/vt/vn`, `v//vn`, `v/vt`.

Local `pytest tests/test_obj.py` 41/42 pass (the 1 failure
`test_multi_nodupe` requires `pycollada` which isn't installed in
this venv — unrelated).  Ruff clean.
