### PR TITLE
Don't require embreex on Linux/aarch64 where it has no wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,8 @@ easy = [
     "rtree",
     "httpx",
     "scipy",
-    "embreex",
+    # embreex ships no Linux/aarch64 wheel, so require it everywhere except there
+    "embreex; platform_machine!='aarch64'",
     "pillow",
     "vhacdx; python_version>='3.9'",
     # old versions of mapbox_earcut produce incorrect values on numpy 2.0


### PR DESCRIPTION
Fixes #2564.

`trimesh[easy]` fails to install on Linux/arm64 (e.g. `python:3.12-slim` Docker on Apple silicon) because `embreex` is pulled in unconditionally but ships no `manylinux` **aarch64** wheel, so the install falls through to a source build that needs the Embree C library and errors out.

This is a regression from the Embree 4 upgrade in 4.12.0: 4.11.x guarded the dependency with `embreex; platform_machine=='x86_64'`, and that marker was dropped to `embreex` when embreex 4.x started shipping macOS-arm64 wheels. That fixed macOS arm64 but over-broadened to Linux aarch64, which embreex still has no wheel for.

The fix narrows the guard to exactly the wheel-less platform rather than reinstating the old x86_64-only marker (which would needlessly drop the now-available macOS-arm64 acceleration):

```toml
"embreex; platform_machine!='aarch64'"
```

embreex is an optional ray-tracing accelerator, so on Linux/aarch64 trimesh simply falls back to its built-in pure-Python ray tracer.

Verified against embreex 4.4.0's published wheels (macOS arm64 + x86_64, Linux x86_64, Windows AMD64 — no Linux aarch64) and by evaluating the marker: it stays `True` on every platform that has a wheel and is `False` only on Linux/aarch64.