### PR TITLE
Round-trip MTL Ni/d/Tf/illum through SimpleMaterial (fixes #2349)

### DIFF
--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -392,6 +392,124 @@ def test_mtl_color_roundtrip():
     assert g.np.isclose(m.visual.material.glossiness, r.visual.material.glossiness)
 
 
+def test_mtl_optional_properties_roundtrip():
+    # regression for issue #2349: SimpleMaterial used to silently
+    # drop `Ni`, `d`, `Tf` and `illum` on export because they were
+    # parsed only into `SimpleMaterial.kwargs` and never written
+    # back out by `to_obj`.  exercise the full
+    # parse_mtl -> SimpleMaterial -> to_obj roundtrip through the
+    # OBJ loader/exporter.
+    mtl_text = "\n".join([
+        "newmtl PropTest",
+        "Ka 0.20 0.30 0.40",
+        "Kd 0.50 0.60 0.70",
+        "Ks 0.10 0.10 0.10",
+        "Ns 250.0",
+        "Ni 1.50",
+        "d 0.85",
+        "Tf 1.0 0.9 0.8",
+        "illum 2",
+        "",
+    ])
+    obj_text = "\n".join([
+        "mtllib mat.mtl",
+        "usemtl PropTest",
+        "v 0 0 0",
+        "v 1 0 0",
+        "v 0 1 0",
+        "vt 0 0",
+        "vt 1 0",
+        "vt 0 1",
+        "f 1/1 2/2 3/3",
+        "",
+    ])
+
+    r = g.trimesh.resolvers.ZipResolver()
+    r["mat.mtl"] = mtl_text.encode("utf-8")
+    mesh = g.trimesh.load(
+        g.io.StringIO(obj_text), file_type="obj", resolver=r
+    )
+
+    mat = mesh.visual.material
+    assert g.np.isclose(mat.index_of_refraction, 1.50)
+    assert g.np.isclose(mat.dissolve, 0.85)
+    assert g.np.allclose(mat.transmission_filter, (1.0, 0.9, 0.8))
+    assert mat.illumination_model == 2
+
+    # round-trip through OBJ export
+    out = g.trimesh.resolvers.ZipResolver()
+    out["m.obj"] = mesh.export(file_type="obj", mtl_name="mat.mtl", resolver=out)
+    mtl_out = out["mat.mtl"].decode("utf-8")
+    assert "Ni 1.50000000" in mtl_out
+    assert "d 0.85000000" in mtl_out
+    assert "Tf 1.00000000 0.90000000 0.80000000" in mtl_out
+    assert "illum 2" in mtl_out
+
+    # parse the exported MTL back and confirm values survived
+    obj_bytes = out["m.obj"]
+    if isinstance(obj_bytes, str):
+        obj_bytes = obj_bytes.encode("utf-8")
+    re_loaded = g.trimesh.load(
+        g.io.BytesIO(obj_bytes), file_type="obj", resolver=out
+    )
+    rmat = re_loaded.visual.material
+    assert g.np.isclose(rmat.index_of_refraction, 1.50)
+    assert g.np.isclose(rmat.dissolve, 0.85)
+    assert g.np.allclose(rmat.transmission_filter, (1.0, 0.9, 0.8))
+    assert rmat.illumination_model == 2
+
+
+def test_mtl_Tr_maps_to_dissolve():
+    # OBJ/MTL allows specifying transparency either as `d <opacity>`
+    # or `Tr <1 - opacity>`.  `parse_mtl` should recognize `Tr` and
+    # store the equivalent `dissolve` value.
+    mtl_text = "\n".join([
+        "newmtl TrTest",
+        "Ka 0 0 0",
+        "Kd 1 1 1",
+        "Ks 0 0 0",
+        "Ns 1",
+        "Tr 0.2",
+        "",
+    ])
+    obj_text = "\n".join([
+        "mtllib m.mtl",
+        "usemtl TrTest",
+        "v 0 0 0",
+        "v 1 0 0",
+        "v 0 1 0",
+        "vt 0 0",
+        "vt 1 0",
+        "vt 0 1",
+        "f 1/1 2/2 3/3",
+        "",
+    ])
+    r = g.trimesh.resolvers.ZipResolver()
+    r["m.mtl"] = mtl_text.encode("utf-8")
+    mesh = g.trimesh.load(g.io.StringIO(obj_text), file_type="obj", resolver=r)
+    assert g.np.isclose(mesh.visual.material.dissolve, 0.8)
+
+
+def test_mtl_optional_properties_distinct_hash():
+    # regression for issue #2349: two SimpleMaterials that differ
+    # only in `Ni` (or `d`/`Tf`/`illum`) had identical hashes,
+    # so when both appeared in a scene the OBJ exporter folded them
+    # into a single output material.
+    from trimesh.visual.material import SimpleMaterial
+
+    base = {"diffuse": [1.0, 0.5, 0.25, 1.0], "glossiness": 10.0}
+    a = SimpleMaterial(**base)
+    b = SimpleMaterial(**base, index_of_refraction=1.5)
+    c = SimpleMaterial(**base, index_of_refraction=2.0)
+    d = SimpleMaterial(**base, dissolve=0.5)
+    e = SimpleMaterial(**base, illumination_model=2)
+    f = SimpleMaterial(**base, transmission_filter=[0.5, 0.5, 0.5])
+    # every variant should hash differently from every other one
+    assert len({hash(x) for x in (a, b, c, d, e, f)}) == 6
+    # repeating the same args should still hash equal
+    assert hash(b) == hash(SimpleMaterial(**base, index_of_refraction=1.5))
+
+
 def test_scene_export_material_name():
     s = g.get_mesh("fuze.obj", force="scene")
 

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -438,7 +438,10 @@ def test_mtl_optional_properties_roundtrip():
 
     # round-trip through OBJ export
     out = g.trimesh.resolvers.ZipResolver()
-    out["m.obj"] = mesh.export(file_type="obj", mtl_name="mat.mtl", resolver=out)
+    obj_bytes = mesh.export(file_type="obj", mtl_name="mat.mtl", resolver=out)
+    if isinstance(obj_bytes, str):
+        obj_bytes = obj_bytes.encode("utf-8")
+    out["m.obj"] = obj_bytes
     mtl_out = out["mat.mtl"].decode("utf-8")
     assert "Ni 1.50000000" in mtl_out
     assert "d 0.85000000" in mtl_out
@@ -447,8 +450,6 @@ def test_mtl_optional_properties_roundtrip():
 
     # parse the exported MTL back and confirm values survived
     obj_bytes = out["m.obj"]
-    if isinstance(obj_bytes, str):
-        obj_bytes = obj_bytes.encode("utf-8")
     re_loaded = g.trimesh.load(
         g.io.BytesIO(obj_bytes), file_type="obj", resolver=out
     )

--- a/trimesh/exchange/obj.py
+++ b/trimesh/exchange/obj.py
@@ -344,7 +344,19 @@ def parse_mtl(mtl, resolver=None):
     lines = str.splitlines(str(mtl).strip())
 
     # remap OBJ property names to kwargs for SimpleMaterial
-    mapped = {"kd": "diffuse", "ka": "ambient", "ks": "specular", "ns": "glossiness"}
+    mapped = {
+        "kd": "diffuse",
+        "ka": "ambient",
+        "ks": "specular",
+        "ns": "glossiness",
+        # issue #2349: these MTL keys were silently swallowed into
+        # `SimpleMaterial.kwargs` and dropped on re-export.  Forward
+        # them as typed constructor arguments so they round-trip.
+        "ni": "index_of_refraction",
+        "d": "dissolve",
+        "tf": "transmission_filter",
+        "illum": "illumination_model",
+    }
 
     for line in lines:
         # split by white space
@@ -396,6 +408,16 @@ def parse_mtl(mtl, resolver=None):
                     material[key] = value
             except BaseException:
                 log.debug("failed to convert color!", exc_info=True)
+        elif key == "tr" and material is not None:
+            # `Tr` is the inverse of `d` (transparency vs opacity).
+            # Per the MTL spec both refer to the same property; if
+            # `d` was already set elsewhere keep it as-authoritative.
+            try:
+                tr = float(split[1])
+                material.setdefault("dissolve", 1.0 - tr)
+                material["tr"] = tr
+            except BaseException:
+                log.debug("failed to convert Tr", exc_info=True)
         # pass everything as kwargs to material constructor
         elif material is not None:
             # save any other unspecified keys

--- a/trimesh/visual/material.py
+++ b/trimesh/visual/material.py
@@ -72,6 +72,10 @@ class SimpleMaterial(Material):
         specular=None,
         glossiness=None,
         name=None,
+        index_of_refraction=None,
+        dissolve=None,
+        transmission_filter=None,
+        illumination_model=None,
         **kwargs,
     ):
         # save image
