### PR TITLE
Validate face_normals setter against every face, sign-agnostic (fixes #2394)

### DIFF
--- a/tests/test_normals.py
+++ b/tests/test_normals.py
@@ -130,6 +130,49 @@ class NormalsTest(g.unittest.TestCase):
         mesh.face_normals = g.np.zeros_like(mesh.faces)
         assert g.np.allclose(g.np.linalg.norm(mesh.face_normals, axis=1), 1.0)
 
+    def test_face_normals_setter_validation(self):
+        """
+        Regression for issue #2394: the face_normals setter used to
+        only validate the first 20 faces against the recomputed
+        normals, so it could silently accept wrong normals (if the
+        first 20 happened to match) and silently drop legitimately
+        sign-flipped normals. The setter should validate every face
+        and accept any normals that are perpendicular to the face
+        plane regardless of sign.
+        """
+        # use enough faces that a "first 20" check would miss errors
+        # (use a fresh mesh per case to avoid face_normals cache carryover)
+        def fresh():
+            m = g.trimesh.creation.icosphere(subdivisions=2)
+            assert len(m.faces) > 20
+            return m, m.face_normals.copy()
+
+        # fully sign-flipped normals are still perpendicular to every
+        # face and must now be accepted as-is (the user's explicit
+        # request in #2394)
+        mesh, computed = fresh()
+        flipped = -computed
+        mesh.face_normals = flipped
+        assert g.np.allclose(mesh.face_normals, flipped)
+
+        # normals that are correct for the first 20 faces but garbage
+        # afterwards must be rejected (the old check missed this)
+        mesh, computed = fresh()
+        partial_garbage = computed.copy()
+        partial_garbage[20:] = [0.0, 0.0, 1.0]
+        mesh.face_normals = partial_garbage
+        assert not g.np.allclose(mesh.face_normals, partial_garbage)
+        # rejected -> falls back to the true computed normals
+        assert g.np.allclose(mesh.face_normals, computed)
+
+        # a non-perpendicular set must be rejected wholesale
+        mesh, computed = fresh()
+        # rotate every normal 30 degrees out of the face plane around x
+        c, s = g.np.cos(0.5), g.np.sin(0.5)
+        rot = g.np.array([[1, 0, 0], [0, c, -s], [0, s, c]])
+        mesh.face_normals = computed.dot(rot.T)
+        assert g.np.allclose(mesh.face_normals, computed)
+
     def test_merge(self):
         """
         Check merging with vertex normals

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -451,6 +451,15 @@ class Trimesh(Geometry3D):
         """
         Assign values to face normals.
 
+        The supplied normals are validated against the actual face
+        geometry: a normal is accepted only if it is perpendicular to
+        its face plane (i.e. parallel or anti-parallel to the cross
+        product of the triangle edges). This check runs over *every*
+        face rather than a sample, and is sign-agnostic so explicitly
+        flipped-but-valid normals are honored. Normals that don't
+        correspond to the face geometry are ignored and the cached
+        cross-product normals will be regenerated on next access.
+
         Parameters
         -------------
         values : (len(self.faces), 3) float
@@ -475,12 +484,29 @@ class Trimesh(Geometry3D):
             log.debug("face_normals all zero, ignoring!")
             return
 
-        # make sure the first few normals match the first few triangles
-        check, valid = triangles.normals(self.vertices.view(np.ndarray)[self.faces[:20]])
-        compare = np.zeros((len(valid), 3))
-        compare[valid] = check
-        if not np.allclose(compare, values[:20]):
-            log.debug("face_normals didn't match triangles, ignoring!")
+        # validate that every supplied normal is actually perpendicular
+        # to its face by comparing against the cross product of the
+        # triangle edges (the unnormalized "true" normal direction).
+        # historically this only checked the first 20 faces against the
+        # recomputed normals which both missed errors past face 20 and
+        # rejected legitimately sign-flipped normals (see issue #2394).
+        crosses = self.triangles_cross
+        # a supplied normal is parallel/anti-parallel to `crosses` when
+        # their cross product is near zero; this is sign independent
+        parallel = np.cross(values, crosses)
+        # scale-invariant comparison: divide the residual by the product
+        # of the magnitudes so the test is on the angle, not the lengths
+        mag = np.sqrt((values**2).sum(axis=1) * (crosses**2).sum(axis=1))
+        # zero-area faces have an undefined normal so we can't validate
+        # them; treat those as always-valid like the getter does
+        nonzero = mag > tol.merge
+        # `sin` of the angle between supplied normal and the face plane
+        residual = np.zeros(len(values), dtype=float64)
+        residual[nonzero] = (
+            np.sqrt((parallel[nonzero] ** 2).sum(axis=1)) / mag[nonzero]
+        )
+        if (residual > 1e-3).any():
+            log.debug("face_normals not perpendicular to faces, ignoring!")
             return
 
         # otherwise store face normals


### PR DESCRIPTION
Fixes #2394.

The `Trimesh.face_normals` setter recomputed normals for only the
**first 20 faces** and demanded the supplied array equal those
*outward* normals exactly. This produced two surprising behaviors
(both reported in the issue):

1. **Only the first 20 faces were checked**, so an array that matched
   there but was garbage afterwards was accepted wholesale.
2. It required equality with the canonical **outward** normals, so a
   legitimately sign-flipped (or otherwise valid) normals array was
   silently dropped — even though it's a perfectly good set of face
   normals. (@mikedh in the thread: *"they probably shouldn't be
   settable… doing a check on the whole array isn't that much faster
   than recomputing, hence the slightly janky 'only check the first
   20' behavior."*)

## Reproducer (from the issue)

```python
import trimesh, numpy as np

mesh = trimesh.creation.icosphere()
fn = mesh.face_normals.copy()
mesh.face_normals = -fn          # fully flipped -> still valid normals
print(np.allclose(mesh.face_normals, -fn))   # main: False  -> this PR: True

mesh = trimesh.creation.icosphere()
fn = mesh.face_normals.copy()
bad = fn.copy(); bad[20:] = [0, 0, 1]         # garbage past face 20
mesh.face_normals = bad
print(np.allclose(mesh.face_normals, bad))    # main: True (!) -> this PR: False
```

## Fix

Replace the first-20 equality check with a full, **sign-agnostic
perpendicularity** check: a supplied normal is accepted iff it is
parallel or anti-parallel to the cross product of the triangle's edges
(the unnormalized true-normal direction, already available via the
cached `triangles_cross`). The residual is the sine of the angle
between the supplied normal and the face plane, computed scale-
invariantly; zero-area faces have an undefined normal and are treated
as always-valid to match the getter's padding behavior.

Result:
- validates **every** face instead of a 20-face sample,
- accepts user-supplied flipped/valid normals (the explicit request in
  the issue),
- still rejects normals that don't correspond to the face geometry,
  falling back to regenerated cross-product normals.

This is essentially the perpendicularity check @mikedh sketched in the
thread, but reusing the already-cached `triangles_cross` so it doesn't
recompute and handles both edges at once.

## Tests

Adds `test_face_normals_setter_validation` (full sign-flip acceptance;
the >20-face partial-garbage rejection the old check missed; rejection
of normals rotated out of the face plane). The existing
`test_face_normals` (garbage + all-zero rejection) passes unchanged.

Local: `tests/test_normals.py tests/test_stl.py tests/test_gltf.py
tests/test_mesh.py tests/test_ply.py` all pass; the only failures in my
run are `test_creation.py` cases that need `shapely` (not installed in
this venv). Ruff clean.
