### PR TITLE
Fix winding when revolve-based primitives get a reflection transform (fixes #2439)

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -32,6 +32,51 @@ def test_cone():
     assert c.metadata["shape"] == "cone"
 
 
+def test_revolve_reflection_transform():
+    # regression for issue #2439: passing a reflection (negative
+    # determinant) transform to a `revolve`-based primitive used to
+    # flip the winding so the result was no longer a valid volume,
+    # while applying the same transform *after* creation worked.
+    # the `transform=` keyword and `apply_transform` should agree.
+    reflections = [
+        g.np.diag([-1.0, 1.0, 1.0, 1.0]),
+        g.np.diag([1.0, 1.0, -1.0, 1.0]),
+        g.np.diag([-1.0, -1.0, -1.0, 1.0]),
+    ]
+
+    builders = [
+        ("cone", lambda T: g.trimesh.creation.cone(radius=0.5, height=1.0, transform=T)),
+        (
+            "cylinder",
+            lambda T: g.trimesh.creation.cylinder(radius=0.5, height=1.0, transform=T),
+        ),
+        (
+            "annulus",
+            lambda T: g.trimesh.creation.annulus(
+                r_min=0.5, r_max=1.0, height=1.0, transform=T
+            ),
+        ),
+    ]
+
+    for name, build in builders:
+        # baseline volume of the un-transformed primitive
+        base = build(g.np.eye(4))
+        assert base.is_volume
+
+        for T in reflections:
+            passed = build(T)
+            # building with the reflection transform must stay a volume
+            assert passed.is_volume, f"{name} not a volume with reflection transform"
+            assert passed.volume > 0
+
+            # and must match applying the transform after construction
+            after = build(g.np.eye(4))
+            after.apply_transform(T)
+            assert after.is_volume
+            assert g.np.isclose(passed.volume, after.volume)
+            assert g.np.isclose(passed.volume, base.volume)
+
+
 def test_cylinder():
     # tolerance for cylinders
     atol = 0.03

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -185,6 +185,14 @@ def revolve(
     if transform is not None:
         # apply transform to vertices
         vertices = tf.transform_points(vertices, transform)
+        # if the transform flips the winding (i.e. has a negative
+        # determinant / reflection) flip faces back so the normals
+        # still face outwards and the result remains a valid volume
+        # (see issue #2439); mirrors the handling in
+        # `extrude_triangulation`
+        if tf.flips_winding(transform):
+            # fliplr makes arrays non-contiguous so re-pack them
+            faces = np.ascontiguousarray(np.fliplr(faces))
 
     # create the mesh from our vertices and faces
     mesh = Trimesh(vertices=vertices, faces=faces, **kwargs)


### PR DESCRIPTION
Fixes #2439.

`trimesh.creation.revolve` (and therefore `cone`, `cylinder` and
`annulus`, which are all built on it) applied a `transform=` keyword by
transforming the vertices but never correcting face winding. For a
transform with a negative determinant (a reflection, e.g.
`diag(1, 1, -1)`) this leaves every face wound backwards, so the
generated normals point inward and the result reports
`is_volume == False` with a negative signed volume.

Applying the identical transform **after** construction via
`apply_transform` worked, because `apply_transform` already flips
winding on reflections — so the two paths disagreed.

## Reproducer (from the issue)

```python
import numpy as np, trimesh

T = np.eye(4); T[2, 2] = -1
print(trimesh.creation.cone(20, 10, transform=T).is_volume)   # main: False

c = trimesh.creation.cone(20, 10)
c.apply_transform(T)
print(c.is_volume)                                            # True
```

`cylinder` and `annulus` are affected identically; `box` was already
fine because it routes through `apply_transform`.

## Fix

In `revolve`, after transforming the vertices, flip the faces back when
`transformations.flips_winding(transform)` is true. This mirrors the
handling already present in `extrude_triangulation` and makes the
`transform=` keyword agree with `apply_transform`.

```python
if transform is not None:
    vertices = tf.transform_points(vertices, transform)
    if tf.flips_winding(transform):
        faces = np.ascontiguousarray(np.fliplr(faces))
```

## Tests

Adds `test_revolve_reflection_transform` exercising cone, cylinder and
annulus against three reflection matrices, asserting each stays a valid
positive volume and matches the volume of the post-construction
`apply_transform` path. Non-reflection transforms and the no-transform
path are unaffected.

Local `pytest tests/test_creation.py -k "revolve_reflection or test_cone
or test_cylinder or test_annulus"` passes (4/4). Ruff clean. (Other
`test_creation` cases that fail in my venv only do so because `shapely`
isn't installed.)