@@ -85,7 +89,29 @@ class SimpleMaterial(Material):
         # save Ns
         self.glossiness = glossiness
 
-        # save other keyword arguments
+        # optional MTL properties; the OBJ/MTL spec allows
+        # `Ni` (index of refraction), `d` (dissolve / opacity),
+        # `Tf` (transmission filter, length-3) and `illum`
+        # (illumination model, int).  Storing them as typed
+        # attributes lets `to_obj` round-trip them and lets
+        # `__hash__` notice materials that differ ONLY in these
+        # fields (otherwise two such materials collapse into one
+        # during export — see issue #2349).
+        self.index_of_refraction = (
+            None if index_of_refraction is None else float(index_of_refraction)
+        )
+        self.dissolve = None if dissolve is None else float(dissolve)
+        if transmission_filter is None:
+            self.transmission_filter = None
+        else:
+            self.transmission_filter = tuple(float(x) for x in transmission_filter)
+        self.illumination_model = (
+            None if illumination_model is None else int(float(illumination_model))
+        )
+
+        # save any other keyword arguments untouched (so callers
+        # that pass arbitrary extension keys still see them on the
+        # instance via `material.kwargs`).
         self.kwargs = kwargs
 
     def to_color(self, uv):
@@ -126,6 +152,21 @@ class SimpleMaterial(Material):
             "Ks {:0.8f} {:0.8f} {:0.8f}".format(*Ks),
             f"Ns {self.glossiness:0.8f}",
         ]
+
+        # optional MTL fields (issue #2349): only emit a line when
+        # the value was explicitly supplied so we don't add bogus
+        # `Ni 1.0` / `d 1.0` / `illum 1` defaults to every exported
+        # material.
+        if self.index_of_refraction is not None:
+            mtl.append(f"Ni {self.index_of_refraction:0.8f}")
+        if self.dissolve is not None:
+            mtl.append(f"d {self.dissolve:0.8f}")
+        if self.transmission_filter is not None:
+            mtl.append(
+                "Tf " + " ".join(f"{v:0.8f}" for v in self.transmission_filter)
+            )
+        if self.illumination_model is not None:
+            mtl.append(f"illum {int(self.illumination_model)}")
 
         # collect the OBJ data into files
         data = {}
@@ -176,6 +217,19 @@ class SimpleMaterial(Material):
             hashed ^= hash(self.specular.tobytes())
         if isinstance(self.glossiness, float):
             hashed ^= hash(int(self.glossiness * 1000))
+        # include optional MTL fields (issue #2349) so two
+        # materials that differ ONLY by `Ni` / `d` / `Tf` / `illum`
+        # don't collide and get exported as a single material.
+        if self.index_of_refraction is not None:
+            hashed ^= hash(("Ni", int(self.index_of_refraction * 1000)))
+        if self.dissolve is not None:
+            hashed ^= hash(("d", int(self.dissolve * 1000)))
+        if self.transmission_filter is not None:
+            hashed ^= hash(
+                ("Tf", tuple(int(v * 1000) for v in self.transmission_filter))
+            )
+        if self.illumination_model is not None:
+            hashed ^= hash(("illum", int(self.illumination_model)))
         return hashed
 
     @property


### PR DESCRIPTION
Fixes #2349.

When loading a Wavefront `.obj` with an associated `.mtl`, the optional
MTL keys `Ni` (index of refraction), `d` (dissolve), `Tf` (transmission
filter) and `illum` (illumination model) were parsed by `parse_mtl` but
only landed in `SimpleMaterial.kwargs` as raw lowercase string tokens.
They were never written back by `SimpleMaterial.to_obj`, and the
material hash didn't consider them, so two materials that differ ONLY
in (e.g.) `Ni` collided and the OBJ exporter folded them into a single
output material.

Even the trimesh-bundled `models/box.mtl` defines `Ni`, so any
round-trip through `load(box.obj).export(...)` silently dropped data.

## Reproducer

```python
import trimesh

# MTL with all optional fields
mtl = (
  "newmtl m\nKa 0.2 0.3 0.4\nKd 0.5 0.6 0.7\nKs 0.1 0.1 0.1\n"
  "Ns 250.0\nNi 1.50\nd 0.85\nTf 1.0 0.9 0.8\nillum 2\n"
)
obj = "mtllib m.mtl\nusemtl m\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n"

# load, export, inspect MTL
import io
r = trimesh.resolvers.ZipResolver()
r["m.mtl"] = mtl.encode()
mesh = trimesh.load(io.StringIO(obj), file_type="obj", resolver=r)
out = trimesh.resolvers.ZipResolver()
out["m.obj"] = mesh.export(file_type="obj", mtl_name="m.mtl", resolver=out)
print(out["m.mtl"].decode())
```

| | trimesh main | this PR |
|---|---|---|
| `Ni 1.50` round-trip | ❌ dropped | ✅ |
| `d 0.85` round-trip  | ❌ dropped | ✅ |
| `Tf 1.0 0.9 0.8` round-trip | ❌ dropped | ✅ |
| `illum 2` round-trip | ❌ dropped | ✅ |
| `hash(mat_with_Ni_1.5) != hash(mat_with_Ni_2.0)` | ❌ collide | ✅ distinct |

## Fix

- Add typed constructor arguments to `SimpleMaterial`:
  `index_of_refraction` (float), `dissolve` (float),
  `transmission_filter` (length-3 float tuple) and
  `illumination_model` (int).  They default to `None` so existing
  callers that don't pass them are unaffected, and unknown extension
  keys still land in `self.kwargs`.
- Extend `SimpleMaterial.to_obj` to emit a corresponding MTL line only
  when the field is set, so we don't tag every exported material with
  bogus `Ni 1.0` / `d 1.0` defaults.
- Extend `SimpleMaterial.__hash__` to mix the four new fields in, so
  materials that differ only in these properties don't collide during
  deduplication in `export_obj`.
- Extend `parse_mtl`'s key-to-kwarg map so the loader actually populates
  the new typed fields, and add a small `Tr` handler that converts
  `Tr <transparency>` into `dissolve = 1 - Tr` (`d` wins if both are
  present, via `setdefault`).

## Tests

Three new tests in `tests/test_obj.py` (all pass, all fail on main):

- `test_mtl_optional_properties_roundtrip` — writes an MTL with every
  optional field, loads it through the resolver flow, asserts the typed
  fields populate, exports back out, asserts the written MTL contains
  the expected `Ni`/`d`/`Tf`/`illum` lines, and re-loads to confirm a
  clean roundtrip.
- `test_mtl_Tr_maps_to_dissolve` — covers the `Tr` -> `dissolve`
  inversion.
- `test_mtl_optional_properties_distinct_hash` — builds six
  SimpleMaterials sharing identical color/glossiness but differing only
  in optional fields and asserts all six hash distinctly while two
  materials with identical args still hash equal.

Local `pytest tests/test_obj.py tests/test_texture.py tests/test_visual.py
tests/test_gltf.py`: 105 pass, 1 unrelated fail (pycollada missing).
Ruff clean.
