### PR TITLE
Release: Minimum Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
   formatting:
     name: Check Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up Python ${{ matrix.python-version }}
@@ -46,6 +47,7 @@ jobs:
   docker:
     name: Run Tests In Docker
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Run Pytest In Docker
@@ -54,6 +56,8 @@ jobs:
   arch:
     name: Architecture Tests (s390x + i386)
     runs-on: ubuntu-latest
+    # emulated so it's slow: usually finishes in ~25 minutes
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
@@ -63,6 +67,7 @@ jobs:
   corpus:
     runs-on: ubuntu-latest
     name: Check Corpus Loading
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Trimesh DiskCache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
   tests:
     name: Run Unit Tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.10", "3.13"]

--- a/README.md
+++ b/README.md
@@ -40,21 +40,20 @@ import trimesh
 trimesh.util.attach_to_log()
 
 # mesh objects can be created from existing faces and vertex data
-mesh = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]],
-                       faces=[[0, 1, 2]])
+mesh = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]], faces=[[0, 1, 2]])
 
 # by default, Trimesh will do a light processing, which will
 # remove any NaN values and merge vertices that share position
 # if you want to not do this on load, you can pass `process=False`
-mesh = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]],
-                       faces=[[0, 1, 2]],
-                       process=False)
+mesh = trimesh.Trimesh(
+    vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]], faces=[[0, 1, 2]], process=False
+)
 
 # some formats like `glb` represent multiple meshes with multiple instances
 # and `load_mesh` will concatenate irreversibly, load it as a Scene
 # if you need instance information:
 #   `scene = trimesh.load_scene('models/CesiumMilkTruck.glb')`
-mesh = trimesh.load_mesh('models/CesiumMilkTruck.glb')
+mesh = trimesh.load_mesh("models/CesiumMilkTruck.glb")
 
 # is the current mesh watertight?
 mesh.is_watertight
@@ -116,10 +115,11 @@ mesh.bounding_box_oriented.primitive.transform
 # available, and will be the minimum volume version of each
 # except in certain degenerate cases, where they will be no worse
 # than a least squares fit version of the primitive.
-print(mesh.bounding_box_oriented.volume,
-      mesh.bounding_cylinder.volume,
-      mesh.bounding_sphere.volume)
-
+print(
+    mesh.bounding_box_oriented.volume,
+    mesh.bounding_cylinder.volume,
+    mesh.bounding_sphere.volume,
+)
 ```
 
 ## Features

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -70,13 +70,13 @@ Trimesh uses the [Sphinx Numpy-style](https://www.sphinx-doc.org/en/master/usage
 We try to add a somewhat helpful `DeprecationWarning` one year in advance of a major API change:
 
 ```python
-    warnings.warn(
-        "`remove_duplicate_faces` is deprecated "
-        + "and will be removed in March 2024: "
-            + "replace with `mesh.update_faces(mesh.unique_faces())`",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
+warnings.warn(
+    "`remove_duplicate_faces` is deprecated "
+    + "and will be removed in March 2024: "
+    + "replace with `mesh.update_faces(mesh.unique_faces())`",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 ```
 
 ## Pull Requests And AI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools >= 61.0", "wheel"]
 [project]
 name = "trimesh"
 requires-python = ">=3.10"
-version = "5.0.0rc1"
+version = "5.0.0"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE.md"}
 description = "Import, export, process, analyze and view triangular meshes."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,11 @@ deprecated = []
 # https://hynek.me/articles/python-recursive-optional-dependencies
 all = ["trimesh[easy,recommend,test,test_more,deprecated]"]
 
+[tool.pytest.ini_options]
+# dump every thread's stack if a test wedges — a hung runner
+# should name the frame rather than burn the job timeout in silence
+faulthandler_timeout = 300
+
 [tool.coverage.html]
 # coverage report publishes to `trimesh.org/coverage`
 title = "trimesh coverage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,13 @@ flake8-implicit-str-concat = {"allow-multiline" = false}
 # ban debug and usually-a-bug imports in `trimesh` core library
 [tool.ruff.lint.per-file-ignores]
 # examples/tests/helpers/docs are allowed to print demo / diagnostic output
-"{examples,tests,helpers,docs}/*" = ["T20", "TID251"]
+"{examples,tests,helpers,docs}/*" = ["T20"]
+# examples and docs are demos rather than tests so they're allowed to plot
+# and to be non-deterministic: they only need the printing exemption
+"{examples,docs}/*" = ["TID251"]
+# these implement and enforce the seeded replacements so they have
+# to touch the global RNG the rest of the suite is banned from
+"tests/{generic,conftest}.py" = ["TID251"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "IPython.embed".msg = "you forgot to remove a debug embed ;)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,13 @@ test_more = [
     "triangle; python_version<'3.14'",  # polygon tesselator
     "ipython",  # check the notebook stuff
     "marimo",   # different notebook stuff
+    "requests", # check WebResolver session compatibility
+    "aiohttp",  # check WebResolver session compatibility
 ]
+
+# kept empty so downstream `trimesh[deprecated]` 
+# pins don't fail strict resolvers like poetry
+deprecated = []
 
 # requires pip >= 21.2
 # https://hynek.me/articles/python-recursive-optional-dependencies

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -294,12 +294,15 @@ def serve_meshes():
             self.httpd.serve_forever()
 
     t = _ServerThread()
-    t.daemon = False
+    t.daemon = True
     t.start()
     time.sleep(0.2)
-    yield "http://localhost:{}".format(t.port)
-    t.httpd.shutdown()
-    t.join()
+    try:
+        yield "http://localhost:{}".format(t.port)
+    finally:
+        # tear down the server even if the `with` body raised
+        t.httpd.shutdown()
+        t.join()
 
 
 def get_meshes(

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -169,17 +169,21 @@ io_wrap = trimesh.util.wrap_as_stream
 
 def random(*args, **kwargs):
     """
-    A random function always seeded from the same value so tests
-    can use random data but they execute mostly deterministically
-    in a large test matrix.
+    A FIXED array of pseudorandom values, not a random stream.
 
-    Drop-in replacement for `np.random.random(*args, **kwargs)`
+    This re-seeds on every call so it is a constant: `random(10)` returns
+    the same array every time and `random(3)` is a prefix of `random(10)`.
+    Two calls in one scope are the SAME array, which silently makes
+    "independent" inputs identical to each other.
+
+    Correct for one-shot bulk data. If you need more than one draw use
+    `RandomSeed`, which yields a real stream.
     """
     state = np.random.RandomState(seed=1)
     return state.random_sample(*args, **kwargs)
 
 
-def random_transforms(count, translate=1000):
+def random_transforms(count, translate=1000, seed=0):
     """
     Deterministic generation of random transforms so unit
     tests have limited levels of flake.
@@ -190,14 +194,19 @@ def random_transforms(count, translate=1000):
       Number of repeatable but random-ish transforms to generate
     translate : float
       The scale of translation to apply.
+    seed : int
+      Seed the generator these are drawn from.
 
     Yields
     ------------
     transform : (4, 4) float
       Homogeneous transformation matrix
     """
-    quaternion = random((count, 3))
-    translate = (random((count, 3)) - 0.5) * float(translate)
+    # draw eagerly: a `with` block spanning a `yield` would stay open
+    # across the consumer and never restore if they stopped early
+    with RandomSeed(seed) as r:
+        quaternion = r.random((count, 3))
+        translate = (r.random((count, 3)) - 0.5) * float(translate)
 
     for quat, trans in zip(quaternion, translate):
         matrix = tf.random_rotation_matrix(rand=quat)
@@ -205,9 +214,76 @@ def random_transforms(count, translate=1000):
         yield matrix
 
 
-# random should be deterministic
-assert np.allclose(random(10), random(10))
+class RandomSeed:
+    """
+    A scope with deterministic randomness which leaves no trace.
+
+    Yields a seeded `numpy.random.Generator` to draw test data from, and
+    seeds the global numpy RNG for code we don't control inside the block
+    — the upstream `transformations` doctests are full of `np.random.*`.
+    The original global state is put back on exit even if the body raised
+    so a seed can never leak out and shift the values a later test sees.
+
+    Unlike `random` the yielded generator is a *stream*: successive draws
+    differ, so two "independent" inputs really are independent.
+
+    Parameters
+    -------------
+    seed : int
+      Value to seed both the generator and the global numpy RNG with.
+
+    Examples
+    -------------
+    >>> with RandomSeed(0) as r:
+    ...     a = r.random((100, 3))
+    ...     b = r.random((100, 3))  # genuinely independent of `a`
+    """
+
+    def __init__(self, seed: int = 0):
+        if not isinstance(seed, (int, np.integer)):
+            raise ValueError(f"seed must be an integer, not {type(seed)!s}")
+        self.seed = int(seed)
+
+    def __enter__(self):
+        # stash the state from before we stomp on it
+        self._state = np.random.get_state()
+        np.random.seed(self.seed)
+        return np.random.default_rng(self.seed)
+
+    def __exit__(self, *args):
+        # always restore even if the body raised
+        np.random.set_state(self._state)
+        return False
+
+
+# `random` is a fixed source: pin the values rather than checking it
+# against itself which would only assert that re-seeding re-seeds
+assert np.allclose(random(3), [4.17022005e-01, 7.20324493e-01, 1.14374817e-04])
+assert np.allclose(random(3), random(10)[:3])
+
+# `RandomSeed` should reproduce across processes
+with RandomSeed(0) as r:
+    _check = r.random(10)
+with RandomSeed(0) as r:
+    assert np.allclose(r.random(10), _check)
+
+# it should be a stream rather than a fixed value: this is the entire
+# point of it and the property `random` doesn't have
+with RandomSeed(0) as r:
+    assert not np.allclose(r.random(10), r.random(10))
+
+# it should leave no trace on the global RNG, including for the
+# third-party code it exists to contain
+_before = np.random.get_state()[2]
+with RandomSeed(0) as r:
+    r.random(10)
+    np.random.random(5)
+assert np.random.get_state()[2] == _before
+
+# transforms should repeat and shouldn't alias rotation into translation
 assert np.allclose(list(random_transforms(10)), list(random_transforms(10)))
+_check = np.array(list(random_transforms(100, translate=10)))
+assert not np.allclose(_check[:, :3, 3], _check[0, :3, 3])
 
 
 def _load_data():

--- a/tests/helpers/id_helper.py
+++ b/tests/helpers/id_helper.py
@@ -51,6 +51,8 @@ def permutations(
 
     identifiers = []
     start = time.time()
+    # a local generator so runs repeat and the global stream is left alone
+    rng = np.random.default_rng(seed=0)
 
     # do subdivisions
     divided = [mesh.copy()]
@@ -61,7 +63,7 @@ def permutations(
         np.linspace(0.0, displacement_max / mesh.scale, count)
     ):
         # get one of the subdivided meshes
-        current = np.random.choice(divided).copy()
+        current = rng.choice(divided).copy()
 
         if i > (count / 10):
             # run first bunch without tessellation permutation
@@ -94,6 +96,8 @@ def get_meshes(path="../../../models", cutoff=None):
     ------------
     meshes: (n,) list of Trimesh objects
     """
+    # a local generator so runs repeat and the global stream is left alone
+    rng = np.random.default_rng(seed=0)
 
     bodies = collections.deque()
     for file_name in os.listdir(path):
@@ -111,23 +115,21 @@ def get_meshes(path="../../../models", cutoff=None):
 
     for _i in range(100):
         cylinder = trimesh.creation.cylinder(
-            radius=np.random.random() * 100,
-            height=np.random.random() * 1000,
-            sections=int(np.clip(np.random.random() * 720, 20, 720)),
+            radius=rng.random() * 100,
+            height=rng.random() * 1000,
+            sections=int(np.clip(rng.random() * 720, 20, 720)),
         )
 
         capsule = trimesh.creation.capsule(
-            radius=np.random.random() * 100,
-            height=np.random.random() * 1000,
-            count=np.clip(np.random.random(2) * 720, 20, 720).astype(int),
+            radius=rng.random() * 100,
+            height=rng.random() * 1000,
+            count=np.clip(rng.random(2) * 720, 20, 720).astype(int),
         )
         bodies.append(cylinder)
         bodies.append(capsule)
     for _i in range(10):
         bodies.append(
-            trimesh.creation.random_soup(
-                int(np.clip(np.random.random() * 1000, 20, 1000))
-            )
+            trimesh.creation.random_soup(int(np.clip(rng.random() * 1000, 20, 1000)))
         )
     bodies.append(trimesh.creation.icosphere())
     bodies.append(trimesh.creation.uv_sphere())

--- a/tests/helpers/id_helper.py
+++ b/tests/helpers/id_helper.py
@@ -52,7 +52,7 @@ def permutations(
     identifiers = []
     start = time.time()
     # a local generator so runs repeat and the global stream is left alone
-    rng = np.random.default_rng(seed=0)
+    random = np.random.default_rng(seed=0)
 
     # do subdivisions
     divided = [mesh.copy()]
@@ -63,7 +63,7 @@ def permutations(
         np.linspace(0.0, displacement_max / mesh.scale, count)
     ):
         # get one of the subdivided meshes
-        current = rng.choice(divided).copy()
+        current = random.choice(divided).copy()
 
         if i > (count / 10):
             # run first bunch without tessellation permutation
@@ -97,7 +97,7 @@ def get_meshes(path="../../../models", cutoff=None):
     meshes: (n,) list of Trimesh objects
     """
     # a local generator so runs repeat and the global stream is left alone
-    rng = np.random.default_rng(seed=0)
+    random = np.random.default_rng(seed=0)
 
     bodies = collections.deque()
     for file_name in os.listdir(path):
@@ -115,21 +115,21 @@ def get_meshes(path="../../../models", cutoff=None):
 
     for _i in range(100):
         cylinder = trimesh.creation.cylinder(
-            radius=rng.random() * 100,
-            height=rng.random() * 1000,
-            sections=int(np.clip(rng.random() * 720, 20, 720)),
+            radius=random.random() * 100,
+            height=random.random() * 1000,
+            sections=int(np.clip(random.random() * 720, 20, 720)),
         )
 
         capsule = trimesh.creation.capsule(
-            radius=rng.random() * 100,
-            height=rng.random() * 1000,
-            count=np.clip(rng.random(2) * 720, 20, 720).astype(int),
+            radius=random.random() * 100,
+            height=random.random() * 1000,
+            count=np.clip(random.random(2) * 720, 20, 720).astype(int),
         )
         bodies.append(cylinder)
         bodies.append(capsule)
     for _i in range(10):
         bodies.append(
-            trimesh.creation.random_soup(int(np.clip(rng.random() * 1000, 20, 1000)))
+            trimesh.creation.random_soup(int(np.clip(random.random() * 1000, 20, 1000)))
         )
     bodies.append(trimesh.creation.icosphere())
     bodies.append(trimesh.creation.uv_sphere())

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -18,10 +18,14 @@ class AlignTests(g.unittest.TestCase):
 
         # start with some edge cases and make sure the transform works
         target = g.np.array([0, 0, -1], dtype=g.np.float64)
+        # draw from a stream: `g.random` returns the same array for the same
+        # shape so these two blocks were the same 1000 directions twice
+        with g.RandomSeed() as r:
+            unit_vectors, raw_vectors = r.random((2, 1000, 3)) - 0.5
         vectors = g.np.vstack(
             (
-                g.trimesh.unitize(g.random((1000, 3)) - 0.5),
-                g.random((1000, 3)) - 0.5,
+                g.trimesh.unitize(unit_vectors),
+                raw_vectors,
                 [-target, target],
                 g.trimesh.util.generate_basis(target),
                 [

--- a/tests/test_arc.py
+++ b/tests/test_arc.py
@@ -71,8 +71,9 @@ class ArcTests(g.unittest.TestCase):
             assert g.np.allclose(center, info["center"])
             assert g.np.allclose(radius, info["radius"])
 
-        for center, radius, three in zip(center_3D, radii, points_3D):
-            transform = g.trimesh.transformations.random_rotation_matrix()
+        for center, radius, three, transform in zip(
+            center_3D, radii, points_3D, g.random_transforms(len(radii), translate=0.0)
+        ):
             center = g.trimesh.transformations.transform_points([center], transform)[0]
             three = g.trimesh.transformations.transform_points(three, transform)
 

--- a/tests/test_binvox.py
+++ b/tests/test_binvox.py
@@ -14,7 +14,7 @@ class BinvoxTest(g.unittest.TestCase):
     def test_load_save_invariance(self):
         np = g.np
         n = 4
-        dense = np.random.uniform(size=(n,) * 3) > 0.8
+        dense = g.random((n,) * 3) > 0.8
         dense[0, 0, 0] = dense[-1, -1, -1] = 1  # ensure extent test works
         shape = dense.shape
         rl_data = rl.dense_to_rle(dense.flatten(), dtype=np.uint8)

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -80,81 +80,95 @@ class BoundsTest(g.unittest.TestCase):
         """
         Test OBB functions with raw points as input
         """
-        for dimension in [3, 2]:
-            for _i in range(25):
-                points = g.random((10, dimension))
+        # draw inside the block: `g.random` would hand every iteration
+        # the same points and make 24 of these 25 rounds a no-op
+        with g.RandomSeed() as r:
+            for dimension in [3, 2]:
+                for _i in range(25):
+                    points = r.random((10, dimension))
+                    to_origin, extents = g.trimesh.bounds.oriented_bounds(points)
+
+                    assert g.trimesh.util.is_shape(
+                        to_origin, (dimension + 1, dimension + 1)
+                    )
+                    assert g.trimesh.util.is_shape(extents, (dimension,))
+
+                    transformed = g.trimesh.transform_points(points, to_origin)
+
+                    transformed_bounds = [
+                        transformed.min(axis=0),
+                        transformed.max(axis=0),
+                    ]
+
+                    for j in transformed_bounds:
+                        # assert that the points once our obb to_origin transform
+                        # is applied has a bounding box centered on the origin
+                        assert g.np.allclose(g.np.abs(j), extents / 2.0)
+
+                    extents_tf = g.np.diff(transformed_bounds, axis=0).reshape(dimension)
+                    assert g.np.allclose(extents_tf, extents)
+
+    def test_obb_coplanar_points(self):
+        """
+        Test OBB functions with coplanar points as input
+        """
+        # draw inside the block: `g.random` would hand every iteration the
+        # same points and the same rotation, making 4 of these 5 a no-op
+        with g.RandomSeed() as r:
+            for _i in range(5):
+                points = g.np.zeros((5, 3))
+                points[:, :2] = r.random((points.shape[0], 2))
+                rot, _ = g.np.linalg.qr(r.random((3, 3)))
+                points = g.np.matmul(points, rot)
                 to_origin, extents = g.trimesh.bounds.oriented_bounds(points)
 
-                assert g.trimesh.util.is_shape(to_origin, (dimension + 1, dimension + 1))
-                assert g.trimesh.util.is_shape(extents, (dimension,))
+                assert g.trimesh.util.is_shape(to_origin, (4, 4))
+                assert g.trimesh.util.is_shape(extents, (3,))
 
                 transformed = g.trimesh.transform_points(points, to_origin)
 
                 transformed_bounds = [transformed.min(axis=0), transformed.max(axis=0)]
 
                 for j in transformed_bounds:
-                    # assert that the points once our obb to_origin transform is applied
-                    # has a bounding box centered on the origin
+                    # assert that the points once our obb to_origin transform is
+                    # applied has a bounding box centered on the origin
                     assert g.np.allclose(g.np.abs(j), extents / 2.0)
 
-                extents_tf = g.np.diff(transformed_bounds, axis=0).reshape(dimension)
+                extents_tf = g.np.diff(transformed_bounds, axis=0).reshape(3)
                 assert g.np.allclose(extents_tf, extents)
 
-    def test_obb_coplanar_points(self):
-        """
-        Test OBB functions with coplanar points as input
-        """
-        for _i in range(5):
-            points = g.np.zeros((5, 3))
-            points[:, :2] = g.random((points.shape[0], 2))
-            rot, _ = g.np.linalg.qr(g.random((3, 3)))
-            points = g.np.matmul(points, rot)
-            to_origin, extents = g.trimesh.bounds.oriented_bounds(points)
-
-            assert g.trimesh.util.is_shape(to_origin, (4, 4))
-            assert g.trimesh.util.is_shape(extents, (3,))
-
-            transformed = g.trimesh.transform_points(points, to_origin)
-
-            transformed_bounds = [transformed.min(axis=0), transformed.max(axis=0)]
-
-            for j in transformed_bounds:
-                # assert that the points once our obb to_origin transform is applied
-                # has a bounding box centered on the origin
-                assert g.np.allclose(g.np.abs(j), extents / 2.0)
-
-            extents_tf = g.np.diff(transformed_bounds, axis=0).reshape(3)
-            assert g.np.allclose(extents_tf, extents)
-
     def test_2D(self):
-        for theta in g.np.linspace(0, g.np.pi * 2, 2000):
-            # create some random rectangular-ish 2D points
-            points = g.random((10, 2)) * [5, 1]
+        # draw inside the block: `g.random` gave all 2000 angles the
+        # same points so this only ever rotated one rectangle
+        with g.RandomSeed() as r:
+            for theta in g.np.linspace(0, g.np.pi * 2, 2000):
+                # create some random rectangular-ish 2D points
+                points = r.random((10, 2)) * [5, 1]
 
-            # save the basic AABB of the points before rotation
-            rectangle_pre = g.np.ptp(points, axis=0)
+                # save the basic AABB of the points before rotation
+                rectangle_pre = g.np.ptp(points, axis=0)
 
-            # rotate them by an increment
-            TR = g.trimesh.transformations.planar_matrix(theta=theta)
-            points = g.trimesh.transform_points(points, TR)
+                # rotate them by an increment
+                TR = g.trimesh.transformations.planar_matrix(theta=theta)
+                points = g.trimesh.transform_points(points, TR)
 
-            # find the OBB of the points
-            T, rectangle = g.trimesh.bounds.oriented_bounds_2D(points)
+                # find the OBB of the points
+                T, rectangle = g.trimesh.bounds.oriented_bounds_2D(points)
 
-            # apply the calculated OBB
-            oriented = g.trimesh.transform_points(points, T)
+                # apply the calculated OBB
+                oriented = g.trimesh.transform_points(points, T)
 
-            origin = oriented.min(axis=0) + g.np.ptp(oriented, axis=0) / 2.0
+                origin = oriented.min(axis=0) + g.np.ptp(oriented, axis=0) / 2.0
 
-            # check to make sure the returned rectangle size is right
-            assert g.np.allclose(g.np.ptp(oriented, axis=0), rectangle)
-            # check to make sure the OBB consistently returns the
-            # long axis in the same direction
-            assert rectangle[0] > rectangle[1]
-            # check to make sure result is actually returning an OBB
-            assert g.np.allclose(origin, 0.0)
-            # make sure OBB has less or same area as naive AABB
-            assert g.np.prod(rectangle) <= g.np.prod(rectangle_pre)
+                # check to make sure the returned rectangle size is right
+                assert g.np.allclose(g.np.ptp(oriented, axis=0), rectangle)
+                # check to make sure the OBB consistently returns the
+                # long axis in the same direction
+                assert rectangle[0] > rectangle[1]
+                # check to make sure result is actually returning an OBB
+                assert g.np.allclose(origin, 0.0)
+                # make sure OBB has less or same area as naive AABB
+                assert g.np.prod(rectangle) <= g.np.prod(rectangle_pre)
 
     def test_cylinder(self):
         """
@@ -226,12 +240,8 @@ class BoundsTest(g.unittest.TestCase):
         extents = [10, 2, 3.5]
         extents_ordered = g.np.sort(extents)
 
-        for _i in range(100):
-            # transform box randomly in rotation and translation
-            mat = g.trimesh.transformations.random_rotation_matrix()
-            # translate in box -100 : +100
-            mat[:3, 3] = (g.random(3) - 0.5) * 200
-
+        # transform box randomly in rotation and translation in box -100 : +100
+        for mat in g.random_transforms(100, translate=200):
             # source mesh to check
             b = g.trimesh.creation.box(extents=extents, transform=mat)
 
@@ -262,13 +272,11 @@ class BoundsTest(g.unittest.TestCase):
     def test_bounds_tree(self):
         # test r-tree intersections
         for dimension in (2, 3):
-            # create some (n, 2, 3) bounds
-            bounds = g.np.array(
-                [
-                    [i.min(axis=0), i.max(axis=0)]
-                    for i in [g.random((4, dimension)) for i in range(10)]
-                ]
-            )
+            # create some (n, 2, 3) bounds from a stream: `g.random` returns
+            # the same array every call which made these 10 identical boxes
+            with g.RandomSeed() as r:
+                corners = r.random((10, 4, dimension))
+            bounds = g.np.array([[i.min(axis=0), i.max(axis=0)] for i in corners])
             tree = g.trimesh.util.bounds_tree(bounds)
             for i, b in enumerate(bounds):
                 assert i in set(tree.intersection(b.ravel()))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -284,7 +284,8 @@ class CacheTest(g.unittest.TestCase):
             False,
             False,
             g.random(dim),
-            g.random(dim[::1]),
+            # `[::1]` was a no-op slice so this was a duplicate of the above
+            g.random(dim[::-1]),
             "shape",
         ]
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -81,23 +81,32 @@ class CameraTests(g.unittest.TestCase):
         # original points
         ori = np.array([[-1, -1], [1, -1], [1, 1], [-1, 1]])
 
-        for _i in range(10):
-            # set the extents to be random but positive
-            extents = g.random() * 10
-            points = g.trimesh.util.stack_3D(ori.copy() * extents)
+        # draw inside the block: `g.random` gave every iteration the same
+        # extents and offset so this tested one camera ten times
+        with g.RandomSeed() as r:
+            for _i in range(10):
+                # set the extents to be random but positive
+                extents = r.random() * 10
+                points = g.trimesh.util.stack_3D(ori.copy() * extents)
 
-            fov = g.np.array([20, 50])
+                fov = g.np.array([20, 50])
 
-            # offset the points by a random amount
-            offset = (g.random(3) - 0.5) * 100
-            T = g.trimesh.scene.cameras.look_at(points + offset, fov)
+                # offset the points by a random amount
+                offset = (r.random(3) - 0.5) * 100
+                moved = points + offset
+                T = g.trimesh.scene.cameras.look_at(moved, fov)
 
-            # check using trig
-            check = (np.ptp(points, axis=0)[:2] / 2.0) / g.np.tan(np.radians(fov / 2))
-            check += points[:, 2].mean()
+                # check using trig
+                check = (np.ptp(points, axis=0)[:2] / 2.0) / g.np.tan(np.radians(fov / 2))
 
-            # Z should be the same as maximum trig option
-            assert np.linalg.inv(T)[2, 3] >= check.max()
+                # `look_at` returns a camera-to-world pose so the distance is
+                # from the camera back to what it's pointed at: comparing the
+                # world-to-camera translation against this only ever passed
+                # because the offset was a fixed large negative number
+                distance = T[2, 3] - moved[:, 2].mean()
+
+                # camera should be far enough back to fit every point in frame
+                assert distance + 1e-8 >= check.max()
 
         # just run to test other arguments
         # TODO(unknown): find the way to test it correctly

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -63,6 +63,16 @@ def test_random_color():
     assert c.shape == (10, 4)
     assert c.dtype == g.np.uint8
 
+    # the requested dtype should be honored
+    c = random_color(dtype=g.np.float64)
+    assert c.dtype == g.np.float64
+    assert c.max() <= 1.0
+
+    c = random_color(dtype=g.np.uint16, count=10)
+    assert c.shape == (10, 4)
+    assert c.dtype == g.np.uint16
+    assert c.max() > 255
+
 
 def test_hsv_rgba():
     # the non-vectorized stdlib HSV -> RGB function

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -33,8 +33,8 @@ def test_visual():
     # stl shouldn't have any visual properties defined
     assert not mesh.visual.defined
 
-    for facet in mesh.facets:
-        mesh.visual.face_colors[facet] = g.trimesh.visual.random_color()
+    for i, facet in enumerate(mesh.facets):
+        mesh.visual.face_colors[facet] = g.trimesh.visual.random_color(seed=i)
 
     assert mesh.visual.defined
     assert not mesh.visual.transparency
@@ -55,11 +55,11 @@ def test_concatenate():
 def test_random_color():
     from trimesh.visual.color import random_color
 
-    c = random_color()
+    c = random_color(seed=0)
     assert c.shape == (4,)
     assert c.dtype == g.np.uint8
 
-    c = random_color(count=10)
+    c = random_color(count=10, seed=0)
     assert c.shape == (10, 4)
     assert c.dtype == g.np.uint8
 
@@ -195,28 +195,33 @@ def test_data_model():
     m.visual.vertex_colors[1] = test_color_transparent
     assert m.visual.transparency
 
-    test = (g.random((len(m.faces), 4)) * 255).astype(g.np.uint8)
-    m.visual.face_colors = test
-    assert bool((m.visual.face_colors == test).all())
+    # draw from a stream: `g.random(4)` returns the same color every call, so
+    # the single-color checks below were asserting a value already set
+    with g.RandomSeed() as r:
+        per_face = (r.random((len(m.faces), 4)) * 255).astype(g.np.uint8)
+        per_vertex = (r.random((len(m.vertices), 4)) * 255).astype(g.np.uint8)
+        one_face = (r.random(4) * 255).astype(g.np.uint8)
+        one_vertex = (r.random(4) * 255).astype(g.np.uint8)
+        two_faces = (r.random((2, 4)) * 255).astype(g.np.uint8)
+
+    m.visual.face_colors = per_face
+    assert bool((m.visual.face_colors == per_face).all())
     assert m.visual.kind == "face"
 
-    test = (g.random((len(m.vertices), 4)) * 255).astype(g.np.uint8)
-    m.visual.vertex_colors = test
-    assert bool((m.visual.vertex_colors == test).all())
+    m.visual.vertex_colors = per_vertex
+    assert bool((m.visual.vertex_colors == per_vertex).all())
     assert m.visual.kind == "vertex"
 
-    test = (g.random(4) * 255).astype(g.np.uint8)
-    m.visual.face_colors = test
-    assert bool((m.visual.vertex_colors == test).all())
+    m.visual.face_colors = one_face
+    assert bool((m.visual.vertex_colors == one_face).all())
     assert m.visual.kind == "face"
     m.visual.vertex_colors[0] = [0, 0, 0, 0]
     assert m.visual.kind == "vertex"
 
-    test = (g.random(4) * 255).astype(g.np.uint8)
-    m.visual.vertex_colors = test
-    assert bool((m.visual.face_colors == test).all())
+    m.visual.vertex_colors = one_vertex
+    assert bool((m.visual.face_colors == one_vertex).all())
     assert m.visual.kind == "vertex"
-    m.visual.face_colors[:2] = (g.random((2, 4)) * 255).astype(g.np.uint8)
+    m.visual.face_colors[:2] = two_faces
     assert m.visual.kind == "face"
 
 
@@ -365,7 +370,8 @@ def test_interpolate():
 
     # now see if we match matplotlib if it's installed
     try:
-        from matplotlib.pyplot import get_cmap
+        # checking against matplotlib is the point of this test
+        from matplotlib.pyplot import get_cmap  # noqa: TID251
     except ImportError:
         return
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -32,6 +32,51 @@ def test_cone():
     assert c.metadata["shape"] == "cone"
 
 
+def test_revolve_reflection_transform():
+    # regression for issue #2439: passing a reflection (negative
+    # determinant) transform to a `revolve`-based primitive used to
+    # flip the winding so the result was no longer a valid volume,
+    # while applying the same transform *after* creation worked.
+    # the `transform=` keyword and `apply_transform` should agree.
+    reflections = [
+        g.np.diag([-1.0, 1.0, 1.0, 1.0]),
+        g.np.diag([1.0, 1.0, -1.0, 1.0]),
+        g.np.diag([-1.0, -1.0, -1.0, 1.0]),
+    ]
+
+    builders = [
+        ("cone", lambda T: g.trimesh.creation.cone(radius=0.5, height=1.0, transform=T)),
+        (
+            "cylinder",
+            lambda T: g.trimesh.creation.cylinder(radius=0.5, height=1.0, transform=T),
+        ),
+        (
+            "annulus",
+            lambda T: g.trimesh.creation.annulus(
+                r_min=0.5, r_max=1.0, height=1.0, transform=T
+            ),
+        ),
+    ]
+
+    for name, build in builders:
+        # baseline volume of the un-transformed primitive
+        base = build(g.np.eye(4))
+        assert base.is_volume
+
+        for T in reflections:
+            passed = build(T)
+            # building with the reflection transform must stay a volume
+            assert passed.is_volume, f"{name} not a volume with reflection transform"
+            assert passed.volume > 0
+
+            # and must match applying the transform after construction
+            after = build(g.np.eye(4))
+            after.apply_transform(T)
+            assert after.is_volume
+            assert g.np.isclose(passed.volume, after.volume)
+            assert g.np.isclose(passed.volume, base.volume)
+
+
 def test_cylinder():
     # tolerance for cylinders
     atol = 0.03

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -126,10 +126,13 @@ def test_capsule():
     assert mesh.body_count == 1
     assert g.np.allclose(mesh.extents, [2, 2, 4], atol=0.05)
 
-    # cylinder must reach the requested radius
-    for count in (6, 7, 8):
-        cap = g.trimesh.creation.capsule(radius=1.0, height=1.0, count=[count, 12])
-        assert g.np.isclose(g.np.linalg.norm(cap.vertices[:, :2], axis=1).max(), 1.0)
+    # the widest vertices must reach the radius
+    # and form a wall spanning the whole height
+    for radius, height, count in ((1.0, 1.0, 6), (2.0, 3.0, 7), (0.5, 4.0, 8)):
+        cap = g.trimesh.creation.capsule(radius=radius, height=height, count=[count, 24])
+        xy = g.np.linalg.norm(cap.vertices[:, :2], axis=1)
+        assert cap.is_volume and g.np.isclose(xy.max(), radius)
+        assert g.np.isclose(g.np.ptp(cap.vertices[g.np.isclose(xy, radius), 2]), height)
 
 
 def test_spheres():

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -128,7 +128,7 @@ def test_capsule():
 
     # cylinder must reach the requested radius
     for count in (6, 7, 8):
-        cap = g.trimesh.creation.capsule(radius=1.0, height=1.0, count=(count, 12))
+        cap = g.trimesh.creation.capsule(radius=1.0, height=1.0, count=[count, 12])
         assert g.np.isclose(g.np.linalg.norm(cap.vertices[:, :2], axis=1).max(), 1.0)
 
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -113,7 +113,7 @@ def test_cylinder():
 
 def test_soup():
     count = 100
-    mesh = g.trimesh.creation.random_soup(face_count=count)
+    mesh = g.trimesh.creation.random_soup(face_count=count, seed=0)
     assert len(mesh.faces) == count
     assert len(mesh.face_adjacency) == 0
     assert len(mesh.split(only_watertight=True)) == 0

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -126,6 +126,11 @@ def test_capsule():
     assert mesh.body_count == 1
     assert g.np.allclose(mesh.extents, [2, 2, 4], atol=0.05)
 
+    # cylinder must reach the requested radius
+    for count in (6, 7, 8):
+        cap = g.trimesh.creation.capsule(radius=1.0, height=1.0, count=(count, 12))
+        assert g.np.isclose(g.np.linalg.norm(cap.vertices[:, :2], axis=1).max(), 1.0)
+
 
 def test_spheres():
     # test generation of UV spheres and icospheres
@@ -454,3 +459,4 @@ def test_torus():
 if __name__ == "__main__":
     # test_torus()
     test_revolve()
+    test_capsule()

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -7,7 +7,7 @@ rl = g.trimesh.voxel.runlength
 np = g.np
 
 shape = (10, 10, 10)
-dense_data = np.random.uniform(size=shape) < 0.2
+dense_data = g.random(shape) < 0.2
 rle = enc.RunLengthEncoding.from_dense(dense_data.reshape((-1,)), dtype=bool).reshape(
     shape
 )

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -6,11 +6,16 @@ files that expand far beyond their size.
 import io
 import warnings
 import zipfile
+from pathlib import Path
 
+import numpy as np
 import pytest
 
 import trimesh
 from trimesh import resolvers, util
+
+# the model corpus, as this file avoids importing `generic`
+MODELS = Path(__file__).parent.parent / "models"
 
 EXPANSION_CHECK = b"""<?xml version="1.0"?>
 <!DOCTYPE root [
@@ -257,3 +262,61 @@ def test_meshscript_argv_no_split_injection(monkeypatch, tmp_path):
         script.run("$MESH_PRE $SCRIPT")
     # whitespace and flag-like text in the substituted path stayed one token
     assert captured["argv"] == [bad_path, "x"]
+
+
+# libxml2 caps a single text node at ~10MB and `XML_PARSE_HUGE` is the
+# only way past it: the limit is a compile-time constant and lxml exposes
+# no memlimit, so `huge_tree` is a bool rather than a size
+HUGE_TEXT = b"x" * 10_500_000
+
+
+def test_svg_huge_tree_opt_in():
+    # `svg` goes through `load_path`, which has to forward the kwarg
+    from lxml import etree
+
+    svg = (
+        b'<svg xmlns="http://www.w3.org/2000/svg"><desc>'
+        + HUGE_TEXT
+        + b'</desc><path d="M0,0L1,1"/></svg>'
+    )
+    # guards are on by default so the oversize text node is refused
+    with pytest.raises(etree.XMLSyntaxError, match="Text node too long"):
+        trimesh.load(io.BytesIO(svg), file_type="svg")
+
+    # the identical bytes load once the caller opts in, which can only
+    # happen if `huge_tree` actually reached the parser
+    path = trimesh.load(io.BytesIO(svg), file_type="svg", huge_tree=True)
+    assert len(path.entities) == 1
+
+
+def test_3mf_huge_tree_opt_in():
+    # `3mf` goes through the mesh branch of `load_scene`
+    from lxml import etree
+
+    original = trimesh.load(MODELS / "pyramids.3mf")
+    with zipfile.ZipFile(MODELS / "pyramids.3mf") as z:
+        model = z.read("3D/3dmodel.model")
+
+    # inject an oversize text node after the `<model>` open tag, leaving
+    # an otherwise unmodified and still-valid 3MF
+    split = model.index(b">", model.index(b"<model")) + 1
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as z:
+        z.writestr(
+            "3D/3dmodel.model",
+            model[:split]
+            + b'<metadata name="pad">'
+            + HUGE_TEXT
+            + b"</metadata>"
+            + model[split:],
+        )
+    padded = buf.getvalue()
+
+    with pytest.raises(etree.XMLSyntaxError, match="Text node too long"):
+        trimesh.load(io.BytesIO(padded), file_type="3mf")
+
+    # opting in parses the same bytes, and the padding is inert: the
+    # geometry has to match the unpadded file exactly
+    scene = trimesh.load(io.BytesIO(padded), file_type="3mf", huge_tree=True)
+    assert scene.triangles.shape == original.triangles.shape
+    assert np.allclose(scene.triangles, original.triangles)

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -85,7 +85,7 @@ def test_filepath_resolver_traversal_rejected(tmp_path):
     root.mkdir()
     (root / "real.txt").write_bytes(b"ok")
     resolver = resolvers.FilePathResolver(str(root / "real.txt"))
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ValueError, match="escapes resolver root"):
         resolver.get("../../../etc/passwd")
     # legitimate name in-root still works — the hardening did not break the
     # happy path

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -6,16 +6,11 @@ files that expand far beyond their size.
 import io
 import warnings
 import zipfile
-from pathlib import Path
 
-import numpy as np
 import pytest
 
 import trimesh
 from trimesh import resolvers, util
-
-# the model corpus, as this file avoids importing `generic`
-MODELS = Path(__file__).parent.parent / "models"
 
 EXPANSION_CHECK = b"""<?xml version="1.0"?>
 <!DOCTYPE root [
@@ -262,62 +257,3 @@ def test_meshscript_argv_no_split_injection(monkeypatch, tmp_path):
         script.run("$MESH_PRE $SCRIPT")
     # whitespace and flag-like text in the substituted path stayed one token
     assert captured["argv"] == [bad_path, "x"]
-
-
-# libxml2 caps a single text node at ~10MB and `XML_PARSE_HUGE` is the
-# only way past it: the limit is a compile-time constant and lxml exposes
-# no memlimit, so `huge_tree` is a bool rather than a size
-HUGE_TEXT = b"x" * 10_500_000
-
-
-def test_svg_huge_tree_opt_in():
-    # `svg` goes through `load_path`, which has to forward the kwarg
-    svg = (
-        b'<svg xmlns="http://www.w3.org/2000/svg"><desc>'
-        + HUGE_TEXT
-        + b'</desc><path d="M0,0L1,1"/></svg>'
-    )
-    # the default is not checked here — whether libxml2 enforces the text cap on
-    # the `fromstring` path varies by build and some do not enforce it at all
-    #
-    # these bytes only load if `huge_tree` actually reached the parser
-    path = trimesh.load(io.BytesIO(svg), file_type="svg", huge_tree=True)
-    assert len(path.entities) == 1
-
-
-def test_3mf_huge_tree_opt_in():
-    # `3mf` goes through the mesh branch of `load_scene`
-    from lxml import etree
-
-    original = trimesh.load(MODELS / "pyramids.3mf")
-    with zipfile.ZipFile(MODELS / "pyramids.3mf") as z:
-        model = z.read("3D/3dmodel.model")
-
-    # inject an oversize text node after the `<model>` open tag, leaving
-    # an otherwise unmodified and still-valid 3MF
-    split = model.index(b">", model.index(b"<model")) + 1
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as z:
-        z.writestr(
-            "3D/3dmodel.model",
-            model[:split]
-            + b'<metadata name="pad">'
-            + HUGE_TEXT
-            + b"</metadata>"
-            + model[split:],
-        )
-    padded = buf.getvalue()
-
-    # the oversize text node is refused by default — match on the type and not the
-    # message as libxml2's wording for this differs between builds
-    try:
-        trimesh.load(io.BytesIO(padded), file_type="3mf")
-        raise AssertionError("oversize text node was accepted by default")
-    except etree.XMLSyntaxError:
-        pass
-
-    # opting in parses the same bytes, and the padding is inert: the
-    # geometry has to match the unpadded file exactly
-    scene = trimesh.load(io.BytesIO(padded), file_type="3mf", huge_tree=True)
-    assert scene.triangles.shape == original.triangles.shape
-    assert np.allclose(scene.triangles, original.triangles)

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -7,6 +7,7 @@ import io
 import warnings
 import zipfile
 
+import numpy as np
 import pytest
 
 import trimesh
@@ -105,45 +106,33 @@ def test_filepath_resolver_write_traversal_rejected(tmp_path):
     assert (root / "ok.txt").read_bytes() == b"safe"
 
 
-def test_decompress_rejects_oversize_archive(monkeypatch):
-    # patch the cap down so we don't have to craft a real 512 MB archive
-    monkeypatch.setattr(util, "MAX_ARCHIVE_SIZE", 1024)
+def test_decompress_skips_oversize_members():
+    # the skip is based on the size the central directory declares so the
+    # payload never has to exist: this builds a 300-ish byte archive claiming
+    # a 50 GiB member in well under a millisecond, against the real budget
+    mesh = trimesh.creation.box()
+    stl = mesh.export(file_type="stl")
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as z:
-        z.writestr("big.bin", b"\x00" * (2 * 1024 * 1024))
+        z.writestr("payload.bin", b"\x00" * 1024)
+        z.writestr("m.stl", stl)
+        # mutated before close so zipfile writes the zip64 extra field for us
+        z.getinfo("payload.bin").file_size = 50 * 1024**3
     buf.seek(0)
-    with pytest.raises(ValueError, match="size cap"):
-        util.decompress(buf, file_type="zip")
 
+    result = util.decompress(buf, file_type="zip")
+    # the oversize member is gone and the rest of the archive survived
+    assert set(result) == {"m.stl"}
+    # nothing beyond the surviving member was ever materialized: over-declaring
+    # only gets you skipped and under-declaring truncates and fails the CRC, so
+    # there is no size to claim that reads more bytes than this
+    assert sum(len(v.read()) for v in result.values()) == len(stl)
 
-def test_decompress_zip_cap_is_cumulative(monkeypatch):
-    # F2 — running byte total spans members. each individual member fits
-    # under the cap, but the sum of several does not. the cap must fire
-    # mid-archive rather than per-member.
-    monkeypatch.setattr(util, "MAX_ARCHIVE_SIZE", 2048)
-    buf = io.BytesIO()
-    payload = b"\x00" * 1024
-    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as z:
-        for i in range(4):
-            z.writestr(f"chunk_{i}.bin", payload)
+    # and the geometry that survived is actually correct
     buf.seek(0)
-    with pytest.raises(ValueError, match="size cap"):
-        util.decompress(buf, file_type="zip")
-
-
-def test_gltf_base64_oversize_rejected(monkeypatch):
-    # F1 — `_uri_to_bytes` decodes `data:…;base64,…` URIs; the encoded
-    # payload size must be capped before allocation. patch the cap low so
-    # we don't have to allocate hundreds of MB to exercise the guard.
-    from trimesh.exchange.gltf import _uri_to_bytes
-
-    monkeypatch.setattr(util, "MAX_ARCHIVE_SIZE", 1024)
-    # build a base64 payload longer than the encoded-length threshold
-    # (MAX_ARCHIVE_SIZE * 4 // 3 + 4)
-    oversize = "A" * (1024 * 4 // 3 + 64)
-    uri = "data:application/octet-stream;base64," + oversize
-    with pytest.raises(ValueError, match="exceeds size cap"):
-        _uri_to_bytes(uri, resolver=None)
+    loaded = trimesh.load_scene(buf, file_type="zip")
+    assert len(loaded.geometry) == 1
+    assert np.isclose(next(iter(loaded.geometry.values())).volume, mesh.volume)
 
 
 def test_obj_image_metadata_records_reference(tmp_path):

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -272,19 +272,15 @@ HUGE_TEXT = b"x" * 10_500_000
 
 def test_svg_huge_tree_opt_in():
     # `svg` goes through `load_path`, which has to forward the kwarg
-    from lxml import etree
-
     svg = (
         b'<svg xmlns="http://www.w3.org/2000/svg"><desc>'
         + HUGE_TEXT
         + b'</desc><path d="M0,0L1,1"/></svg>'
     )
-    # guards are on by default so the oversize text node is refused
-    with pytest.raises(etree.XMLSyntaxError, match="Text node too long"):
-        trimesh.load(io.BytesIO(svg), file_type="svg")
-
-    # the identical bytes load once the caller opts in, which can only
-    # happen if `huge_tree` actually reached the parser
+    # the default is not checked here — whether libxml2 enforces the text cap on
+    # the `fromstring` path varies by build and some do not enforce it at all
+    #
+    # these bytes only load if `huge_tree` actually reached the parser
     path = trimesh.load(io.BytesIO(svg), file_type="svg", huge_tree=True)
     assert len(path.entities) == 1
 
@@ -312,8 +308,13 @@ def test_3mf_huge_tree_opt_in():
         )
     padded = buf.getvalue()
 
-    with pytest.raises(etree.XMLSyntaxError, match="Text node too long"):
+    # the oversize text node is refused by default — match on the type and not the
+    # message as libxml2's wording for this differs between builds
+    try:
         trimesh.load(io.BytesIO(padded), file_type="3mf")
+        raise AssertionError("oversize text node was accepted by default")
+    except etree.XMLSyntaxError:
+        pass
 
     # opting in parses the same bytes, and the padding is inert: the
     # geometry has to match the unpadded file exactly

--- a/tests/test_extrude.py
+++ b/tests/test_extrude.py
@@ -5,7 +5,7 @@ except BaseException:
 
 
 def test_extrusion():
-    transform = g.trimesh.transformations.random_rotation_matrix()
+    transform = next(g.random_transforms(1, translate=0.0))
     polygon = g.Point([0, 0]).buffer(0.5)
     e = g.trimesh.primitives.Extrusion(polygon=polygon, transform=transform)
 

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -905,6 +905,30 @@ class GLTFTest(g.unittest.TestCase):
         assert g.np.allclose(reloaded.vertices, points)
         assert g.np.allclose(reloaded.colors, colors)
 
+    def test_world_node_collision(self):
+        # a non-root node named "world" must not merge with the hardcoded base
+        # frame; on main its transform collapses to identity on round-trip
+        tf = g.trimesh.transformations.rotation_matrix(0.7, [1.0, 2.0, 3.0])
+        tf[:3, 3] = [5.0, -3.0, 2.0]
+
+        scene = g.trimesh.Scene(base_frame="root")
+        scene.add_geometry(
+            g.trimesh.creation.box(),
+            node_name="world",
+            parent_node_name="root",
+            geom_name="box",
+            transform=tf,
+        )
+
+        def geom_world_transform(s):
+            return s.graph.get(s.graph.nodes_geometry[0])[0]
+
+        reloaded = g.trimesh.load(
+            g.trimesh.util.wrap_as_stream(scene.export(file_type="glb")),
+            file_type="glb",
+        )
+        assert g.np.allclose(geom_world_transform(scene), geom_world_transform(reloaded))
+
     def test_bulk(self):
         # Try exporting every loadable model to GLTF and checking
         # the generated header against the schema.

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -575,14 +575,14 @@ class GLTFTest(g.unittest.TestCase):
         sphere = g.trimesh.primitives.Sphere()
         v_count, _ = sphere.vertices.shape
 
-        rng = g.np.random.default_rng(seed=0)
-        sphere.vertex_attributes["_CustomFloat32Scalar"] = rng.random(
+        random = g.np.random.default_rng(seed=0)
+        sphere.vertex_attributes["_CustomFloat32Scalar"] = random.random(
             (v_count, 1)
         ).astype(g.np.float32)
-        sphere.vertex_attributes["_CustomFloat32Vec3"] = rng.random((v_count, 3)).astype(
-            g.np.float32
-        )
-        sphere.vertex_attributes["_CustomFloat32Mat4"] = rng.random(
+        sphere.vertex_attributes["_CustomFloat32Vec3"] = random.random(
+            (v_count, 3)
+        ).astype(g.np.float32)
+        sphere.vertex_attributes["_CustomFloat32Mat4"] = random.random(
             (v_count, 4, 4)
         ).astype(g.np.float32)
 
@@ -594,7 +594,7 @@ class GLTFTest(g.unittest.TestCase):
         # uint32 is slightly off-label and may cause
         # validators to fail but if you're a bad larry who
         # doesn't follow the rules it should be fine
-        sphere.vertex_attributes["_CustomUInt32Scalar"] = rng.integers(
+        sphere.vertex_attributes["_CustomUInt32Scalar"] = random.integers(
             0, 1000, size=(v_count, 1)
         ).astype(g.np.uint32)
 
@@ -602,10 +602,10 @@ class GLTFTest(g.unittest.TestCase):
         # complains about the 4-byte boundaries even though
         # all their lengths and offsets mod 4 are zero
         # not sure if that's a validator bug or what
-        sphere.vertex_attributes["_CustomUInt16Scalar"] = rng.integers(
+        sphere.vertex_attributes["_CustomUInt16Scalar"] = random.integers(
             0, 1000, size=(v_count, 1)
         ).astype(g.np.uint16)
-        sphere.vertex_attributes["_CustomInt16Scalar"] = rng.integers(
+        sphere.vertex_attributes["_CustomInt16Scalar"] = random.integers(
             0, 1000, size=(v_count, 1)
         ).astype(g.np.int16)
 

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -575,14 +575,15 @@ class GLTFTest(g.unittest.TestCase):
         sphere = g.trimesh.primitives.Sphere()
         v_count, _ = sphere.vertices.shape
 
-        sphere.vertex_attributes["_CustomFloat32Scalar"] = g.np.random.rand(
-            v_count, 1
+        rng = g.np.random.default_rng(seed=0)
+        sphere.vertex_attributes["_CustomFloat32Scalar"] = rng.random(
+            (v_count, 1)
         ).astype(g.np.float32)
-        sphere.vertex_attributes["_CustomFloat32Vec3"] = g.np.random.rand(
-            v_count, 3
-        ).astype(g.np.float32)
-        sphere.vertex_attributes["_CustomFloat32Mat4"] = g.np.random.rand(
-            v_count, 4, 4
+        sphere.vertex_attributes["_CustomFloat32Vec3"] = rng.random((v_count, 3)).astype(
+            g.np.float32
+        )
+        sphere.vertex_attributes["_CustomFloat32Mat4"] = rng.random(
+            (v_count, 4, 4)
         ).astype(g.np.float32)
 
         # export as GLB bytes
@@ -593,7 +594,7 @@ class GLTFTest(g.unittest.TestCase):
         # uint32 is slightly off-label and may cause
         # validators to fail but if you're a bad larry who
         # doesn't follow the rules it should be fine
-        sphere.vertex_attributes["_CustomUInt32Scalar"] = g.np.random.randint(
+        sphere.vertex_attributes["_CustomUInt32Scalar"] = rng.integers(
             0, 1000, size=(v_count, 1)
         ).astype(g.np.uint32)
 
@@ -601,10 +602,10 @@ class GLTFTest(g.unittest.TestCase):
         # complains about the 4-byte boundaries even though
         # all their lengths and offsets mod 4 are zero
         # not sure if that's a validator bug or what
-        sphere.vertex_attributes["_CustomUInt16Scalar"] = g.np.random.randint(
+        sphere.vertex_attributes["_CustomUInt16Scalar"] = rng.integers(
             0, 1000, size=(v_count, 1)
         ).astype(g.np.uint16)
-        sphere.vertex_attributes["_CustomInt16Scalar"] = g.np.random.randint(
+        sphere.vertex_attributes["_CustomInt16Scalar"] = rng.integers(
             0, 1000, size=(v_count, 1)
         ).astype(g.np.int16)
 

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -56,6 +56,34 @@ def validate_glb(data, name=None):
 load_kwargs = g.trimesh.exchange.load._load_kwargs
 
 
+def world_root_tree():
+    # minimal single-file glTF whose ROOT node is named "world"
+    # and carries a transform — the shape external tools produce
+    indices = g.np.array([0, 1, 2], dtype=g.np.uint32).tobytes()
+    uri = "data:application/octet-stream;base64," + g.base64.b64encode(indices).decode(
+        "utf-8"
+    )
+    tree = {
+        "asset": {"version": "2.0"},
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+        "nodes": [
+            {"name": "world", "translation": [10.0, 0.0, 0.0], "children": [1]},
+            {"name": "geom", "mesh": 0},
+        ],
+        "meshes": [
+            {"primitives": [{"attributes": {"POSITION": 0}, "indices": 1, "mode": 4}]}
+        ],
+        "accessors": [
+            {"componentType": 5126, "count": 3, "type": "VEC3"},
+            {"componentType": 5125, "count": 3, "type": "SCALAR", "bufferView": 0},
+        ],
+        "bufferViews": [{"buffer": 0, "byteLength": 12, "byteOffset": 0}],
+        "buffers": [{"byteLength": 12, "uri": uri}],
+    }
+    return g.trimesh.util.wrap_as_stream(g.json.dumps(tree).encode("utf-8"))
+
+
 class GLTFTest(g.unittest.TestCase):
     def test_duck(self):
         scene = g.get_mesh("Duck.glb", process=False)
@@ -928,6 +956,61 @@ class GLTFTest(g.unittest.TestCase):
             file_type="glb",
         )
         assert g.np.allclose(geom_world_transform(scene), geom_world_transform(reloaded))
+
+    def test_world_root_transform(self):
+        # a root node named "world" with a transform must keep it —
+        # merging with the synthetic base frame silently dropped it
+        scene = g.trimesh.load(world_root_tree(), file_type="gltf")
+        transform = scene.graph.get(scene.graph.nodes_geometry[0])[0]
+        assert g.np.allclose(transform[:3, 3], [10.0, 0.0, 0.0])
+
+    def test_world_no_accumulation(self):
+        # the 2025-08-11 unconditional-rename attempt failed because every
+        # round-trip of trimesh's own exports renamed the wrapper node and
+        # grew the graph — pin names and node count across cycles
+        scene = g.trimesh.load(world_root_tree(), file_type="gltf")
+
+        def cycle(s):
+            return g.trimesh.load(
+                g.trimesh.util.wrap_as_stream(s.export(file_type="glb")),
+                file_type="glb",
+            )
+
+        once = cycle(scene)
+        twice = cycle(once)
+        thrice = cycle(twice)
+        assert set(once.graph.nodes) == set(twice.graph.nodes)
+        assert set(twice.graph.nodes) == set(thrice.graph.nodes)
+        # the world transform of the geometry must be stable too
+        for s in (once, twice, thrice):
+            transform = s.graph.get(s.graph.nodes_geometry[0])[0]
+            assert g.np.allclose(transform[:3, 3], [10.0, 0.0, 0.0])
+
+    def test_export_no_wrapper_node(self):
+        # exports hang children as real scene roots instead of wrapping
+        # everything in a synthetic transform-less "world" node
+        scene = g.trimesh.Scene(g.trimesh.creation.box())
+        scene.metadata["hi"] = 3
+
+        export = scene.export(file_type="gltf")
+        tree = g.json.loads(export["model.gltf"].decode("utf-8"))
+
+        # no wrapper node and the real nodes are the scene roots
+        names = [n.get("name") for n in tree["nodes"]]
+        assert scene.graph.base_frame not in names
+        assert len(tree["nodes"]) == len(scene.graph.nodes) - 1
+        assert len(tree["scenes"][0]["nodes"]) == len(
+            scene.graph.transforms.children[scene.graph.base_frame]
+        )
+        # scene metadata must survive the root change
+        assert tree["scenes"][0]["extras"]["hi"] == 3
+
+        # round-trips keep the node names identical
+        reloaded = g.trimesh.load(
+            g.trimesh.util.wrap_as_stream(scene.export(file_type="glb")),
+            file_type="glb",
+        )
+        assert set(reloaded.graph.nodes) == set(scene.graph.nodes)
 
     def test_bulk(self):
         # Try exporting every loadable model to GLTF and checking

--- a/tests/test_gltf_handlers.py
+++ b/tests/test_gltf_handlers.py
@@ -1,0 +1,108 @@
+"""
+test_gltf_handlers.py
+---------------------
+
+Pin the glTF extension-handler interface that upstream packages register against.
+"""
+
+import base64
+
+try:
+    from . import generic as g
+except BaseException:
+    import generic as g
+
+from trimesh.exchange.gltf import extensions as ext
+
+
+def minimal_gltf():
+    # one-triangle glTF whose POSITION accessor is bufferless -- a placeholder
+    # an extension is expected to fill -- and whose primitive carries a dummy extension
+    indices = g.np.array([0, 1, 2], dtype=g.np.uint32).tobytes()
+    uri = "data:application/octet-stream;base64," + base64.b64encode(indices).decode()
+    tree = {
+        "asset": {"version": "2.0"},
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+        "nodes": [{"mesh": 0}],
+        "meshes": [
+            {
+                "primitives": [
+                    {
+                        "attributes": {"POSITION": 0},
+                        "indices": 1,
+                        "mode": 4,
+                        "extensions": {"TEST_dummy": {}},
+                    }
+                ]
+            }
+        ],
+        "accessors": [
+            # bufferless -> created as placeholder zeros
+            {"componentType": 5126, "count": 3, "type": "VEC3"},
+            {"componentType": 5125, "count": 3, "type": "SCALAR", "bufferView": 0},
+        ],
+        "bufferViews": [{"buffer": 0, "byteLength": 12, "byteOffset": 0}],
+        "buffers": [{"byteLength": 12, "uri": uri}],
+    }
+    return g.io.BytesIO(g.json.dumps(tree).encode())
+
+
+class GLTFHandlerTest(g.unittest.TestCase):
+    def setUp(self):
+        # snapshot the global handler registry so tests don't leak
+        self._snapshot = {scope: dict(h) for scope, h in ext._handlers.items()}
+
+    def tearDown(self):
+        ext._handlers.clear()
+        ext._handlers.update(self._snapshot)
+
+    def test_register_roundtrip(self):
+        @ext.register_handler("TEST_x", scope="primitive_preprocess")
+        def handler(context):
+            return None
+
+        # the decorator registers into the scope registry and returns the function
+        assert ext._handlers["primitive_preprocess"]["TEST_x"] is handler
+
+    def test_preprocess_context_keys(self):
+        # the loader must pass the documented context keys to preprocess handlers
+        seen = {}
+
+        @ext.register_handler("TEST_dummy", scope="primitive_preprocess")
+        def spy(context):
+            seen.update({k: type(v) for k, v in context.items()})
+            return None
+
+        g.trimesh.load(minimal_gltf(), file_type="gltf")
+        assert {"data", "primitive", "accessors", "views"}.issubset(seen)
+
+    def test_no_handler_warns_and_zeros(self):
+        # without a handler the placeholder geometry stays zero and we warn by name
+        with self.assertLogs("trimesh", level="WARNING") as cm:
+            scene = g.trimesh.load(minimal_gltf(), file_type="gltf")
+        geom = next(iter(scene.geometry.values()))
+        assert g.np.allclose(geom.vertices, 0.0)
+        assert any("TEST_dummy" in line for line in cm.output)
+
+    def test_handler_fills_placeholder(self):
+        # a handler may fill the placeholder accessor in place -- a successful
+        # decode must not warn
+        filled = g.np.arange(9, dtype=g.np.float32).reshape((3, 3))
+
+        @ext.register_handler("TEST_dummy", scope="primitive_preprocess")
+        def fill(context):
+            context["accessors"][context["primitive"]["attributes"]["POSITION"]][:] = (
+                filled
+            )
+            return None
+
+        with self.assertNoLogs("trimesh", level="WARNING"):
+            scene = g.trimesh.load(minimal_gltf(), file_type="gltf")
+        geom = next(iter(scene.geometry.values()))
+        assert g.np.allclose(geom.vertices, filled)
+
+
+if __name__ == "__main__":
+    g.trimesh.util.attach_to_log()
+    g.unittest.main()

--- a/tests/test_gltf_handlers.py
+++ b/tests/test_gltf_handlers.py
@@ -15,9 +15,9 @@ except BaseException:
 from trimesh.exchange.gltf import extensions as ext
 
 
-def minimal_gltf():
-    # one-triangle glTF whose POSITION accessor is bufferless -- a placeholder
-    # an extension is expected to fill -- and whose primitive carries a dummy extension
+def minimal_gltf(extension="TEST_dummy"):
+    # one-triangle glTF whose POSITION accessor is bufferless — a placeholder
+    # an extension is expected to fill — and whose primitive carries the extension
     indices = g.np.array([0, 1, 2], dtype=g.np.uint32).tobytes()
     uri = "data:application/octet-stream;base64," + base64.b64encode(indices).decode()
     tree = {
@@ -32,13 +32,13 @@ def minimal_gltf():
                         "attributes": {"POSITION": 0},
                         "indices": 1,
                         "mode": 4,
-                        "extensions": {"TEST_dummy": {}},
+                        "extensions": {extension: {}},
                     }
                 ]
             }
         ],
         "accessors": [
-            # bufferless -> created as placeholder zeros
+            # bufferless — created as placeholder zeros
             {"componentType": 5126, "count": 3, "type": "VEC3"},
             {"componentType": 5125, "count": 3, "type": "SCALAR", "bufferView": 0},
         ],
@@ -85,8 +85,15 @@ class GLTFHandlerTest(g.unittest.TestCase):
         assert g.np.allclose(geom.vertices, 0.0)
         assert any("TEST_dummy" in line for line in cm.output)
 
+    def test_draco_warns_by_name(self):
+        # a draco-compressed primitive with no registered decoder must
+        # warn naming the real extension
+        with self.assertLogs("trimesh", level="WARNING") as cm:
+            g.trimesh.load(minimal_gltf("KHR_draco_mesh_compression"), file_type="gltf")
+        assert any("KHR_draco_mesh_compression" in line for line in cm.output)
+
     def test_handler_fills_placeholder(self):
-        # a handler may fill the placeholder accessor in place -- a successful
+        # a handler may fill the placeholder accessor in place — a successful
         # decode must not warn
         filled = g.np.arange(9, dtype=g.np.float32).reshape((3, 3))
 

--- a/tests/test_inertia.py
+++ b/tests/test_inertia.py
@@ -103,21 +103,23 @@ def test_primitives():
         g.trimesh.primitives.Box(),
         g.trimesh.primitives.Sphere(radius=1.23),
     ]
-    for p in primitives:
-        for _i in range(100):
-            # check to make sure the analytic inertia tensors are relatively
-            # close to the meshed inertia tensor (order of magnitude and
-            # sign)
-            b = p.to_mesh()
-            comparison = g.np.abs(p.moment_inertia - b.moment_inertia)
-            c_max = comparison.max() / g.np.abs(p.moment_inertia).max()
-            assert c_max < 0.1
+    # draw inside the block: `g.random` pinned the sphere to one center
+    # so every round of its loop re-checked an identical primitive
+    with g.RandomSeed() as r:
+        for p in primitives:
+            for matrix in g.random_transforms(100, translate=0.0):
+                # check to make sure the analytic inertia tensors are relatively
+                # close to the meshed inertia tensor (order of magnitude and
+                # sign)
+                b = p.to_mesh()
+                comparison = g.np.abs(p.moment_inertia - b.moment_inertia)
+                c_max = comparison.max() / g.np.abs(p.moment_inertia).max()
+                assert c_max < 0.1
 
-            if hasattr(p.primitive, "transform"):
-                matrix = g.trimesh.transformations.random_rotation_matrix()
-                p.primitive.transform = matrix
-            elif hasattr(p.primitive, "center"):
-                p.primitive.center = g.random(3)
+                if hasattr(p.primitive, "transform"):
+                    p.primitive.transform = matrix
+                elif hasattr(p.primitive, "center"):
+                    p.primitive.center = r.random(3)
 
 
 def test_tetrahedron():

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -210,9 +210,7 @@ def test_remove_infinite_values_drops_dependent_faces():
         ],
         dtype=g.np.int64,
     )
-    mesh = g.trimesh.Trimesh(
-        vertices=vertices.copy(), faces=faces.copy(), process=True
-    )
+    mesh = g.trimesh.Trimesh(vertices=vertices.copy(), faces=faces.copy(), process=True)
 
     # the non-finite vertex is gone
     assert g.np.isfinite(mesh.vertices).all()
@@ -247,9 +245,7 @@ def test_remove_infinite_values_inf_vertex_drops_face():
         dtype=g.np.float64,
     )
     faces = g.np.array([[0, 1, 2], [0, 3, 1]], dtype=g.np.int64)
-    mesh = g.trimesh.Trimesh(
-        vertices=vertices.copy(), faces=faces.copy(), process=True
-    )
+    mesh = g.trimesh.Trimesh(vertices=vertices.copy(), faces=faces.copy(), process=True)
 
     assert g.np.isfinite(mesh.vertices).all()
     assert len(mesh.vertices) == 3

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -180,6 +180,100 @@ def test_mesh_2D():
     assert len(rend) > 1
 
 
+def test_remove_infinite_values_drops_dependent_faces():
+    # Regression test for https://github.com/mikedh/trimesh/issues/2445
+    #
+    # `remove_infinite_values` was checking `np.isfinite(self.faces)` which
+    # is always all-True (face indices are int64), so faces referencing a
+    # NaN/Inf vertex were never explicitly dropped. They then sneaked
+    # through `update_vertices`, whose inverse-index map defaults to 0
+    # for removed vertices — turning each face that touched a NaN vertex
+    # into a degenerate triangle (e.g. `[0,1,2]` -> `[0,1,0]`). Those
+    # degenerate faces crashed the renderer with `IndexError` on `mesh.show`.
+    vertices = g.np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.5, 0.5, g.np.nan],
+        ],
+        dtype=g.np.float64,
+    )
+    faces = g.np.array(
+        [
+            [0, 1, 2],
+            [1, 3, 2],
+            [0, 4, 1],
+            [1, 4, 3],
+            [3, 4, 2],
+        ],
+        dtype=g.np.int64,
+    )
+    mesh = g.trimesh.Trimesh(
+        vertices=vertices.copy(), faces=faces.copy(), process=True
+    )
+
+    # the non-finite vertex is gone
+    assert g.np.isfinite(mesh.vertices).all()
+    assert len(mesh.vertices) == 4
+
+    # the three faces that touched the NaN vertex are removed; the two
+    # entirely-finite faces survive without being remapped to degenerates
+    assert len(mesh.faces) == 2
+    # every surviving face references a valid vertex
+    assert (mesh.faces < len(mesh.vertices)).all()
+    # no surviving face is degenerate (no repeated vertex index)
+    assert (mesh.faces[:, 0] != mesh.faces[:, 1]).all()
+    assert (mesh.faces[:, 1] != mesh.faces[:, 2]).all()
+    assert (mesh.faces[:, 0] != mesh.faces[:, 2]).all()
+
+    # a scene-build round-trip should work without crashing now that the
+    # mesh contains only well-formed faces
+    scene = mesh.scene()
+    assert "geometry_0" in scene.geometry
+
+
+def test_remove_infinite_values_inf_vertex_drops_face():
+    # Companion to #2445: `np.inf` vertices should be dropped along with
+    # any face referencing them — the bug fix must cover both NaN and Inf.
+    vertices = g.np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.5, 0.5, g.np.inf],
+        ],
+        dtype=g.np.float64,
+    )
+    faces = g.np.array([[0, 1, 2], [0, 3, 1]], dtype=g.np.int64)
+    mesh = g.trimesh.Trimesh(
+        vertices=vertices.copy(), faces=faces.copy(), process=True
+    )
+
+    assert g.np.isfinite(mesh.vertices).all()
+    assert len(mesh.vertices) == 3
+    # only the all-finite face survives
+    assert len(mesh.faces) == 1
+    assert (mesh.faces < len(mesh.vertices)).all()
+
+
+def test_remove_infinite_values_no_op_on_finite_mesh():
+    # Sanity: when every vertex is finite, `remove_infinite_values` must
+    # not drop anything. Guards against an over-eager fix that would
+    # touch face counts on healthy meshes.
+    vertices = g.np.random.RandomState(0).random((40, 3))
+    # random integer faces, deduped so we don't start with degenerates
+    raw = g.np.random.RandomState(1).randint(0, 40, (50, 3))
+    faces = g.np.array([f for f in raw if len(set(f)) == 3], dtype=g.np.int64)
+
+    mesh = g.trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+    n_v, n_f = len(mesh.vertices), len(mesh.faces)
+    mesh.remove_infinite_values()
+    assert len(mesh.vertices) == n_v
+    assert len(mesh.faces) == n_f
+
+
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()
     test_mesh_2D()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -270,6 +270,33 @@ def test_remove_infinite_values_no_op_on_finite_mesh():
     assert len(mesh.faces) == n_f
 
 
+def test_remove_infinite_values_edge_shapes():
+    # the guards live inside `update_faces` (early-returns on empty
+    # meshes and all-true masks) so degenerate shapes must work
+    empty = g.trimesh.Trimesh()
+    empty.remove_infinite_values()
+    assert len(empty.vertices) == 0
+    assert len(empty.faces) == 0
+
+    # NaN vertex with no faces at all is still removed
+    cloud = g.trimesh.Trimesh(
+        vertices=[[0.0, 0.0, 0.0], [g.np.nan, 0.0, 0.0]], process=False
+    )
+    cloud.remove_infinite_values()
+    assert len(cloud.vertices) == 1
+    assert g.np.isfinite(cloud.vertices).all()
+
+    # a NaN vertex referenced by no face drops no faces
+    mesh = g.trimesh.Trimesh(
+        vertices=[[0, 0, 0], [1, 0, 0], [0, 1, 0], [g.np.nan, 0, 0]],
+        faces=[[0, 1, 2]],
+        process=False,
+    )
+    mesh.remove_infinite_values()
+    assert len(mesh.vertices) == 3
+    assert mesh.faces.tolist() == [[0, 1, 2]]
+
+
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()
     test_mesh_2D()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -170,7 +170,7 @@ def test_meshes():
 def test_mesh_2D():
     # check a simple mesh with 2D vertices
     m = g.trimesh.Trimesh(
-        vertices=g.np.random.random((100, 2)),
+        vertices=g.random((100, 2)),
         faces=g.np.arange(99, dtype=g.np.int64).reshape((-1, 3)),
     )
     # the face normals should be 3D (+Z)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -26,7 +26,10 @@ class MetaTest(g.unittest.TestCase):
             # note that JSON doesn't support integers as keys
             # so convert integers to strings for comparison
             m.metadata.update(
-                g.np.random.randint(0, 1000, 10).reshape((-1, 2)).astype(str)
+                g.np.random.default_rng(seed=0)
+                .integers(0, 1000, 10)
+                .reshape((-1, 2))
+                .astype(str)
             )
 
         # reload the exported scene

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -140,23 +140,27 @@ class MutateTests(g.unittest.TestCase):
         _ = mesh.face_adjacency_tree
         _ = mesh.copy()
 
+        # draw from a stream: `g.random` returns the same array for the
+        # same shape, which made every `origins` and `normals` pair identical
+        with g.RandomSeed() as r:
+            ray_origins = r.random((100, 3)) * 1000
+            points = r.random((500, 3)) * 100
+            section_count = 20
+            origins = r.random((section_count, 3)) * 100
+            normals = r.random((section_count, 3)) * 100
+            heights = r.random((10,)) * 100
+
         # ray.intersects_id
         centre = mesh.vertices.mean(axis=0)
-        origins = g.random((100, 3)) * 1000
-        directions = g.np.copy(origins)
+        directions = g.np.copy(ray_origins)
         directions[:50, :] -= centre
         directions[50:, :] += centre
-        mesh.ray.intersects_id(origins, directions)
+        mesh.ray.intersects_id(ray_origins, directions)
 
         # nearest.vertex
-        points = g.random((500, 3)) * 100
         mesh.nearest.vertex(points)
 
         # section
-        section_count = 20
-        origins = g.random((section_count, 3)) * 100
-        normals = g.random((section_count, 3)) * 100
-        heights = g.random((10,)) * 100
         for o, n in zip(origins, normals):
             # try slicing at random origin and at center mass
             mesh.slice_plane(o, n)

--- a/tests/test_nsphere.py
+++ b/tests/test_nsphere.py
@@ -21,21 +21,24 @@ class NSphereTest(g.unittest.TestCase):
             assert s.volume > (m.volume - tol_fit)
 
         # check minimum n-sphere for points in 2, 3, 4 dimensions
-        for d in [2, 3, 4]:
-            for _i in range(5):
-                points = g.random((100, d))
-                C, R = g.trimesh.nsphere.minimum_nsphere(points)
-                R_check = ((points - C) ** 2).sum(axis=1).max() ** 0.5
-                assert len(C) == d
-                assert R > 0.0
-                assert abs(R - R_check) < g.tol.merge
+        # draw inside the block: `g.random` gave every iteration the same
+        # cloud so this fit one sphere five times per dimension
+        with g.RandomSeed() as r:
+            for d in [2, 3, 4]:
+                for _i in range(5):
+                    points = r.random((100, d))
+                    C, R = g.trimesh.nsphere.minimum_nsphere(points)
+                    R_check = ((points - C) ** 2).sum(axis=1).max() ** 0.5
+                    assert len(C) == d
+                    assert R > 0.0
+                    assert abs(R - R_check) < g.tol.merge
 
     def test_isnsphere(self):
         # make sure created spheres are uv sphere
         m = g.trimesh.creation.uv_sphere()
         # move the mesh around for funsies
         m.apply_translation(g.random(3))
-        m.apply_transform(g.trimesh.transformations.random_rotation_matrix())
+        m.apply_transform(next(g.random_transforms(1, translate=0.0)))
         # all vertices should be on nsphere
         assert g.trimesh.nsphere.is_nsphere(m.vertices)
 

--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -185,13 +185,14 @@ class PackingTest(g.unittest.TestCase):
         )
 
         density = []
-        with g.Profiler() as P:
-            for i in range(10):
-                # roll the extents by a random amount and offset
-                extents = []
-                for i in ori:
-                    extents.append(g.np.roll(i, int(g.random() * 10)) + g.random(3))
-                extents = g.np.array(extents)
+        with g.Profiler() as P, g.RandomSeed() as r:
+            for _i in range(10):
+                # roll the extents by a random amount and offset: drawing
+                # from `g.random` rolled every rectangle by the same 4 and
+                # offset them all identically on every iteration
+                extents = g.np.array(
+                    [g.np.roll(rect, int(r.random() * 10)) + r.random(3) for rect in ori]
+                )
 
                 bounds, consume = packing.rectangles(extents)
                 # should have inserted everything because we didn't specify

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -92,54 +92,52 @@ def test_vertex_only():
 
 
 def test_plane():
-    # make sure plane fitting works for 2D points in space
-    for _i in range(10):
-        # create a random rotation
-        matrix = g.trimesh.transformations.random_rotation_matrix()
-        # create some random points in spacd
-        p = g.random((1000, 3))
-        # make them all lie on the XY plane so we know
-        # the correct normal to check against
-        p[:, 2] = 0
-        # transform them into random frame
-        p = g.trimesh.transform_points(p, matrix)
-        # we made the Z values zero before transforming
-        # so the true normal should be Z then rotated
-        truth = g.trimesh.transform_points([[0, 0, 1]], matrix, translate=False)[0]
-        # run the plane fit
-        _C, N = g.trimesh.points.plane_fit(p)
-        # sign of normal is arbitrary on fit so check both
-        assert g.np.allclose(truth, N) or g.np.allclose(truth, -N)
-    # make sure plane fit works with multiple point sets at once
-    nb_points_sets = 20
-    for _i in range(10):
-        # create a random rotation
-        matrices = [
-            g.trimesh.transformations.random_rotation_matrix()
-            for _ in range(nb_points_sets)
-        ]
-        # create some random points in spacd
-        p = g.random((nb_points_sets, 1000, 3))
-        # make them all lie on the XY plane so we know
-        # the correct normal to check against
-        p[..., 2] = 0
-        # transform them into random frame
-        for j, matrix in enumerate(matrices):
-            p[j, ...] = g.trimesh.transform_points(p[j, ...], matrix)
-        # p = g.trimesh.transform_points(p, matrix)
-        # we made the Z values zero before transforming
-        # so the true normal should be Z then rotated
-        truths = g.np.zeros((len(p), 3))
-        for j, matrix in enumerate(matrices):
-            truths[j, :] = g.trimesh.transform_points(
-                [[0, 0, 1]], matrix, translate=False
-            )[0]
-        # run the plane fit
-        _C, N = g.trimesh.points.plane_fit(p)
+    # draw inside the block: `g.random` would hand every iteration the
+    # same points, so each loop below only ever fit one point cloud
+    with g.RandomSeed() as r:
+        # make sure plane fitting works for 2D points in space
+        for matrix in g.random_transforms(10, translate=0.0):
+            # create some random points in spacd
+            p = r.random((1000, 3))
+            # make them all lie on the XY plane so we know
+            # the correct normal to check against
+            p[:, 2] = 0
+            # transform them into random frame
+            p = g.trimesh.transform_points(p, matrix)
+            # we made the Z values zero before transforming
+            # so the true normal should be Z then rotated
+            truth = g.trimesh.transform_points([[0, 0, 1]], matrix, translate=False)[0]
+            # run the plane fit
+            _C, N = g.trimesh.points.plane_fit(p)
+            # sign of normal is arbitrary on fit so check both
+            assert g.np.allclose(truth, N) or g.np.allclose(truth, -N)
 
-        # sign of normal is arbitrary on fit so check both
-        cosines = g.np.einsum("ij,ij->i", N, truths)
-        assert g.np.allclose(g.np.abs(cosines), g.np.ones_like(cosines))
+        # make sure plane fit works with multiple point sets at once
+        nb_points_sets = 20
+        for i in range(10):
+            # vary the rotations per iteration as well as the points
+            matrices = list(g.random_transforms(nb_points_sets, translate=0.0, seed=i))
+            # create some random points in spacd
+            p = r.random((nb_points_sets, 1000, 3))
+            # make them all lie on the XY plane so we know
+            # the correct normal to check against
+            p[..., 2] = 0
+            # transform them into random frame
+            for j, matrix in enumerate(matrices):
+                p[j, ...] = g.trimesh.transform_points(p[j, ...], matrix)
+            # we made the Z values zero before transforming
+            # so the true normal should be Z then rotated
+            truths = g.np.zeros((len(p), 3))
+            for j, matrix in enumerate(matrices):
+                truths[j, :] = g.trimesh.transform_points(
+                    [[0, 0, 1]], matrix, translate=False
+                )[0]
+            # run the plane fit
+            _C, N = g.trimesh.points.plane_fit(p)
+
+            # sign of normal is arbitrary on fit so check both
+            cosines = g.np.einsum("ij,ij->i", N, truths)
+            assert g.np.allclose(g.np.abs(cosines), g.np.ones_like(cosines))
 
 
 def test_kmeans(cluster_count=5, points_per_cluster=100):
@@ -156,7 +154,9 @@ def test_kmeans(cluster_count=5, points_per_cluster=100):
     clustered = g.np.vstack(clustered)
 
     # run k- means clustering on our nicely separated data
-    centroids, klabel = g.trimesh.points.k_means(points=clustered, k=cluster_count)
+    centroids, klabel = g.trimesh.points.k_means(
+        points=clustered, k=cluster_count, seed=0
+    )
 
     # reshape to make sure all groups have the same index
     variance = g.np.ptp(klabel.reshape((cluster_count, points_per_cluster)), axis=1)
@@ -169,21 +169,24 @@ def test_tsp():
     """
     Test our solution for visiting every point in order.
     """
-    for dimension in [2, 3]:
-        for count in [2, 10, 100]:
-            for _i in range(10):
-                points = g.random((count, dimension))
+    # draw inside the block: `g.random` gave every iteration the same
+    # points so this solved one tour ten times per shape
+    with g.RandomSeed() as r:
+        for dimension in [2, 3]:
+            for count in [2, 10, 100]:
+                for _i in range(10):
+                    points = r.random((count, dimension))
 
-                # find a path that visits every point quickly
-                idx, dist = g.trimesh.points.tsp(points, start=0)
+                    # find a path that visits every point quickly
+                    idx, dist = g.trimesh.points.tsp(points, start=0)
 
-                # indexes should visit every point exactly once
-                assert set(idx) == set(range(len(points)))
-                assert len(idx) == len(points)
-                assert len(dist) == len(points) - 1
+                    # indexes should visit every point exactly once
+                    assert set(idx) == set(range(len(points)))
+                    assert len(idx) == len(points)
+                    assert len(dist) == len(points) - 1
 
-                # shouldn't be any negative indexes
-                assert (idx >= 0).all()
+                    # shouldn't be any negative indexes
+                    assert (idx >= 0).all()
 
                 # make sure distances returned are correct
                 dist_check = g.np.linalg.norm(g.np.diff(points[idx], axis=0), axis=1)
@@ -291,7 +294,7 @@ def test_radial_sort():
     points *= g.random(len(theta)).reshape((-1, 1))
 
     # apply a random order to the points
-    order = g.np.random.permutation(g.np.arange(len(points)))
+    order = g.np.random.default_rng(seed=0).permutation(g.np.arange(len(points)))
 
     # get the sorted version of these points
     # when we pass them the randomly ordered points

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -332,10 +332,12 @@ def test_polygons_full_none():
         entities=[g.trimesh.path.entities.Line([0, 1])],
         vertices=g.np.array([[0.0, 0.0], [1.0, 1.0]]),
     )
-    # used to raise AttributeError on the `None` root
+    # used to raise AttributeError on the `None` root; correspondence
+    # with `self.root` is preserved (unrecoverable entry stays `None`)
     full = path.polygons_full
-    assert len(full) == 1
-    assert g.np.isclose(full[0].area, square.area)
+    assert len(full) == len(path.root) == 2
+    assert full[0] is None
+    assert g.np.isclose(full[1].area, square.area)
 
 
 if __name__ == "__main__":

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -43,7 +43,7 @@ def test_random_polygon():
     """
     Test creation of random polygons
     """
-    p = g.trimesh.path.polygons.random_polygon()
+    p = g.trimesh.path.polygons.random_polygon(seed=0)
     assert p.area > 0.0
     assert p.is_valid
 
@@ -56,7 +56,7 @@ def test_polygon_sample():
     p = g.Point([0, 0]).buffer(1.0)
     count = 100
 
-    s = g.trimesh.path.polygons.sample(p, count=count)
+    s = g.trimesh.path.polygons.sample(p, count=count, seed=0)
     assert len(s) <= count
     assert s.shape[1] == 2
 
@@ -87,7 +87,7 @@ def test_polygon_sample():
     # try a polygon with a low area/aabb-area ratio to
     # check the iteration loop.
     p = g.Polygon([[0, 0], [1, 1], [0.5 - 1e-3, 0.5], [0, 0]])
-    s = g.trimesh.path.polygons.sample(polygon=p, count=100)
+    s = g.trimesh.path.polygons.sample(polygon=p, count=100, seed=0)
 
 
 def test_project():

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -275,6 +275,69 @@ def test_native_centroid():
         assert g.np.isclose(abs(area), p.area)
 
 
+def test_enclosure_tree_none():
+    # `paths_to_polygons` documents that unrecoverable geometry
+    # produces `None` entries: `enclosure_tree` should never emit
+    # a `None` polygon as a root curve
+    # a closed "loop" with fewer than 4 vertices can not have
+    # nonzero area and is documented to produce `None`
+    degenerate = g.np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 0.0]])
+    polys = g.trimesh.path.polygons.paths_to_polygons([degenerate])
+    assert len(polys) == 1
+    assert polys[0] is None
+
+    # single-polygon early exit used to return `roots=[0]` here
+    # which crashed `Path2D.polygons_full` with
+    # `'NoneType' object has no attribute 'exterior'`
+    roots, contains = g.trimesh.path.polygons.enclosure_tree(polys)
+    assert len(roots) == 0
+    assert len(contains.nodes) == 0
+
+    # multi-polygon path: `None` alongside a valid polygon
+    # is excluded by the bounds check
+    square = g.np.array(
+        [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0], [0.0, 0.0]]
+    )
+    polys = g.trimesh.path.polygons.paths_to_polygons([degenerate, square])
+    roots, contains = g.trimesh.path.polygons.enclosure_tree(polys)
+    assert list(roots) == [1]
+
+
+def test_polygons_full_none():
+    # `Path2D.polygons_full` should skip root curves whose closed
+    # polygon could not be recovered instead of raising
+    # AttributeError on `None.exterior`. Simulate what
+    # `mesh.section` produces in the wild for a degenerate slice:
+    # `polygons_closed` containing `None` (documented behavior of
+    # `paths_to_polygons`) alongside a valid polygon.
+    square = g.Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+
+    class _Degenerate(g.trimesh.path.Path2D):
+        # simulate one recovered and one unrecoverable circuit
+        @property
+        def polygons_closed(self):
+            return g.np.array([None, square], dtype=object)
+
+        @property
+        def root(self):
+            return [0, 1]
+
+        @property
+        def enclosure_directed(self):
+            graph = g.nx.DiGraph()
+            graph.add_nodes_from([0, 1])
+            return graph
+
+    path = _Degenerate(
+        entities=[g.trimesh.path.entities.Line([0, 1])],
+        vertices=g.np.array([[0.0, 0.0], [1.0, 1.0]]),
+    )
+    # used to raise AttributeError on the `None` root
+    full = path.polygons_full
+    assert len(full) == 1
+    assert g.np.isclose(full[0].area, square.area)
+
+
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()
     test_polygon_sample()

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -295,9 +295,7 @@ def test_enclosure_tree_none():
 
     # multi-polygon path: `None` alongside a valid polygon
     # is excluded by the bounds check
-    square = g.np.array(
-        [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0], [0.0, 0.0]]
-    )
+    square = g.np.array([[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0], [0.0, 0.0]])
     polys = g.trimesh.path.polygons.paths_to_polygons([degenerate, square])
     roots, contains = g.trimesh.path.polygons.enclosure_tree(polys)
     assert list(roots) == [1]

--- a/tests/test_poses.py
+++ b/tests/test_poses.py
@@ -9,7 +9,7 @@ class PosesTest(g.unittest.TestCase):
         mesh = g.trimesh.creation.icosahedron()
 
         # Compute the stable poses of the icosahedron
-        trans, probs = mesh.compute_stable_poses()
+        trans, probs = mesh.compute_stable_poses(seed=0)
 
         # Probabilities should all be 0.05 (20 faces)
         self.assertTrue(g.np.allclose(g.np.array(probs) - 0.05, 0.0))
@@ -29,7 +29,7 @@ class PosesTest(g.unittest.TestCase):
                 copied.apply_transform(matrix)
 
                 # Compute the stable poses of the icosahedron
-                _trans, probs = copied.compute_stable_poses()
+                _trans, probs = copied.compute_stable_poses(seed=0)
 
                 # we are only testing primitives with point symmetry
                 # AKA 3 principal components of inertia are the same
@@ -43,8 +43,8 @@ class PosesTest(g.unittest.TestCase):
     def test_round(self):
         mesh = g.trimesh.primitives.Cylinder(radius=1.0, height=10.0)
 
-        _transforms, _probabilities = mesh.compute_stable_poses()
-        _transforms, _probabilities = mesh.compute_stable_poses(n_samples=10)
+        _transforms, _probabilities = mesh.compute_stable_poses(seed=0)
+        _transforms, _probabilities = mesh.compute_stable_poses(n_samples=10, seed=0)
 
 
 if __name__ == "__main__":

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -50,7 +50,7 @@ def generate_primitives():
     primitives.append(
         g.trimesh.primitives.Box(
             extents=[10, 20, 30],
-            transform=g.trimesh.transformations.random_rotation_matrix(),
+            transform=next(g.random_transforms(1, translate=0.0)),
         )
     )
 
@@ -106,7 +106,7 @@ def test_scaling():
         perm[1].primitive.transform = g.tf.translation_matrix([0, 0, 7])
         perm[2].apply_transform(g.tf.rotation_matrix(g.np.pi / 4, [0, 0, 1]))
         # try with a gnarly rotation
-        perm[3].primitive.transform = g.tf.random_rotation_matrix(translate=1000)
+        perm[3].primitive.transform = next(g.random_transforms(1, translate=1000))
 
         fields = set(dir(original.primitive))
         ori_radius, ori_height = None, None
@@ -225,7 +225,7 @@ def test_primitives():
 
 
 def test_sample():
-    transform = g.trimesh.transformations.random_rotation_matrix()
+    transform = next(g.random_transforms(1, translate=0.0))
     box = g.trimesh.primitives.Box(transform=transform, extents=[20, 10, 100])
     for kwargs in [
         {"step": 8},
@@ -264,7 +264,7 @@ def test_cyl_buffer():
     c = g.trimesh.primitives.Cylinder(
         radius=1.0,
         height=10.0,
-        transform=g.trimesh.transformations.random_rotation_matrix(),
+        transform=next(g.random_transforms(1, translate=0.0)),
     )
     # inflate cylinder
     b = c.buffer(1.0)

--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -1,4 +1,3 @@
-
 try:
     from . import generic as g
 except BaseException:
@@ -215,7 +214,6 @@ class NearestTest(g.unittest.TestCase):
             process=False,
         )
         points = g.np.array([[0.2, 0.2, 0.5], [0.2, 0.2, 0.5]], dtype=g.np.float32)
-        tree = mesh.triangles_tree
 
         expected = g.trimesh.proximity.nearby_faces(mesh, points)
         assert g.np.allclose(expected, [[0, 1], [0, 1]])

--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -232,7 +232,8 @@ class NearestTest(g.unittest.TestCase):
                 mock.patch.object(tree, method, wraps=getattr(tree, method)) as query,
             ):
                 actual = g.trimesh.proximity.nearby_faces(mesh, points)
-            assert actual == expected
+            assert len(actual) == len(expected)
+            assert all(g.np.array_equal(a, e) for a, e in zip(actual, expected))
             assert query.call_count == (1 if method == "intersection_v" else len(points))
 
     def test_candidates_empty(self):

--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -1,4 +1,3 @@
-from unittest import mock
 
 try:
     from . import generic as g
@@ -218,23 +217,8 @@ class NearestTest(g.unittest.TestCase):
         points = g.np.array([[0.2, 0.2, 0.5], [0.2, 0.2, 0.5]], dtype=g.np.float32)
         tree = mesh.triangles_tree
 
-        with mock.patch.object(g.trimesh.proximity, "_rtree_version", (1, 3, 0)):
-            expected = g.trimesh.proximity.nearby_faces(mesh, points)
-        assert expected == [[0, 1], [0, 1]]
-
-        for version, method in [
-            ((1, 4, 1), "intersection_v"),
-            ((1, 4, 0), "intersection"),
-            ((1, 3, 0), "intersection"),
-        ]:
-            with (
-                mock.patch.object(g.trimesh.proximity, "_rtree_version", version),
-                mock.patch.object(tree, method, wraps=getattr(tree, method)) as query,
-            ):
-                actual = g.trimesh.proximity.nearby_faces(mesh, points)
-            assert len(actual) == len(expected)
-            assert all(g.np.array_equal(a, e) for a, e in zip(actual, expected))
-            assert query.call_count == (1 if method == "intersection_v" else len(points))
+        expected = g.trimesh.proximity.nearby_faces(mesh, points)
+        assert g.np.allclose(expected, [[0, 1], [0, 1]])
 
     def test_candidates_empty(self):
         # an empty (0, 3) query set must return an empty list of candidates
@@ -242,7 +226,7 @@ class NearestTest(g.unittest.TestCase):
         candidates = g.trimesh.proximity.nearby_faces(
             mesh=mesh, points=g.np.zeros((0, 3))
         )
-        assert candidates == []
+        assert len(candidates) == 0
 
     def test_returns_correct_point_in_ambiguous_cases(self):
         mesh = g.trimesh.Trimesh(

--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 try:
     from . import generic as g
 except BaseException:
@@ -206,6 +208,40 @@ class NearestTest(g.unittest.TestCase):
         mesh = g.trimesh.creation.random_soup(2000)
         points = g.random((2000, 3))
         g.trimesh.proximity.nearby_faces(mesh=mesh, points=points)
+
+    def test_candidates_rtree_versions(self):
+        mesh = g.trimesh.Trimesh(
+            vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            faces=[[0, 1, 2], [0, 1, 2]],
+            process=False,
+        )
+        points = g.np.array([[0.2, 0.2, 0.5], [0.2, 0.2, 0.5]], dtype=g.np.float32)
+        tree = mesh.triangles_tree
+
+        with mock.patch.object(g.trimesh.proximity, "_rtree_version", (1, 3, 0)):
+            expected = g.trimesh.proximity.nearby_faces(mesh, points)
+        assert expected == [[0, 1], [0, 1]]
+
+        for version, method in [
+            ((1, 4, 1), "intersection_v"),
+            ((1, 4, 0), "intersection"),
+            ((1, 3, 0), "intersection"),
+        ]:
+            with (
+                mock.patch.object(g.trimesh.proximity, "_rtree_version", version),
+                mock.patch.object(tree, method, wraps=getattr(tree, method)) as query,
+            ):
+                actual = g.trimesh.proximity.nearby_faces(mesh, points)
+            assert actual == expected
+            assert query.call_count == (1 if method == "intersection_v" else len(points))
+
+    def test_candidates_empty(self):
+        # an empty (0, 3) query set must return an empty list of candidates
+        mesh = g.trimesh.creation.box()
+        candidates = g.trimesh.proximity.nearby_faces(
+            mesh=mesh, points=g.np.zeros((0, 3))
+        )
+        assert candidates == []
 
     def test_returns_correct_point_in_ambiguous_cases(self):
         mesh = g.trimesh.Trimesh(

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -53,7 +53,7 @@ class RasterTest(g.unittest.TestCase):
         theta = g.np.linspace(0, g.np.pi * 2, 100)
         unit = g.np.column_stack((g.np.cos(theta), g.np.sin(theta)))
         radii = g.np.linspace(1.0, 10.0, 10)
-        g.np.random.shuffle(radii)
+        g.np.random.default_rng(seed=0).shuffle(radii)
         paths = []
         for R in radii:
             paths.append(g.trimesh.load_path(R * unit))

--- a/tests/test_ray_upstream.py
+++ b/tests/test_ray_upstream.py
@@ -160,8 +160,8 @@ def test_issue_1898_locations_colinear_with_directions():
     # rays fired from (0,0,-5) with small angular jitter — with a
     # unit-radius sphere at origin the half-angle to graze is ~11.3°,
     # so a jitter of 0.05 in XY (about ±3°) stays well inside that cone
-    rng = np.random.RandomState(seed=1)
-    jitter = (rng.random_sample((8, 3)) - 0.5) * 0.1
+    random = np.random.RandomState(seed=1)
+    jitter = (random.random_sample((8, 3)) - 0.5) * 0.1
     directions = trimesh.unitize(jitter + [[0, 0, 1]])
     origins = np.tile([[0.0, 0.0, -5.0]], (len(directions), 1))
 
@@ -400,9 +400,9 @@ def test_issue_1919_engines_agree_simple_mesh():
     The embree and native (pure-Python) ray backends disagreed on
     `intersects_any` for random rays through a simple convex mesh."""
     mesh = trimesh.creation.icosphere(subdivisions=2)
-    rng = np.random.default_rng(0)
-    origins = (rng.random((200, 3)) - 0.5) * 5
-    directions = trimesh.unitize(rng.random((200, 3)) - 0.5)
+    random = np.random.default_rng(0)
+    origins = (random.random((200, 3)) - 0.5) * 5
+    directions = trimesh.unitize(random.random((200, 3)) - 0.5)
 
     embree_hits = ray_pyembree.RayMeshIntersector(mesh).intersects_any(
         origins, directions
@@ -426,9 +426,9 @@ def test_issue_1180_first_hit_arrays_aligned():
     # we scale down to keep CI fast but cover the 1024 boundary
     for ray_count in [1023, 1024, 1025, 2048, 10000]:
         origins = np.tile([[0.0, 0.0, -5.0]], (ray_count, 1))
-        rng = np.random.default_rng(ray_count)
+        random = np.random.default_rng(ray_count)
         # direction jitter offset so the mean is roughly +z toward sphere
-        directions = trimesh.unitize(rng.random((ray_count, 3)) - [0.5, 0.5, -0.2])
+        directions = trimesh.unitize(random.random((ray_count, 3)) - [0.5, 0.5, -0.2])
 
         locations, index_ray, index_tri = mesh.ray.intersects_location(
             origins, directions, multiple_hits=False
@@ -443,9 +443,9 @@ def test_issue_1786_contains_stable_over_many_calls():
     `mesh.contains` drifted after many calls in a loop — the reporter
     saw results change after a few million queries."""
     mesh = trimesh.creation.icosphere()
-    rng = np.random.default_rng(0)
+    random = np.random.default_rng(0)
     # 256 points in [-0.5, 0.5] — all strictly inside the unit sphere
-    points = rng.random((256, 3)) - 0.5
+    points = random.random((256, 3)) - 0.5
 
     first = mesh.contains(points)
     # all points are strictly inside, so `first` must be all-True,

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -148,6 +148,35 @@ class RegistrationTest(g.unittest.TestCase):
         _matrix, _transformed, cost = g.trimesh.registration.icp(X, m, scale=False)
         assert cost < 0.01
 
+    def test_mesh_other_no_reflection(self):
+        # regression test for #2482: `mesh_other` seeds ICP with sign-flip
+        # initial transforms, half of which are reflections. With
+        # `reflection=False` those reflected seeds could still win and return
+        # a transform with a negative determinant (i.e. a reflection).
+        a = g.get_mesh("featuretype.STL")
+
+        # build a mirrored, inside-out copy of `a`
+        b = a.copy()
+        b.apply_transform(g.trimesh.transformations.rotation_matrix(0.9, [0.3, 0.6, 0.2]))
+        b.apply_transform(g.np.diag([-1.0, -1.0, 1.0, 1.0]))
+        b.vertices[:, 1] *= -1.0
+
+        # with reflection disabled the result must be a proper rotation
+        for seed in range(3):
+            g.np.random.seed(seed)
+            matrix, _cost = g.trimesh.registration.mesh_other(
+                a, b, samples=500, reflection=False, scale=False
+            )
+            assert g.np.linalg.det(matrix[:3, :3]) > 0
+
+        # with reflection enabled it is still allowed to use a reflection
+        # to fit the mirrored mesh
+        g.np.random.seed(0)
+        matrix, _cost = g.trimesh.registration.mesh_other(
+            a, b, samples=500, reflection=True, scale=False
+        )
+        assert g.np.linalg.det(matrix[:3, :3]) < 0
+
     def test_icp_points(self):
         # see if ICP alignment works with point clouds
         # create random points in space

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -163,17 +163,15 @@ class RegistrationTest(g.unittest.TestCase):
 
         # with reflection disabled the result must be a proper rotation
         for seed in range(3):
-            g.np.random.seed(seed)
             matrix, _cost = g.trimesh.registration.mesh_other(
-                a, b, samples=500, reflection=False, scale=False
+                a, b, samples=500, reflection=False, scale=False, seed=seed
             )
             assert g.np.linalg.det(matrix[:3, :3]) > 0
 
         # with reflection enabled it is still allowed to use a reflection
         # to fit the mirrored mesh
-        g.np.random.seed(0)
         matrix, _cost = g.trimesh.registration.mesh_other(
-            a, b, samples=500, reflection=True, scale=False
+            a, b, samples=500, reflection=True, scale=False, seed=0
         )
         assert g.np.linalg.det(matrix[:3, :3]) < 0
 
@@ -189,7 +187,7 @@ class RegistrationTest(g.unittest.TestCase):
 
         # take a few randomly chosen points and make
         # sure the order is permutated
-        index = g.np.random.choice(g.np.arange(len(points_a)), 20)
+        index = g.np.random.default_rng(seed=0).choice(g.np.arange(len(points_a)), 20)
         # transform and apply index
         points_b = g.trimesh.transform_points(points_a[index], matrix)
         # tun the solver
@@ -211,8 +209,7 @@ class RegistrationTest(g.unittest.TestCase):
         # apply tessellation and random noise
         mesh = mesh.permutate.noise(noise)
         # randomly rotation with translation
-        transform = g.trimesh.transformations.random_rotation_matrix()
-        transform[:3, 3] = (g.random(3) - 0.5) * 1000
+        transform = next(g.random_transforms(1, translate=1000))
 
         mesh.apply_transform(transform)
 
@@ -234,7 +231,8 @@ class RegistrationTest(g.unittest.TestCase):
 
         # try our registration with points
         points = g.trimesh.transform_points(
-            scan.sample(100), matrix=g.trimesh.transformations.random_rotation_matrix()
+            scan.sample(100, seed=0),
+            matrix=next(g.random_transforms(1, translate=0.0)),
         )
         truth_to_points, _cost = truth.register(points)
         truth.apply_transform(truth_to_points)

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -81,6 +81,19 @@ class SubDivideTest(g.unittest.TestCase):
             )
             assert check.faces.shape == m.faces.shape
 
+    def test_subdivide_iterations(self):
+        # subdivide should run exactly `iterations` times
+        # https://github.com/mikedh/trimesh/issues/2575
+        m = g.trimesh.creation.box()
+
+        # each subdivision replaces every face with 4 smaller faces
+        for iterations in range(1, 4):
+            s = m.subdivide(iterations=iterations)
+            assert len(s.faces) == len(m.faces) * 4**iterations
+
+        # passing iterations=1 should match the default single subdivision
+        assert m.subdivide(iterations=1).faces.shape == m.subdivide().faces.shape
+
     def test_sub(self):
         # try on some primitives
         meshes = [g.trimesh.creation.box(), g.trimesh.creation.icosphere()]

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,7 +1,127 @@
+import asyncio
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
 try:
     from . import generic as g
 except BaseException:
     import generic as g
+
+# canned response body for the local web server
+CANNED = b"hello resolver"
+
+
+@pytest.fixture(scope="module")
+def local_url():
+    # a local server so session handling is tested end-to-end
+    # against the real clients without touching the network
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if "missing" in self.path:
+                self.send_error(404)
+            elif "redirect" in self.path:
+                # exercises the redirect kwarg each library names differently
+                self.send_response(302)
+                self.send_header("Location", "/models/thing.obj")
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(CANNED)))
+                self.end_headers()
+                self.wfile.write(CANNED)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{server.server_port}/models/thing.obj"
+    server.shutdown()
+
+
+def test_filepath_allow_anywhere(tmp_path):
+    # a model in `root/sub` referencing `../outside.txt`
+    outside = b"outside the root"
+    (tmp_path / "outside.txt").write_bytes(outside)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "inside.txt").write_bytes(CANNED)
+
+    resolver = g.trimesh.resolvers.FilePathResolver(str(sub))
+    assert resolver.get("inside.txt") == CANNED
+    # escaping paths are blocked by default with an actionable message
+    with pytest.raises(ValueError, match="allow_anywhere"):
+        resolver.get("../outside.txt")
+    with pytest.raises(ValueError, match="allow_anywhere"):
+        resolver.write("../evil.txt", b"nope")
+
+    # the flag restores the pre-5.0 behavior
+    anywhere = g.trimesh.resolvers.FilePathResolver(str(sub), allow_anywhere=True)
+    assert anywhere.get("../outside.txt") == outside
+    anywhere.write("../written.txt", b"fine")
+    assert (tmp_path / "written.txt").read_bytes() == b"fine"
+
+    # namespaced resolvers keep the flag
+    (sub / "deeper").mkdir()
+    assert anywhere.namespaced("deeper").allow_anywhere
+    assert not resolver.namespaced("deeper").allow_anywhere
+
+    # a genuinely missing file must not mention the policy
+    with pytest.raises(FileNotFoundError) as excinfo:
+        resolver.get("nope.txt")
+    assert "allow_anywhere" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("library", ["httpx", "requests"])
+def test_web_sessions(local_url, library):
+    # every supported session flavor must fetch through the same path
+    lib = pytest.importorskip(library)
+    session = lib.Client() if library == "httpx" else lib.Session()
+
+    resolver = g.trimesh.resolvers.WebResolver(local_url, session=session)
+    # fetch twice — catches clients that break on connection reuse
+    assert resolver.get("thing.mtl") == CANNED
+    assert resolver.get("thing.mtl") == CANNED
+    assert resolver.get_base() == CANNED
+    # both libraries must follow redirects
+    assert resolver.get("redirect.mtl") == CANNED
+    # a missing asset raises the session's own http error
+    with pytest.raises(Exception, match="404"):
+        resolver.get("missing.mtl")
+
+
+def test_web_session_duck(local_url):
+    # a duck-typed session must be called with no assumed kwargs
+    class Response:
+        status_code = 200
+        content = CANNED
+
+        def raise_for_status(self):
+            pass
+
+    class Duck:
+        def get(self, url):
+            return Response()
+
+    resolver = g.trimesh.resolvers.WebResolver(local_url, session=Duck())
+    assert resolver.request_kwargs == {}
+    assert resolver.get("thing.mtl") == CANNED
+
+
+def test_web_session_aiohttp(local_url):
+    # aiohttp sessions only construct inside a running event loop and
+    # bind to it, so the resolver must reject them loud and early
+    aiohttp = pytest.importorskip("aiohttp")
+
+    async def check():
+        session = aiohttp.ClientSession()
+        with pytest.raises(ValueError, match="aiohttp"):
+            g.trimesh.resolvers.WebResolver(local_url, session=session)
+        await session.close()
+
+    asyncio.run(check())
 
 
 class ResolverTest(g.unittest.TestCase):

--- a/tests/test_runlength.py
+++ b/tests/test_runlength.py
@@ -8,17 +8,11 @@ np = g.np
 
 
 def random_rle_encoding(n=20, max_value=255, dtype=np.uint8):
-    return (
-        np.random.uniform(
-            size=(n,),
-        )
-        * (max_value - 1)
-        + 1
-    ).astype(np.uint8)
+    return (g.random((n,)) * (max_value - 1) + 1).astype(np.uint8)
 
 
 def random_brle_encoding(n=20, max_value=255, dtype=np.uint8):
-    return (np.random.uniform(size=(n,)) * (max_value - 1) + 1).astype(dtype)
+    return (g.random((n,)) * (max_value - 1) + 1).astype(dtype)
 
 
 class RleTest(g.unittest.TestCase):
@@ -26,7 +20,7 @@ class RleTest(g.unittest.TestCase):
 
     def test_rle_encode_decode(self):
         small = np.array([3] * 500 + [5] * 1000 + [2], dtype=np.uint8)
-        rand = (np.random.uniform(size=(10000,)) > 0.05).astype(np.uint8)
+        rand = (g.random((10000,)) > 0.05).astype(np.uint8)
         for original in [small, rand]:
             for dtype in [np.uint8, np.int64]:
                 enc = rl.dense_to_rle(original, dtype=dtype)
@@ -81,7 +75,7 @@ class RleTest(g.unittest.TestCase):
 
     def test_brle_encode_decode(self):
         small = np.array([False] * 500 + [True] * 1000 + [False], dtype=bool)
-        rand = np.random.uniform(size=(10000,)) > 0.05
+        rand = g.random((10000,)) > 0.05
         for original in [small, rand]:
             for dtype in [np.uint8, np.int64]:
                 enc = rl.dense_to_brle(original, dtype=dtype)
@@ -170,7 +164,7 @@ class RleTest(g.unittest.TestCase):
     def test_rle_mask(self):
         rle_data = random_rle_encoding()
         dense = rl.rle_to_dense(rle_data)
-        mask = np.random.uniform(size=dense.shape) > 0.8
+        mask = g.random(dense.shape) > 0.8
         expected = dense[mask]
         actual = tuple(rl.rle_mask(rle_data, mask))
         np.testing.assert_equal(actual, expected)
@@ -178,7 +172,7 @@ class RleTest(g.unittest.TestCase):
     def test_brle_mask(self):
         brle_data = random_brle_encoding()
         dense = rl.brle_to_dense(brle_data)
-        mask = np.random.uniform(size=dense.shape) > 0.8
+        mask = g.random(dense.shape) > 0.8
         expected = dense[mask]
         actual = tuple(rl.brle_mask(brle_data, mask))
         np.testing.assert_equal(actual, expected)

--- a/tests/test_scenegraph.py
+++ b/tests/test_scenegraph.py
@@ -6,14 +6,14 @@ except BaseException:
 from trimesh.scene.transforms import EnforcedForest
 
 
-def random_chr():
-    return chr(ord("a") + round(g.random() * 25))
-
-
 def test_forest():
     graph = EnforcedForest()
-    for _i in range(5000):
-        graph.add_edge(random_chr(), random_chr())
+    # draw from a stream: `g.random` returns the same value every call
+    # which made this 5000 self-edges on a single node
+    with g.RandomSeed() as r:
+        edges = r.integers(0, 26, (5000, 2))
+    for a, b in edges:
+        graph.add_edge(chr(ord("a") + a), chr(ord("a") + b))
 
 
 def test_cache():
@@ -156,7 +156,7 @@ def test_scene_transform():
     assert g.np.allclose(scene.convex_hull.bounds, b)
 
     # get a random rotation matrix
-    T = g.trimesh.transformations.random_rotation_matrix()
+    T = next(g.random_transforms(1, translate=0.0))
 
     # apply it to both the mesh and the scene
     m.apply_transform(T)
@@ -249,7 +249,9 @@ def test_shortest_path():
         forest.add_edge(*k, **v)
 
     # generate a lot of random queries
-    queries = g.np.random.choice(list(forest.nodes), 10000).reshape((-1, 2))
+    queries = (
+        g.np.random.default_rng(seed=0).choice(list(forest.nodes), 10000).reshape((-1, 2))
+    )
     # filter out any self-queries as networkx doesn't handle them
     queries = queries[g.np.ptp(queries, axis=1) > 0]
 
@@ -312,7 +314,7 @@ def test_translation_cache():
 def test_translation_origin():
     # check to see if we can translate to the origin
     c = g.get_mesh("cycloidal.3DXML")
-    c.apply_transform(g.trimesh.transformations.random_rotation_matrix())
+    c.apply_transform(next(g.random_transforms(1, translate=0.0)))
     s = c.scaled(1.0 / c.extents)
     # shouldn't be at the origin
     assert not g.np.allclose(s.bounds[0], 0.0)

--- a/tests/test_scenegraph.py
+++ b/tests/test_scenegraph.py
@@ -321,6 +321,24 @@ def test_translation_origin():
     assert g.np.allclose(s.bounds[0], 0)
 
 
+def test_falsy_base_frame():
+    # frames are documented as any hashable so a falsy
+    # node name like `0` must not be replaced with `world`
+    assert g.trimesh.scene.transforms.SceneGraph(base_frame=0).base_frame == 0
+
+    # a scene with `world -> 0 -> child` where child has geometry
+    s = g.trimesh.Scene()
+    box = g.trimesh.creation.box()
+    s.graph.update(frame_to=0, frame_from=s.graph.base_frame)
+    s.add_geometry(box, node_name="child", parent_node_name=0)
+
+    # subscene rooted at the falsy node must keep its name and geometry
+    sub = s.subscene(0)
+    assert sub.graph.base_frame == 0
+    assert set(sub.graph.nodes_geometry) == {"child"}
+    assert g.np.isclose(sub.volume, box.volume)
+
+
 def test_reconstruct():
     original = g.get_mesh("cycloidal.3DXML")
     assert isinstance(original, g.trimesh.Scene)

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -14,7 +14,7 @@ class SectionTest(g.unittest.TestCase):
             start=mesh.bounds[0][2], stop=mesh.bounds[1][2] + 2 * step, step=step
         )
         # randomly order Z so first level is probably not zero
-        z_levels = g.np.random.permutation(z_levels)
+        z_levels = g.np.random.default_rng(seed=0).permutation(z_levels)
 
         # rotate around so we're not just testing XY parallel planes
         for angle in [0.0, g.np.radians(1.0), g.np.radians(11.11232)]:
@@ -393,15 +393,12 @@ class SliceTest(g.unittest.TestCase):
         if not g.has_earcut:
             return
 
-        from trimesh.transformations import random_rotation_matrix
+        # rotate-only as both boxes have to overlap to produce a cap
+        transforms = list(g.random_transforms(200, translate=0.0))
 
-        for _i in range(100):
-            box1 = g.trimesh.primitives.Box(
-                extents=[10, 20, 30], transform=random_rotation_matrix()
-            )
-            box2 = g.trimesh.primitives.Box(
-                extents=[10, 20, 30], transform=random_rotation_matrix()
-            )
+        for first, second in zip(transforms[::2], transforms[1::2]):
+            box1 = g.trimesh.primitives.Box(extents=[10, 20, 30], transform=first)
+            box2 = g.trimesh.primitives.Box(extents=[10, 20, 30], transform=second)
 
             result = g.trimesh.intersections.slice_mesh_plane(
                 mesh=box2,

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -80,7 +80,7 @@ class SimplifyTest(g.unittest.TestCase):
     def test_merge_colinear(self):
         num = 100
         dists = g.np.linspace(0, 1000, num=num)
-        direction = g.trimesh.unitize([1, g.np.random.rand()])
+        direction = g.trimesh.unitize([1, g.random()])
         points = direction * dists.reshape((-1, 1))
         merged = g.trimesh.path.simplify.merge_colinear(points, scale=1000)
         g.log.debug("direction:", direction)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -4,6 +4,40 @@ except BaseException:
     import generic as g
 
 
+def test_flips_winding():
+    tf = g.trimesh.transformations
+    # a transform flips winding exactly when its determinant is negative
+    assert not tf.flips_winding(g.np.eye(4))
+    assert not tf.flips_winding(tf.rotation_matrix(1.0, [0, 1, 0]))
+    # single-axis reflections flip
+    assert tf.flips_winding(g.np.diag([-1, 1, 1, 1]))
+    # two reflections compose to a rotation
+    assert not tf.flips_winding(g.np.diag([-1, -1, 1, 1]))
+    # mirroring all three axes flips — determinant sign, not element signs
+    assert tf.flips_winding(g.np.diag([-1, -1, -1, 1]))
+    # anisotropic positive scale never flips
+    assert not tf.flips_winding(g.np.diag([2.0, 0.5, 3.0, 1]))
+    # bare (3, 3) rotations are accepted too
+    assert tf.flips_winding(g.np.diag([-1.0, 1.0, 1.0]))
+    assert not tf.flips_winding(g.np.eye(3))
+    # anything else errors early
+    try:
+        tf.flips_winding(g.np.zeros((2, 3)))
+        raise AssertionError("should have raised on (2, 3)")
+    except ValueError:
+        pass
+
+    # winding checks must not consume the global numpy RNG —
+    # seeded pipelines depend on bit-exact reproducibility
+    matrix = tf.random_rotation_matrix()
+    state = g.np.random.get_state()
+    tf.flips_winding(matrix)
+    after = g.np.random.get_state()
+    assert state[0] == after[0]
+    assert g.np.array_equal(state[1], after[1])
+    assert state[2:] == after[2:]
+
+
 class TransformTest(g.unittest.TestCase):
     def test_doctest(self):
         """

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -29,7 +29,7 @@ def test_flips_winding():
 
     # winding checks must not consume the global numpy RNG —
     # seeded pipelines depend on bit-exact reproducibility
-    matrix = tf.random_rotation_matrix()
+    matrix = tf.random_rotation_matrix(seed=0)
     state = g.np.random.get_state()
     tf.flips_winding(matrix)
     after = g.np.random.get_state()
@@ -62,9 +62,12 @@ class TransformTest(g.unittest.TestCase):
 
         # search for interactive sessions in docstrings and verify they work
         # they are super unreliable and depend on janky string formatting
-        results = doctest.testmod(
-            trimesh.transformations, verbose=False, raise_on_error=False
-        )
+        # the examples call the `random_*` functions which draw from the
+        # global RNG so seed in a scope which puts the state back
+        with g.RandomSeed(0):
+            results = doctest.testmod(
+                trimesh.transformations, verbose=False, raise_on_error=False
+            )
 
         if results.failed > 0:
             raise ValueError(str(results))
@@ -101,26 +104,30 @@ class TransformTest(g.unittest.TestCase):
         assert g.np.allclose(tr.transform_points(points, g.np.eye(3)), points)
 
     def test_around(self):
-        # check transform_around on 2D points
-        points = g.random((100, 2))
-        for i, p in enumerate(points):
-            offset = g.random(2)
-            matrix = g.trimesh.transformations.planar_matrix(
-                theta=g.random() + 0.1, offset=offset, point=p
-            )
+        # draw inside the block: `g.random` pinned `offset` and `theta` to
+        # one value so all 100 rounds used the same rotation
+        with g.RandomSeed() as r:
+            # check transform_around on 2D points
+            points = r.random((100, 2))
+            for i, p in enumerate(points):
+                offset = r.random(2)
+                matrix = g.trimesh.transformations.planar_matrix(
+                    theta=r.random() + 0.1, offset=offset, point=p
+                )
 
-            # apply the matrix
-            check = g.trimesh.transform_points(points, matrix)
-            compare = g.np.isclose(check, points + offset)
-            # the point we rotated around shouldn't move
-            assert compare[i].all()
-            # all other points should move
-            assert compare.all(axis=1).sum() == 1
+                # apply the matrix
+                check = g.trimesh.transform_points(points, matrix)
+                compare = g.np.isclose(check, points + offset)
+                # the point we rotated around shouldn't move
+                assert compare[i].all()
+                # all other points should move
+                assert compare.all(axis=1).sum() == 1
 
         # check transform_around on 3D points
         points = g.random((100, 3))
-        for i, p in enumerate(points):
-            matrix = g.trimesh.transformations.random_rotation_matrix()
+        for (i, p), matrix in zip(
+            enumerate(points), g.random_transforms(len(points), translate=0.0)
+        ):
             matrix = g.trimesh.transformations.transform_around(matrix, p)
 
             # apply the matrix
@@ -140,9 +147,12 @@ class TransformTest(g.unittest.TestCase):
         R = rotation_matrix(g.np.pi / 2, [0, 0, 1], [1, 0, 0])
         assert g.np.allclose(g.np.dot(R, [0, 0, 0, 1]), [1, -1, 0, 1])
 
-        angle = (g.random() - 0.5) * (2 * g.np.pi)
-        direc = g.random(3) - 0.5
-        point = g.random(3) - 0.5
+        # draw from a stream: `g.random` returns the same values for the same
+        # shape, which put `point` exactly on the axis through `direc`
+        with g.RandomSeed() as r:
+            angle = (r.random() - 0.5) * (2 * g.np.pi)
+            direc = r.random(3) - 0.5
+            point = r.random(3) - 0.5
         R0 = rotation_matrix(angle, direc, point)
         R1 = rotation_matrix(angle - 2 * g.np.pi, direc, point)
         assert g.trimesh.transformations.is_same_transform(R0, R1)
@@ -206,10 +216,10 @@ class TransformTest(g.unittest.TestCase):
         # results should be the same
         assert g.np.allclose(mm, qm, atol=1e-5)
         # all random matrices should be rigid transforms
-        assert all(is_rigid(T) for T in random_matrix(num=100))
+        assert all(is_rigid(T) for T in random_matrix(num=100, seed=0))
         # random quaternions should all be unit vector
         assert g.np.allclose(
-            g.np.linalg.norm(random_quat(num=100), axis=1), 1.0, atol=1e-6
+            g.np.linalg.norm(random_quat(num=100, seed=0), axis=1), 1.0, atol=1e-6
         )
 
     def test_angle(self):

--- a/tests/test_triangles.py
+++ b/tests/test_triangles.py
@@ -143,7 +143,7 @@ class TrianglesTest(g.unittest.TestCase):
         # an equilateral triangle transformed into space
         tris = g.trimesh.transform_points(
             g.np.array([[-1, 0, 0], [1, 0, 0], [0, g.np.sqrt(3), 0]], dtype=g.np.float64),
-            g.trimesh.transformations.random_rotation_matrix(),
+            next(g.random_transforms(1, translate=0.0)),
         ).reshape((-1, 3, 3))
         angles = g.trimesh.triangles.angles(tris)
         # all angles should be 60 degrees
@@ -152,7 +152,7 @@ class TrianglesTest(g.unittest.TestCase):
         # an 3-4-5 right triangle
         tris = g.trimesh.transform_points(
             g.np.array([[0, 0, 0], [3, 0, 0], [0, 4, 0]], dtype=g.np.float64),
-            g.trimesh.transformations.random_rotation_matrix(),
+            next(g.random_transforms(1, translate=0.0)),
         ).reshape((-1, 3, 3))
         # get angles
         angles = g.trimesh.triangles.angles(tris)

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -3,6 +3,7 @@ try:
 except BaseException:
     import generic as g
 
+import io
 import typing
 
 import numpy as np
@@ -25,6 +26,31 @@ def _check(values: ArrayLike) -> NDArray[int64]:
 
 def _run() -> NDArray[int64]:
     return _check(values=[1, 2])
+
+
+def test_deprecated_aliases():
+    # aliases from the pre-5.0 typed module stay importable
+    # until their removal after july 2028
+    import trimesh.typed
+
+    deprecated = {
+        "List": list,
+        "Dict": dict,
+        "Tuple": tuple,
+        "Set": set,
+        "Optional": typing.Optional,
+        "Union": typing.Union,
+        "TextIO": typing.TextIO,
+        "BytesIO": io.BytesIO,
+        "StringIO": io.StringIO,
+        "BufferedRandom": io.BufferedRandom,
+        "unsignedinteger": np.unsignedinteger,
+    }
+    for name, expect in deprecated.items():
+        assert getattr(trimesh.typed, name) is expect
+
+    # everything in `__all__` must be an attribute
+    assert all(hasattr(trimesh.typed, name) for name in trimesh.typed.__all__)
 
 
 class TypedTest(g.unittest.TestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -68,20 +68,23 @@ def test_jsonify():
 def test_align():
     log.info("Testing vector alignment")
     target = np.array([0, 0, 1])
-    for _i in range(100):
-        vector = trimesh.unitize(np.random.random(3) - 0.5)
+    # generate in one call as `g.random` re-seeds every time it's called
+    for vector in trimesh.unitize(g.random((100, 3)) - 0.5):
         T = trimesh.geometry.align_vectors(vector, target)
         result = np.dot(T, np.append(vector, 1))[0:3]
         assert np.abs(result - target).sum() < TOL_ZERO
 
 
 def test_bounds_tree():
-    for _attempt in range(3):
-        for dimension in [2, 3]:
-            t = g.random((1000, 3, dimension))
-            bounds = g.np.column_stack((t.min(axis=1), t.max(axis=1)))
-            tree = g.trimesh.util.bounds_tree(bounds)
-            assert 0 in tree.intersection(bounds[0])
+    # draw inside the block: `g.random` gave every attempt the same
+    # boxes so two of these three rounds were a no-op
+    with g.RandomSeed() as r:
+        for _attempt in range(3):
+            for dimension in [2, 3]:
+                t = r.random((1000, 3, dimension))
+                bounds = g.np.column_stack((t.min(axis=1), t.max(axis=1)))
+                tree = g.trimesh.util.bounds_tree(bounds)
+                assert 0 in tree.intersection(bounds[0])
 
 
 def test_stack():
@@ -314,7 +317,7 @@ def test_unique_name():
 def test_inside():
     sphere = g.trimesh.primitives.Sphere(radius=1.0, subdivisions=4)
     g.log.info("Testing contains function with sphere")
-    samples = (np.random.random((1000, 3)) - 0.5) * 5
+    samples = (g.random((1000, 3)) - 0.5) * 5
     radius = np.linalg.norm(samples, axis=1)
 
     margin = 0.05
@@ -375,7 +378,7 @@ def test_unique():
         np.array([0, 1, 2, 3, 1, 3, 10, 20]),
         np.arange(100),
         np.array([], dtype=np.int64),
-        (np.random.random(1000) * 10).astype(int),
+        (g.random(1000) * 10).astype(int),
     ]
 
     for values in options:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,4 @@
 import logging
-import unittest
 
 import numpy as np
 
@@ -29,6 +28,41 @@ def test_unitize_multi():
 
     length = np.sum(vectors[1:] ** 2, axis=1) ** 0.5
     assert np.allclose(length, 1.0)
+
+
+def test_jsonify():
+    # check our numpy+timestamp+dataclass JSON exporter
+    import json
+    from dataclasses import dataclass
+    from datetime import datetime
+
+    import numpy as np
+
+    from trimesh.util import jsonify
+
+    @dataclass
+    class Things:
+        a: float
+        b: int
+
+    # we support timestamps, numpy arrays, and dataclasses
+    # all will be downgraded into simpler types
+    data = {
+        "stamp": datetime.now(),
+        "array": np.arange(10),
+        "thing": Things(a=10.2, b=11),
+    }
+
+    # roundtrip our payload through JSON
+    trip = json.loads(jsonify(data))
+
+    # datetime is downgraded to float timestamp
+    assert np.isclose(data["stamp"].timestamp(), trip["stamp"])
+    # arrays are downgraded to JSON lists
+    assert np.allclose(data["array"], trip["array"])
+    # dataclasses downgraded to dicts
+    assert np.isclose(data["thing"].a, trip["thing"]["a"])
+    assert data["thing"].b == trip["thing"]["b"]
 
 
 def test_align():
@@ -452,9 +486,12 @@ def test_supports_uints():
 
 
 def test_supports_repeat_format():
-    assert g.trimesh.util.array_to_string(
-        np.array([[1, 2, 3], [4, 5, 6]]), value_format="{} {}"
-    ) == "1 1 2 2 3 3\n4 4 5 5 6 6"
+    assert (
+        g.trimesh.util.array_to_string(
+            np.array([[1, 2, 3], [4, 5, 6]]), value_format="{} {}"
+        )
+        == "1 1 2 2 3 3\n4 4 5 5 6 6"
+    )
 
 
 def test_raises_if_array_is_structured():
@@ -505,13 +542,16 @@ def test_converts_a_structured_array_with_2d_elements():
 
 
 def test_uses_the_specified_column_delimiter():
-    assert g.trimesh.util.structured_array_to_string(
-        np.array(
-            [(1, 1.1), (2, 2.2)],
-            dtype=[("some_int", np.int64), ("some_float", np.float64)],
-        ),
-        col_delim="col",
-    ) == "1col1.10000000\n2col2.20000000"
+    assert (
+        g.trimesh.util.structured_array_to_string(
+            np.array(
+                [(1, 1.1), (2, 2.2)],
+                dtype=[("some_int", np.int64), ("some_float", np.float64)],
+            ),
+            col_delim="col",
+        )
+        == "1col1.10000000\n2col2.20000000"
+    )
 
 
 def test_uses_the_specified_row_delimiter_structured():
@@ -591,4 +631,5 @@ def test_raises_if_array_is_not_flat_structured():
 
 if __name__ == "__main__":
     trimesh.util.attach_to_log()
-    unittest.main()
+
+    test_jsonify()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -629,6 +629,35 @@ def test_raises_if_array_is_not_flat_structured():
         return
 
 
+def test_log_helper():
+    # exercise attach_to_log without polluting global logging
+    import io
+
+    logger = logging.getLogger("trimesh.test_attach")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    printoptions = np.get_printoptions()
+    try:
+        # numpy integer level exercises the int(level) coercion
+        trimesh.util.attach_to_log(
+            level=np.int64(logging.INFO),
+            handler=handler,
+            loggers={logger},
+            colors=False,
+            capture_warnings=False,
+        )
+        assert handler in logger.handlers
+        assert logger.level == logging.INFO
+        assert handler.level == logging.INFO
+        logger.info("hello from test_log_helper")
+        assert "hello from test_log_helper" in stream.getvalue()
+    finally:
+        # do not pollute global state
+        logger.removeHandler(handler)
+        logging.getLogger("py.warnings").removeHandler(handler)
+        np.set_printoptions(**printoptions)
+
+
 if __name__ == "__main__":
     trimesh.util.attach_to_log()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,7 +10,7 @@ try:
 except BaseException:
     import generic as g
 
-TEST_DIM = (100, 3)
+TEST_DIM = (1000, 3)
 TOL_ZERO = 1e-9
 TOL_CHECK = 1e-2
 
@@ -18,556 +18,575 @@ log = logging.getLogger("trimesh")
 log.addHandler(logging.NullHandler())
 
 
-class VectorTests(unittest.TestCase):
-    def setUp(self):
-        self.test_dim = TEST_DIM
+def test_unitize_multi():
+    vectors = np.ones(TEST_DIM)
 
-    def test_unitize_multi(self):
-        vectors = np.ones(self.test_dim)
-        vectors[0] = [0, 0, 0]
-        vectors, valid = trimesh.unitize(vectors, check_valid=True)
+    vectors[0] = [0, 0, 0]
+    vectors, valid = trimesh.unitize(vectors, check_valid=True)
 
-        assert not valid[0]
-        assert valid[1:].all()
+    assert not valid[0]
+    assert valid[1:].all()
 
-        length = np.sum(vectors[1:] ** 2, axis=1) ** 0.5
-        assert np.allclose(length, 1.0)
-
-    def test_align(self):
-        log.info("Testing vector alignment")
-        target = np.array([0, 0, 1])
-        for _i in range(100):
-            vector = trimesh.unitize(np.random.random(3) - 0.5)
-            T = trimesh.geometry.align_vectors(vector, target)
-            result = np.dot(T, np.append(vector, 1))[0:3]
-            aligned = np.abs(result - target).sum() < TOL_ZERO
-            self.assertTrue(aligned)
+    length = np.sum(vectors[1:] ** 2, axis=1) ** 0.5
+    assert np.allclose(length, 1.0)
 
 
-class UtilTests(unittest.TestCase):
-    def test_bounds_tree(self):
-        for _attempt in range(3):
-            for dimension in [2, 3]:
-                t = g.random((1000, 3, dimension))
-                bounds = g.np.column_stack((t.min(axis=1), t.max(axis=1)))
-                tree = g.trimesh.util.bounds_tree(bounds)
-                self.assertTrue(0 in tree.intersection(bounds[0]))
+def test_align():
+    log.info("Testing vector alignment")
+    target = np.array([0, 0, 1])
+    for _i in range(100):
+        vector = trimesh.unitize(np.random.random(3) - 0.5)
+        T = trimesh.geometry.align_vectors(vector, target)
+        result = np.dot(T, np.append(vector, 1))[0:3]
+        assert np.abs(result - target).sum() < TOL_ZERO
 
-    def test_stack(self):
-        # shortcut to the function
-        f = g.trimesh.util.stack_3D
-        # start with some random points
-        p = g.random((100, 2))
-        stack = f(p)
-        # shape should be 3D
-        assert stack.shape == (100, 3)
-        # points should be equal
-        assert g.np.allclose(p, stack[:, :2])
 
-        # check an empty array
-        assert f([]).shape == (0,)
+def test_bounds_tree():
+    for _attempt in range(3):
+        for dimension in [2, 3]:
+            t = g.random((1000, 3, dimension))
+            bounds = g.np.column_stack((t.min(axis=1), t.max(axis=1)))
+            tree = g.trimesh.util.bounds_tree(bounds)
+            assert 0 in tree.intersection(bounds[0])
 
-        try:
-            # try with 4D points
-            f(g.np.ones((100, 4)))
-            raise AssertionError()
-        except ValueError:
-            # this is what should happen
-            pass
 
-    def test_has_module(self):
-        # built-in
-        assert g.trimesh.util.has_module("collections")
-        # required for everything
-        assert g.trimesh.util.has_module("numpy")
-        # not-a-thing
-        assert not g.trimesh.util.has_module("foobarrionananan")
+def test_stack():
+    # shortcut to the function
+    f = g.trimesh.util.stack_3D
+    # start with some random points
+    p = g.random((100, 2))
+    stack = f(p)
+    # shape should be 3D
+    assert stack.shape == (100, 3)
+    # points should be equal
+    assert g.np.allclose(p, stack[:, :2])
 
-    def test_strips(self):
+    # check an empty array
+    assert f([]).shape == (0,)
+
+    try:
+        # try with 4D points
+        f(g.np.ones((100, 4)))
+        raise AssertionError()
+    except ValueError:
+        # this is what should happen
+        pass
+
+
+def test_has_module():
+    # built-in
+    assert g.trimesh.util.has_module("collections")
+    # required for everything
+    assert g.trimesh.util.has_module("numpy")
+    # not-a-thing
+    assert not g.trimesh.util.has_module("foobarrionananan")
+
+
+def test_strips():
+    """
+    Test our conversion of triangle strips to face indexes.
+    """
+
+    def strips_to_faces(strips):
         """
-        Test our conversion of triangle strips to face indexes.
+        A slow but straightforward version of the function to test against
         """
+        faces = g.collections.deque()
+        for s in strips:
+            s = g.np.asanyarray(s, dtype=g.np.int64)
+            # each triangle is defined by one new vertex
+            tri = g.np.column_stack([g.np.roll(s, -i) for i in range(3)])[:-2]
+            # we need to flip ever other triangle
+            idx = (g.np.arange(len(tri)) % 2).astype(bool)
+            tri[idx] = g.np.fliplr(tri[idx])
+            faces.append(tri)
+        # stack into one (m,3) array
+        faces = g.np.vstack(faces)
+        return faces
 
-        def strips_to_faces(strips):
-            """
-            A slow but straightforward version of the function to test against
-            """
-            faces = g.collections.deque()
-            for s in strips:
-                s = g.np.asanyarray(s, dtype=g.np.int64)
-                # each triangle is defined by one new vertex
-                tri = g.np.column_stack([g.np.roll(s, -i) for i in range(3)])[:-2]
-                # we need to flip ever other triangle
-                idx = (g.np.arange(len(tri)) % 2).astype(bool)
-                tri[idx] = g.np.fliplr(tri[idx])
-                faces.append(tri)
-            # stack into one (m,3) array
-            faces = g.np.vstack(faces)
-            return faces
+    # test 4- triangle strip
+    s = [g.np.arange(6)]
+    f = g.trimesh.util.triangle_strips_to_faces(s)
+    assert (f == g.np.array([[0, 1, 2], [3, 2, 1], [2, 3, 4], [5, 4, 3]])).all()
+    assert len(f) + 2 == len(s[0])
+    assert (f == strips_to_faces(s)).all()
 
-        # test 4- triangle strip
-        s = [g.np.arange(6)]
-        f = g.trimesh.util.triangle_strips_to_faces(s)
-        assert (f == g.np.array([[0, 1, 2], [3, 2, 1], [2, 3, 4], [5, 4, 3]])).all()
-        assert len(f) + 2 == len(s[0])
-        assert (f == strips_to_faces(s)).all()
+    # test single triangle
+    s = [g.np.arange(3)]
+    f = g.trimesh.util.triangle_strips_to_faces(s)
+    assert (f == g.np.array([[0, 1, 2]])).all()
+    assert len(f) + 2 == len(s[0])
+    assert (f == strips_to_faces(s)).all()
 
-        # test single triangle
-        s = [g.np.arange(3)]
-        f = g.trimesh.util.triangle_strips_to_faces(s)
-        assert (f == g.np.array([[0, 1, 2]])).all()
-        assert len(f) + 2 == len(s[0])
-        assert (f == strips_to_faces(s)).all()
+    s = [g.np.arange(100)]
+    f = g.trimesh.util.triangle_strips_to_faces(s)
+    assert len(f) + 2 == len(s[0])
+    assert (f == strips_to_faces(s)).all()
 
-        s = [g.np.arange(100)]
-        f = g.trimesh.util.triangle_strips_to_faces(s)
-        assert len(f) + 2 == len(s[0])
-        assert (f == strips_to_faces(s)).all()
 
-    def test_pairwise(self):
-        # check to make sure both itertools and numpy
-        # methods return the same result
-        pa = np.array(list(g.trimesh.util.pairwise(range(5))))
-        pb = g.trimesh.util.pairwise(np.arange(5))
+def test_pairwise():
+    # check to make sure both itertools and numpy
+    # methods return the same result
+    pa = np.array(list(g.trimesh.util.pairwise(range(5))))
+    pb = g.trimesh.util.pairwise(np.arange(5))
 
-        # make sure results are the same from both methods
-        assert (pa == pb).all()
-        # make sure we have 4 pairs for 5 values
-        assert len(pa) == 4
-        # make sure all pairs are length 2
-        assert all(len(i) == 2 for i in pa)
+    # make sure results are the same from both methods
+    assert (pa == pb).all()
+    # make sure we have 4 pairs for 5 values
+    assert len(pa) == 4
+    # make sure all pairs are length 2
+    assert all(len(i) == 2 for i in pa)
 
-    def test_concat(self):
-        a = g.get_mesh("ballA.off")
-        b = g.get_mesh("ballB.off")
 
-        hA = a.__hash__()
-        hB = b.__hash__()
+def test_concat():
+    a = g.get_mesh("ballA.off")
+    b = g.get_mesh("ballB.off")
 
-        # make sure we're not mutating original mesh
-        for _i in range(4):
-            c = a + b
-            assert g.np.isclose(c.volume, a.volume + b.volume)
-            assert a.__hash__() == hA
-            assert b.__hash__() == hB
+    hA = a.__hash__()
+    hB = b.__hash__()
 
-        count = 5
-        meshes = []
-        for _i in range(count):
-            m = a.copy()
-            m.vertex_attributes["test"] = np.arange(len(m.vertices))
-            m.face_attributes["test"] = np.arange(len(m.faces))
-            m.apply_translation([a.scale, 0, 0])
-            meshes.append(m)
-
-        # do a multimesh concatenate
-        r = g.trimesh.util.concatenate(meshes)
-        assert g.np.isclose(r.volume, a.volume * count)
+    # make sure we're not mutating original mesh
+    for _i in range(4):
+        c = a + b
+        assert g.np.isclose(c.volume, a.volume + b.volume)
         assert a.__hash__() == hA
-        assert r.vertex_attributes["test"].shape[0] == len(r.vertices)
-        assert r.face_attributes["test"].shape[0] == len(r.faces)
+        assert b.__hash__() == hB
 
-    def test_concat_vertex_normals(self):
-        # vertex normals should only be included if they already exist
+    count = 5
+    meshes = []
+    for _i in range(count):
+        m = a.copy()
+        m.vertex_attributes["test"] = np.arange(len(m.vertices))
+        m.face_attributes["test"] = np.arange(len(m.faces))
+        m.apply_translation([a.scale, 0, 0])
+        meshes.append(m)
 
-        a = g.trimesh.creation.icosphere().apply_translation([1, 0, 0])
-        assert "vertex_normals" not in a._cache
-
-        b = g.trimesh.creation.icosphere().apply_translation([-1, 0, 0])
-        assert "vertex_normals" not in b._cache
-
-        c = g.trimesh.util.concatenate([a, b])
-        assert "vertex_normals" not in c._cache
-
-        rando = g.trimesh.unitize(g.random(a.vertices.shape))
-        a.vertex_normals = rando
-        assert "vertex_normals" in a._cache
-
-        c = g.trimesh.util.concatenate([a, b])
-        assert "vertex_normals" in c._cache
-        # should have included the rando normals
-        assert g.np.allclose(c.vertex_normals[: len(a.vertices)], rando)
-
-    def test_concat_face_normals(self):
-        # face normals should only be included if they already exist
-        a = g.trimesh.creation.icosphere().apply_translation([1, 0, 0])
-        assert "face_normals" not in a._cache
-
-        b = g.trimesh.creation.icosphere().apply_translation([-1, 0, 0])
-        assert "face_normals" not in b._cache
-
-        c = g.trimesh.util.concatenate([a, b])
-        assert "face_normals" not in c._cache
-
-        # will generate normals
-        _ = a.face_normals
-        assert "face_normals" in a._cache
-
-        c = g.trimesh.util.concatenate([a, b])
-        assert "face_normals" in c._cache
-
-    def test_unique_id(self):
-        num_ids = 10000
-
-        g.trimesh.util.random.seed(0)
-        unique_ids_0 = []
-        for _i in range(num_ids):
-            s = g.trimesh.util.unique_id()
-            unique_ids_0.append(s)
-
-        # make sure every id is truly unique
-        assert len(unique_ids_0) == len(g.np.unique(unique_ids_0))
-
-        g.trimesh.util.random.seed(0)
-        unique_ids_1 = []
-        for i in range(num_ids):
-            s = g.trimesh.util.unique_id()
-            unique_ids_1.append(s)
-
-            # make sure id's can be reproduced
-            assert s == unique_ids_0[i]
-
-    def test_unique_name(self):
-        from trimesh.util import unique_name
-
-        assert len(unique_name(None, {})) > 0
-        assert len(unique_name("", {})) > 0
-
-        count = 10
-        names = set()
-        for _i in range(count):
-            names.add(unique_name("hi", names))
-        assert len(names) == count
-
-        names = set()
-        for _i in range(count):
-            names.add(unique_name("", names))
-        assert len(names) == count
-
-        # Try with a larger set of names
-        # get some random strings
-        names = [g.uuid4().hex for _ in range(20)]
-        # make it a whole lotta duplicates
-        names = names * 1000
-        # add a non-int postfix to test
-        names.extend(["suppp_hi"] * 10)
-
-        assigned = set()
-        with g.Profiler() as P:
-            for name in names:
-                assigned.add(unique_name(name, assigned))
-        g.log.debug(P.output_text())
-
-        assigned_new = set()
-        # tracker = UniqueName()\
-        counts = {}
-        with g.Profiler() as P:
-            for name in names:
-                assigned_new.add(unique_name(name, contains=assigned_new, counts=counts))
-        g.log.debug(P.output_text())
-
-        # new scheme should match the old one
-        assert assigned_new == assigned
-        # de-duplicated set should match original length
-        assert len(assigned) == len(names)
+    # do a multimesh concatenate
+    r = g.trimesh.util.concatenate(meshes)
+    assert g.np.isclose(r.volume, a.volume * count)
+    assert a.__hash__() == hA
+    assert r.vertex_attributes["test"].shape[0] == len(r.vertices)
+    assert r.face_attributes["test"].shape[0] == len(r.faces)
 
 
-class ContainsTest(unittest.TestCase):
-    def test_inside(self):
-        sphere = g.trimesh.primitives.Sphere(radius=1.0, subdivisions=4)
-        g.log.info("Testing contains function with sphere")
-        samples = (np.random.random((1000, 3)) - 0.5) * 5
-        radius = np.linalg.norm(samples, axis=1)
+def test_concat_vertex_normals():
+    # vertex normals should only be included if they already exist
 
-        margin = 0.05
-        truth_in = radius < (1.0 - margin)
-        truth_out = radius > (1.0 + margin)
+    a = g.trimesh.creation.icosphere().apply_translation([1, 0, 0])
+    assert "vertex_normals" not in a._cache
 
-        contains = sphere.contains(samples)
+    b = g.trimesh.creation.icosphere().apply_translation([-1, 0, 0])
+    assert "vertex_normals" not in b._cache
 
-        if not contains[truth_in].all():
-            raise ValueError("contains test does not match truth!")
+    c = g.trimesh.util.concatenate([a, b])
+    assert "vertex_normals" not in c._cache
 
-        if contains[truth_out].any():
-            raise ValueError("contains test does not match truth!")
+    rando = g.trimesh.unitize(g.random(a.vertices.shape))
+    a.vertex_normals = rando
+    assert "vertex_normals" in a._cache
 
-
-class IOWrapTests(unittest.TestCase):
-    def test_io_wrap(self):
-        util = g.trimesh.util
-
-        # check wrap_as_stream
-        test_b = g.random(1).tobytes()
-        test_s = "this is a test yo"
-        res_b = util.wrap_as_stream(test_b).read()
-        res_s = util.wrap_as_stream(test_s).read()
-        assert res_b == test_b
-        assert res_s == test_s
-
-        # check __enter__ and __exit__
-        hi = b"hi"
-        with util.BytesIO(hi) as f:
-            assert f.read() == hi
-
-        # check __enter__ and __exit__
-        hi = "hi"
-        with util.StringIO(hi) as f:
-            assert f.read() == hi
+    c = g.trimesh.util.concatenate([a, b])
+    assert "vertex_normals" in c._cache
+    # should have included the rando normals
+    assert g.np.allclose(c.vertex_normals[: len(a.vertices)], rando)
 
 
-class CompressTests(unittest.TestCase):
-    def test_compress(self):
-        source = {"hey": "sup", "naa": "2002211"}
+def test_concat_face_normals():
+    # face normals should only be included if they already exist
+    a = g.trimesh.creation.icosphere().apply_translation([1, 0, 0])
+    assert "face_normals" not in a._cache
 
-        # will return bytes
-        c = g.trimesh.util.compress(source)
+    b = g.trimesh.creation.icosphere().apply_translation([-1, 0, 0])
+    assert "face_normals" not in b._cache
 
-        # wrap bytes as file- like object
-        f = g.trimesh.util.wrap_as_stream(c)
-        # try to decompress file- like object
-        d = g.trimesh.util.decompress(f, file_type="zip")
+    c = g.trimesh.util.concatenate([a, b])
+    assert "face_normals" not in c._cache
 
-        # make sure compressed- decompressed items
-        # are the same after a cycle
-        for key, value in source.items():
-            result = d[key].read().decode("utf-8")
-            assert result == value
+    # will generate normals
+    _ = a.face_normals
+    assert "face_normals" in a._cache
+
+    c = g.trimesh.util.concatenate([a, b])
+    assert "face_normals" in c._cache
 
 
-class UniqueTests(unittest.TestCase):
-    def test_unique(self):
-        options = [
-            np.array([0, 1, 2, 3, 1, 3, 10, 20]),
-            np.arange(100),
-            np.array([], dtype=np.int64),
-            (np.random.random(1000) * 10).astype(int),
-        ]
+def test_unique_id():
+    num_ids = 10000
 
-        for values in options:
-            if len(values) > 0:
-                minlength = values.max()
-            else:
-                minlength = 10
+    g.trimesh.util.random.seed(0)
+    unique_ids_0 = []
+    for _i in range(num_ids):
+        s = g.trimesh.util.unique_id()
+        unique_ids_0.append(s)
 
-            # try our unique bincount function
-            unique, inverse, counts = g.trimesh.grouping.unique_bincount(
-                values, minlength=minlength, return_inverse=True, return_counts=True
+    # make sure every id is truly unique
+    assert len(unique_ids_0) == len(g.np.unique(unique_ids_0))
+
+    g.trimesh.util.random.seed(0)
+    unique_ids_1 = []
+    for i in range(num_ids):
+        s = g.trimesh.util.unique_id()
+        unique_ids_1.append(s)
+
+        # make sure id's can be reproduced
+        assert s == unique_ids_0[i]
+
+
+def test_unique_name():
+    from trimesh.util import unique_name
+
+    assert len(unique_name(None, {})) > 0
+    assert len(unique_name("", {})) > 0
+
+    count = 10
+    names = set()
+    for _i in range(count):
+        names.add(unique_name("hi", names))
+    assert len(names) == count
+
+    names = set()
+    for _i in range(count):
+        names.add(unique_name("", names))
+    assert len(names) == count
+
+    # Try with a larger set of names
+    # get some random strings
+    names = [g.uuid4().hex for _ in range(20)]
+    # make it a whole lotta duplicates
+    names = names * 1000
+    # add a non-int postfix to test
+    names.extend(["suppp_hi"] * 10)
+
+    assigned = set()
+    with g.Profiler() as P:
+        for name in names:
+            assigned.add(unique_name(name, assigned))
+    g.log.debug(P.output_text())
+
+    assigned_new = set()
+    # tracker = UniqueName()\
+    counts = {}
+    with g.Profiler() as P:
+        for name in names:
+            assigned_new.add(unique_name(name, contains=assigned_new, counts=counts))
+    g.log.debug(P.output_text())
+
+    # new scheme should match the old one
+    assert assigned_new == assigned
+    # de-duplicated set should match original length
+    assert len(assigned) == len(names)
+
+
+def test_inside():
+    sphere = g.trimesh.primitives.Sphere(radius=1.0, subdivisions=4)
+    g.log.info("Testing contains function with sphere")
+    samples = (np.random.random((1000, 3)) - 0.5) * 5
+    radius = np.linalg.norm(samples, axis=1)
+
+    margin = 0.05
+    truth_in = radius < (1.0 - margin)
+    truth_out = radius > (1.0 + margin)
+
+    contains = sphere.contains(samples)
+
+    if not contains[truth_in].all():
+        raise ValueError("contains test does not match truth!")
+
+    if contains[truth_out].any():
+        raise ValueError("contains test does not match truth!")
+
+
+def test_io_wrap():
+    util = g.trimesh.util
+
+    # check wrap_as_stream
+    test_b = g.random(1).tobytes()
+    test_s = "this is a test yo"
+    res_b = util.wrap_as_stream(test_b).read()
+    res_s = util.wrap_as_stream(test_s).read()
+    assert res_b == test_b
+    assert res_s == test_s
+
+    # check __enter__ and __exit__
+    hi = b"hi"
+    with util.BytesIO(hi) as f:
+        assert f.read() == hi
+
+    # check __enter__ and __exit__
+    hi = "hi"
+    with util.StringIO(hi) as f:
+        assert f.read() == hi
+
+
+def test_compress():
+    source = {"hey": "sup", "naa": "2002211"}
+
+    # will return bytes
+    c = g.trimesh.util.compress(source)
+
+    # wrap bytes as file- like object
+    f = g.trimesh.util.wrap_as_stream(c)
+    # try to decompress file- like object
+    d = g.trimesh.util.decompress(f, file_type="zip")
+
+    # make sure compressed- decompressed items
+    # are the same after a cycle
+    for key, value in source.items():
+        result = d[key].read().decode("utf-8")
+        assert result == value
+
+
+def test_unique():
+    options = [
+        np.array([0, 1, 2, 3, 1, 3, 10, 20]),
+        np.arange(100),
+        np.array([], dtype=np.int64),
+        (np.random.random(1000) * 10).astype(int),
+    ]
+
+    for values in options:
+        if len(values) > 0:
+            minlength = values.max()
+        else:
+            minlength = 10
+
+        # try our unique bincount function
+        unique, inverse, counts = g.trimesh.grouping.unique_bincount(
+            values, minlength=minlength, return_inverse=True, return_counts=True
+        )
+        # make sure inverse is correct
+        assert (unique[inverse] == values).all()
+
+        # make sure that the number of counts matches
+        # the number of unique values
+        assert len(unique) == len(counts)
+
+        # get the truth
+        truth_unique, truth_inverse, truth_counts = np.unique(
+            values, return_inverse=True, return_counts=True
+        )
+        # make sure truth is doing what we think
+        assert (truth_unique[truth_inverse] == values).all()
+
+        # make sure we have same number of values
+        assert len(truth_unique) == len(unique)
+
+        # make sure all values are identical
+        assert set(truth_unique) == set(unique)
+
+        # make sure that the truth counts are identical to our counts
+        assert np.all(truth_counts == counts)
+
+
+def test_comment():
+    # test our comment stripping logic
+    f = g.trimesh.util.comment_strip
+
+    text = "hey whats up"
+    assert f(text) == text
+
+    text = "#hey whats up"
+    assert f(text) == ""
+
+    text = "   # hey whats up "
+    assert f(text) == ""
+
+    text = "# naahah\nhey whats up"
+    assert f(text) == "hey whats up"
+
+    text = "#naahah\nhey whats up\nhi"
+    assert f(text) == "hey whats up\nhi"
+
+    text = "#naahah\nhey whats up\n hi"
+    assert f(text) == "hey whats up\n hi"
+
+    text = "#naahah\nhey whats up\n hi#"
+    assert f(text) == "hey whats up\n hi"
+
+    text = "hey whats up# see here\n hi#"
+    assert f(text) == "hey whats up\n hi"
+
+
+def test_converts_an_unstructured_1d_array():
+    assert g.trimesh.util.array_to_string(np.array([1, 2, 3])) == "1 2 3"
+
+
+def test_converts_an_unstructured_int_array():
+    assert (
+        g.trimesh.util.array_to_string(np.array([[1, 2, 3], [4, 5, 6]])) == "1 2 3\n4 5 6"
+    )
+
+
+def test_converts_an_unstructured_float_array():
+    assert (
+        g.trimesh.util.array_to_string(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64))
+        == "1.00000000 2.00000000 3.00000000\n4.00000000 5.00000000 6.00000000"
+    )
+
+
+def test_uses_the_specified_column_delimiter_format():
+    assert (
+        g.trimesh.util.array_to_string(np.array([[1, 2, 3], [4, 5, 6]]), col_delim="col")
+        == "1col2col3\n4col5col6"
+    )
+
+
+def test_uses_the_specified_row_delimiter():
+    assert (
+        g.trimesh.util.array_to_string(np.array([[1, 2, 3], [4, 5, 6]]), row_delim="row")
+        == "1 2 3row4 5 6"
+    )
+
+
+def test_uses_the_specified_value_format():
+    assert (
+        g.trimesh.util.array_to_string(
+            np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64), value_format="{:.1f}"
+        )
+        == "1.0 2.0 3.0\n4.0 5.0 6.0"
+    )
+
+
+def test_supports_uints():
+    assert g.trimesh.util.array_to_string(np.array([1, 2, 3], dtype=np.uint8)) == "1 2 3"
+
+
+def test_supports_repeat_format():
+    assert g.trimesh.util.array_to_string(
+        np.array([[1, 2, 3], [4, 5, 6]]), value_format="{} {}"
+    ) == "1 1 2 2 3 3\n4 4 5 5 6 6"
+
+
+def test_raises_if_array_is_structured():
+
+    try:
+        g.trimesh.util.array_to_string(
+            np.array(
+                [(1, 1.1), (2, 2.2)],
+                dtype=[("some_int", np.int64), ("some_float", np.float64)],
             )
-            # make sure inverse is correct
-            assert (unique[inverse] == values).all()
+        )
+        raise NameError("shoulda raised a ValueError")
+    except ValueError:
+        # correctly raised
+        return
 
-            # make sure that the number of counts matches
-            # the number of unique values
-            assert len(unique) == len(counts)
 
-            # get the truth
-            truth_unique, truth_inverse, truth_counts = np.unique(
-                values, return_inverse=True, return_counts=True
+def test_raises_if_array_is_not_flat():
+    try:
+        g.trimesh.util.array_to_string(np.array([[[1, 2, 3], [4, 5, 6]]]))
+        raise NameError("should have raised a ValueError")
+    except ValueError:
+        return
+
+
+def test_converts_a_structured_array_with_1d_elements():
+    assert (
+        g.trimesh.util.structured_array_to_string(
+            np.array(
+                [(1, 1.1), (2, 2.2)],
+                dtype=[("some_int", np.int64), ("some_float", np.float64)],
             )
-            # make sure truth is doing what we think
-            assert (truth_unique[truth_inverse] == values).all()
-
-            # make sure we have same number of values
-            assert len(truth_unique) == len(unique)
-
-            # make sure all values are identical
-            assert set(truth_unique) == set(unique)
-
-            # make sure that the truth counts are identical to our counts
-            assert np.all(truth_counts == counts)
-
-
-class CommentTests(unittest.TestCase):
-    def test_comment(self):
-        # test our comment stripping logic
-        f = g.trimesh.util.comment_strip
-
-        text = "hey whats up"
-        assert f(text) == text
-
-        text = "#hey whats up"
-        assert f(text) == ""
-
-        text = "   # hey whats up "
-        assert f(text) == ""
-
-        text = "# naahah\nhey whats up"
-        assert f(text) == "hey whats up"
-
-        text = "#naahah\nhey whats up\nhi"
-        assert f(text) == "hey whats up\nhi"
-
-        text = "#naahah\nhey whats up\n hi"
-        assert f(text) == "hey whats up\n hi"
-
-        text = "#naahah\nhey whats up\n hi#"
-        assert f(text) == "hey whats up\n hi"
-
-        text = "hey whats up# see here\n hi#"
-        assert f(text) == "hey whats up\n hi"
-
-
-class ArrayToString(unittest.TestCase):
-    def test_converts_an_unstructured_1d_array(self):
-        self.assertEqual(g.trimesh.util.array_to_string(np.array([1, 2, 3])), "1 2 3")
-
-    def test_converts_an_unstructured_int_array(self):
-        self.assertEqual(
-            g.trimesh.util.array_to_string(np.array([[1, 2, 3], [4, 5, 6]])),
-            "1 2 3\n4 5 6",
         )
+        == "1 1.10000000\n2 2.20000000"
+    )
 
-    def test_converts_an_unstructured_float_array(self):
-        self.assertEqual(
-            g.trimesh.util.array_to_string(
-                np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64)
-            ),
-            "1.00000000 2.00000000 3.00000000\n4.00000000 5.00000000 6.00000000",
-        )
 
-    def test_uses_the_specified_column_delimiter(self):
-        self.assertEqual(
-            g.trimesh.util.array_to_string(
-                np.array([[1, 2, 3], [4, 5, 6]]), col_delim="col"
-            ),
-            "1col2col3\n4col5col6",
-        )
-
-    def test_uses_the_specified_row_delimiter(self):
-        self.assertEqual(
-            g.trimesh.util.array_to_string(
-                np.array([[1, 2, 3], [4, 5, 6]]), row_delim="row"
-            ),
-            "1 2 3row4 5 6",
-        )
-
-    def test_uses_the_specified_value_format(self):
-        self.assertEqual(
-            g.trimesh.util.array_to_string(
-                np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64), value_format="{:.1f}"
-            ),
-            "1.0 2.0 3.0\n4.0 5.0 6.0",
-        )
-
-    def test_supports_uints(self):
-        self.assertEqual(
-            g.trimesh.util.array_to_string(np.array([1, 2, 3], dtype=np.uint8)), "1 2 3"
-        )
-
-    def test_supports_repeat_format(self):
-        self.assertEqual(
-            g.trimesh.util.array_to_string(
-                np.array([[1, 2, 3], [4, 5, 6]]), value_format="{} {}"
-            ),
-            "1 1 2 2 3 3\n4 4 5 5 6 6",
-        )
-
-    def test_raises_if_array_is_structured(self):
-        with self.assertRaises(ValueError):
-            g.trimesh.util.array_to_string(
-                np.array(
-                    [(1, 1.1), (2, 2.2)],
-                    dtype=[("some_int", np.int64), ("some_float", np.float64)],
-                )
+def test_converts_a_structured_array_with_2d_elements():
+    assert (
+        g.trimesh.util.structured_array_to_string(
+            np.array(
+                [([1, 2], 1.1), ([3, 4], 2.2)],
+                dtype=[("some_int", np.int64, 2), ("some_float", np.float64)],
             )
-
-    def test_raises_if_array_is_not_flat(self):
-        with self.assertRaises(ValueError):
-            g.trimesh.util.array_to_string(np.array([[[1, 2, 3], [4, 5, 6]]]))
-
-
-class StructuredArrayToString(unittest.TestCase):
-    def test_converts_a_structured_array_with_1d_elements(self):
-        self.assertEqual(
-            g.trimesh.util.structured_array_to_string(
-                np.array(
-                    [(1, 1.1), (2, 2.2)],
-                    dtype=[("some_int", np.int64), ("some_float", np.float64)],
-                )
-            ),
-            "1 1.10000000\n2 2.20000000",
         )
+        == "1 2 1.10000000\n3 4 2.20000000"
+    )
 
-    def test_converts_a_structured_array_with_2d_elements(self):
-        self.assertEqual(
-            g.trimesh.util.structured_array_to_string(
-                np.array(
-                    [([1, 2], 1.1), ([3, 4], 2.2)],
-                    dtype=[("some_int", np.int64, 2), ("some_float", np.float64)],
-                )
+
+def test_uses_the_specified_column_delimiter():
+    assert g.trimesh.util.structured_array_to_string(
+        np.array(
+            [(1, 1.1), (2, 2.2)],
+            dtype=[("some_int", np.int64), ("some_float", np.float64)],
+        ),
+        col_delim="col",
+    ) == "1col1.10000000\n2col2.20000000"
+
+
+def test_uses_the_specified_row_delimiter_structured():
+
+    assert (
+        g.trimesh.util.structured_array_to_string(
+            np.array(
+                [(1, 1.1), (2, 2.2)],
+                dtype=[("some_int", np.int64), ("some_float", np.float64)],
             ),
-            "1 2 1.10000000\n3 4 2.20000000",
+            row_delim="row",
         )
+        == "1 1.10000000row2 2.20000000"
+    )
 
-    def test_uses_the_specified_column_delimiter(self):
-        self.assertEqual(
-            g.trimesh.util.structured_array_to_string(
-                np.array(
-                    [(1, 1.1), (2, 2.2)],
-                    dtype=[("some_int", np.int64), ("some_float", np.float64)],
-                ),
-                col_delim="col",
+
+def test_uses_the_specified_value_format_structured():
+    assert (
+        g.trimesh.util.structured_array_to_string(
+            np.array(
+                [(1, 1.1), (2, 2.2)],
+                dtype=[("some_int", np.int64), ("some_float", np.float64)],
             ),
-            "1col1.10000000\n2col2.20000000",
+            value_format="{:.1f}",
         )
+        == "1.0 1.1\n2.0 2.2"
+    )
 
-    def test_uses_the_specified_row_delimiter(self):
-        self.assertEqual(
-            g.trimesh.util.structured_array_to_string(
-                np.array(
-                    [(1, 1.1), (2, 2.2)],
-                    dtype=[("some_int", np.int64), ("some_float", np.float64)],
-                ),
-                row_delim="row",
-            ),
-            "1 1.10000000row2 2.20000000",
-        )
 
-    def test_uses_the_specified_value_format(self):
-        self.assertEqual(
-            g.trimesh.util.structured_array_to_string(
-                np.array(
-                    [(1, 1.1), (2, 2.2)],
-                    dtype=[("some_int", np.int64), ("some_float", np.float64)],
-                ),
-                value_format="{:.1f}",
-            ),
-            "1.0 1.1\n2.0 2.2",
-        )
-
-    def test_supports_uints(self):
-        self.assertEqual(
-            g.trimesh.util.structured_array_to_string(
-                np.array(
-                    [(1, 1.1), (2, 2.2)],
-                    dtype=[("some_int", np.uint8), ("some_float", np.float64)],
-                )
-            ),
-            "1 1.10000000\n2 2.20000000",
-        )
-
-    def test_raises_if_array_is_unstructured(self):
-        with self.assertRaises(ValueError):
-            g.trimesh.util.structured_array_to_string(np.ndarray([1, 2, 3]))
-
-    def test_raises_if_value_format_specifies_repeats(self):
-        with self.assertRaises(ValueError):
-            g.trimesh.util.structured_array_to_string(
-                np.array(
-                    [(1, 1.1), (2, 2.2)],
-                    dtype=[("some_int", np.int64), ("some_float", np.float64)],
-                ),
-                value_format="{} {}",
+def test_supports_uints_check():
+    assert (
+        g.trimesh.util.structured_array_to_string(
+            np.array(
+                [(1, 1.1), (2, 2.2)],
+                dtype=[("some_int", np.uint8), ("some_float", np.float64)],
             )
+        )
+        == "1 1.10000000\n2 2.20000000"
+    )
 
-    def test_raises_if_array_is_not_flat(self):
-        with self.assertRaises(ValueError):
-            g.trimesh.util.structured_array_to_string(
-                np.array(
-                    [[(1, 1.1), (2, 2.2)], [(1, 1.1), (2, 2.2)]],
-                    dtype=[("some_int", np.int64), ("some_float", np.float64)],
-                )
+
+def test_raises_if_array_is_unstructured():
+
+    try:
+        g.trimesh.util.structured_array_to_string(np.ndarray([1, 2, 3]))
+        raise NameError("should have raised a ValueError")
+    except ValueError:
+        return
+
+
+def test_raises_if_value_format_specifies_repeats():
+    try:
+        g.trimesh.util.structured_array_to_string(
+            np.array(
+                [(1, 1.1), (2, 2.2)],
+                dtype=[("some_int", np.int64), ("some_float", np.float64)],
+            ),
+            value_format="{} {}",
+        )
+        raise NameError("should have raised a ValueError")
+    except ValueError:
+        return
+
+
+def test_raises_if_array_is_not_flat_structured():
+    try:
+        g.trimesh.util.structured_array_to_string(
+            np.array(
+                [[(1, 1.1), (2, 2.2)], [(1, 1.1), (2, 2.2)]],
+                dtype=[("some_int", np.int64), ("some_float", np.float64)],
             )
+        )
+        raise NameError("should have raised a ValueError")
+    except ValueError:
+        return
 
 
 if __name__ == "__main__":

--- a/tests/test_vertices.py
+++ b/tests/test_vertices.py
@@ -19,7 +19,9 @@ class VerticesTest(g.unittest.TestCase):
 
             # choose some random vertices and make sure their
             # face indices are correct
-            rand_vertices = g.np.random.randint(low=0, high=len(m.vertices), size=100)
+            rand_vertices = g.np.random.default_rng(seed=0).integers(
+                low=0, high=len(m.vertices), size=100
+            )
             for v in rand_vertices:
                 v_faces = g.np.where(m.faces == v)[0][::-1]
                 assert g.np.all(v_faces == m.vertex_faces[v][m.vertex_faces[v] >= 0])

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -4,6 +4,14 @@ except BaseException:
     import generic as g
 
 
+def test_all_exists():
+    # every name in `__all__` should be an attribute — a stale
+    # entry breaks `from trimesh.viewer import *`
+    from trimesh import viewer
+
+    assert all(hasattr(viewer, name) for name in viewer.__all__)
+
+
 class ViewerTest(g.unittest.TestCase):
     def test_viewer(self):
         # if the runner has not asked to include rendering exit

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -8,7 +8,8 @@ class VisualTest(g.unittest.TestCase):
     def test_face_subset_texture_visuals(self):
         m = g.get_mesh("fuze.obj", force="mesh")
 
-        face_index = g.np.random.choice(len(m.faces), len(m.triangles) // 2)
+        rng = g.np.random.default_rng(seed=0)
+        face_index = rng.choice(len(m.faces), len(m.triangles) // 2)
         idx = m.faces[g.np.unique(face_index)].flatten()
 
         ori = m.visual.uv[idx]
@@ -23,10 +24,11 @@ class VisualTest(g.unittest.TestCase):
 
         m = g.get_mesh("torus.STL")
 
-        vertex_colors = g.np.random.randint(0, 255, size=(len(m.vertices), 3))
+        rng = g.np.random.default_rng(seed=0)
+        vertex_colors = rng.integers(0, 255, size=(len(m.vertices), 3))
         m.visual = trimesh.visual.ColorVisuals(mesh=m, vertex_colors=vertex_colors)
 
-        face_index = g.np.random.choice(len(m.faces), len(m.triangles) // 2)
+        face_index = rng.choice(len(m.faces), len(m.triangles) // 2)
         idx = m.faces[g.np.unique(face_index)].flatten()
 
         ori = m.visual.vertex_colors[idx]

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -8,8 +8,8 @@ class VisualTest(g.unittest.TestCase):
     def test_face_subset_texture_visuals(self):
         m = g.get_mesh("fuze.obj", force="mesh")
 
-        rng = g.np.random.default_rng(seed=0)
-        face_index = rng.choice(len(m.faces), len(m.triangles) // 2)
+        random = g.np.random.default_rng(seed=0)
+        face_index = random.choice(len(m.faces), len(m.triangles) // 2)
         idx = m.faces[g.np.unique(face_index)].flatten()
 
         ori = m.visual.uv[idx]
@@ -24,11 +24,11 @@ class VisualTest(g.unittest.TestCase):
 
         m = g.get_mesh("torus.STL")
 
-        rng = g.np.random.default_rng(seed=0)
-        vertex_colors = rng.integers(0, 255, size=(len(m.vertices), 3))
+        random = g.np.random.default_rng(seed=0)
+        vertex_colors = random.integers(0, 255, size=(len(m.vertices), 3))
         m.visual = trimesh.visual.ColorVisuals(mesh=m, vertex_colors=vertex_colors)
 
-        face_index = rng.choice(len(m.faces), len(m.triangles) // 2)
+        face_index = random.choice(len(m.faces), len(m.triangles) // 2)
         idx = m.faces[g.np.unique(face_index)].flatten()
 
         ori = m.visual.vertex_colors[idx]

--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -215,10 +215,11 @@ class VoxelGridTest(g.unittest.TestCase):
     def test_is_filled(self):
         """More rigorous test of VoxelGrid.is_filled."""
         n = 10
-        matrix = g.np.random.uniform(size=(n + 1,) * 3) > 0.5
+        rng = g.np.random.default_rng(seed=0)
+        matrix = rng.uniform(size=(n + 1,) * 3) > 0.5
         not_matrix = g.np.logical_not(matrix)
         pitch = 1.0 / n
-        origin = g.np.random.uniform(size=(3,))
+        origin = rng.uniform(size=(3,))
         vox = g.trimesh.voxel.VoxelGrid(matrix)
         vox = vox.apply_scale(pitch).apply_translation(origin)
         not_vox = g.trimesh.voxel.VoxelGrid(not_matrix)
@@ -226,8 +227,8 @@ class VoxelGridTest(g.unittest.TestCase):
         for a, b in ((vox, not_vox), (not_vox, vox)):
             points = a.points
             # slight jitter - shouldn't change indices
-            points += (g.np.random.uniform(size=points.shape) - 1) * 0.4 * pitch
-            g.np.random.shuffle(points)
+            points += (rng.uniform(size=points.shape) - 1) * 0.4 * pitch
+            rng.shuffle(points)
 
             # all points are filled, and no empty points are filled
             assert g.np.all(a.is_filled(points))
@@ -337,7 +338,7 @@ class VoxelGridTest(g.unittest.TestCase):
         )
 
         v_brle = voxel.VoxelGrid(brle_obj.reshape(shape))
-        query_points = g.np.random.uniform(size=(100, 3), high=4)
+        query_points = g.np.random.default_rng(seed=0).uniform(size=(100, 3), high=4)
         self._test_equiv(v_rle, v_brle, query_points)
 
     def test_hollow(self):

--- a/tests/test_voxel.py
+++ b/tests/test_voxel.py
@@ -215,11 +215,11 @@ class VoxelGridTest(g.unittest.TestCase):
     def test_is_filled(self):
         """More rigorous test of VoxelGrid.is_filled."""
         n = 10
-        rng = g.np.random.default_rng(seed=0)
-        matrix = rng.uniform(size=(n + 1,) * 3) > 0.5
+        random = g.np.random.default_rng(seed=0)
+        matrix = random.uniform(size=(n + 1,) * 3) > 0.5
         not_matrix = g.np.logical_not(matrix)
         pitch = 1.0 / n
-        origin = rng.uniform(size=(3,))
+        origin = random.uniform(size=(3,))
         vox = g.trimesh.voxel.VoxelGrid(matrix)
         vox = vox.apply_scale(pitch).apply_translation(origin)
         not_vox = g.trimesh.voxel.VoxelGrid(not_matrix)
@@ -227,8 +227,8 @@ class VoxelGridTest(g.unittest.TestCase):
         for a, b in ((vox, not_vox), (not_vox, vox)):
             points = a.points
             # slight jitter - shouldn't change indices
-            points += (rng.uniform(size=points.shape) - 1) * 0.4 * pitch
-            rng.shuffle(points)
+            points += (random.uniform(size=points.shape) - 1) * 0.4 * pitch
+            random.shuffle(points)
 
             # all points are filled, and no empty points are filled
             assert g.np.all(a.is_filled(points))

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1392,14 +1392,24 @@ class Trimesh(Geometry3D):
 
         Alters `self.faces` and `self.vertices`
         """
-        if util.is_shape(self.faces, (-1, 3)):
-            # (len(self.faces), ) bool, mask for faces
-            face_mask = np.isfinite(self.faces).all(axis=1)
-            self.update_faces(face_mask)
-
         if util.is_shape(self.vertices, (-1, 3)):
             # (len(self.vertices), ) bool, mask for vertices
             vertex_mask = np.isfinite(self.vertices).all(axis=1)
+            # faces referencing a non-finite vertex must be dropped BEFORE
+            # the vertex is removed. `update_vertices` reindexes faces via
+            # an inverse-array whose entries for removed vertices default
+            # to 0, so any face touching a NaN/Inf vertex would otherwise
+            # be silently rewritten to a degenerate triangle (e.g. `[0,1,2]`
+            # becomes `[0,1,0]`) that later crashes the renderer. See #2445.
+            if (
+                util.is_shape(self.faces, (-1, 3))
+                and not vertex_mask.all()
+                and len(self.faces) > 0
+            ):
+                # face is kept only if all three vertex indices are valid
+                face_mask = vertex_mask[self.faces].all(axis=1)
+                if not face_mask.all():
+                    self.update_faces(face_mask)
             self.update_vertices(vertex_mask)
 
     def unique_faces(self) -> NDArray[np.bool_]:

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -53,6 +53,7 @@ from .typed import (
     Loadable,
     NDArray,
     Number,
+    Seed,
     Self,
     Sequence,
     ViewerType,
@@ -2016,6 +2017,7 @@ class Trimesh(Geometry3D):
         sigma: Floating = 0.0,
         n_samples: Integer = 1,
         threshold: Floating = 0.0,
+        seed: Seed = None,
     ) -> tuple[NDArray[float64], NDArray[float64]]:
         """
         Computes stable orientations of a mesh and their quasi-static probabilities.
@@ -2064,6 +2066,7 @@ class Trimesh(Geometry3D):
             sigma=sigma,
             n_samples=n_samples,
             threshold=threshold,
+            seed=seed,
         )
 
     def subdivide(
@@ -2504,6 +2507,7 @@ class Trimesh(Geometry3D):
         count: Integer,
         return_index: bool = False,
         face_weight: NDArray[float64] | None = None,
+        seed: Seed = None,
     ):
         """
         Return random samples distributed across the
@@ -2519,6 +2523,8 @@ class Trimesh(Geometry3D):
         face_weight : None or len(mesh.faces) float
           Weight faces by a factor other than face area.
           If None will be the same as face_weight=mesh.area
+        seed : None or int
+          Seed for deterministic results, otherwise OS entropy.
 
         Returns
         ---------
@@ -2528,7 +2534,7 @@ class Trimesh(Geometry3D):
           Index of self.faces
         """
         samples, index = sample.sample_surface(
-            mesh=self, count=count, face_weight=face_weight
+            mesh=self, count=count, face_weight=face_weight, seed=seed
         )
         if return_index:
             return samples, index

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2094,15 +2094,8 @@ class Trimesh(Geometry3D):
         mesh: trimesh.Trimesh
           The copy of current mesh with subdivided faces.
         """
-        if iterations is not None:
-            # check that our arguments are executable
-            if face_index is not None:
-                raise ValueError("Unable to subdivide a subset with multiple iterations!")
-            # decrement the next iteration
-            next_iteration = iterations - 1
-            # if we've reached zero exit
-            if next_iteration <= 0:
-                next_iteration = None
+        if iterations is not None and face_index is not None:
+            raise ValueError("Unable to subdivide a subset with multiple iterations!")
 
         visual = None
         if hasattr(self.visual, "uv") and np.shape(self.visual.uv) == (
@@ -2141,8 +2134,8 @@ class Trimesh(Geometry3D):
             process=False,
         )
 
-        if iterations is not None:
-            return result.subdivide(iterations=next_iteration)
+        if iterations is not None and iterations > 1:
+            return result.subdivide(iterations=iterations - 1)
 
         return result
 

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -1390,21 +1390,11 @@ class Trimesh(Geometry3D):
         if util.is_shape(self.vertices, (-1, 3)):
             # (len(self.vertices), ) bool, mask for vertices
             vertex_mask = np.isfinite(self.vertices).all(axis=1)
-            # faces referencing a non-finite vertex must be dropped BEFORE
-            # the vertex is removed. `update_vertices` reindexes faces via
-            # an inverse-array whose entries for removed vertices default
-            # to 0, so any face touching a NaN/Inf vertex would otherwise
-            # be silently rewritten to a degenerate triangle (e.g. `[0,1,2]`
-            # becomes `[0,1,0]`) that later crashes the renderer. See #2445.
-            if (
-                util.is_shape(self.faces, (-1, 3))
-                and not vertex_mask.all()
-                and len(self.faces) > 0
-            ):
-                # face is kept only if all three vertex indices are valid
-                face_mask = vertex_mask[self.faces].all(axis=1)
-                if not face_mask.all():
-                    self.update_faces(face_mask)
+            if util.is_shape(self.faces, (-1, 3)) and not vertex_mask.all():
+                # drop faces touching a removed vertex before reindexing
+                # maps them to a degenerate triangle, #2445 — empty faces
+                # and all-true masks early-return inside `update_faces`
+                self.update_faces(vertex_mask[self.faces].all(axis=1))
             self.update_vertices(vertex_mask)
 
     def unique_faces(self) -> NDArray[np.bool_]:

--- a/trimesh/collision.py
+++ b/trimesh/collision.py
@@ -9,18 +9,13 @@ except BaseException:
     fcl = None
 
 
-# fcl caps result.contacts at num_max_contacts per fcl.collide() call.
-# with our custom callback that becomes a per-pair cap: for return_names
-# we only need to know each pair collided so 1 suffices, but for
-# return_data the caller wants the full contact list so the cap must be
-# bigger than the worst-case contact count for any single pair — picked
-# high enough to be effectively unlimited for realistic geometry
+# contact cap per pair
 COLLISION_PER_PAIR_CAP = 100000
 
 
 def _fcl_collide_callback(o1, o2, cdata):
-    # fcl.defaultCollisionCallback halts BVH traversal once cumulative
-    # contacts hit num_max_contacts — dropping any later colliding pairs
+    # unlike fcl.defaultCollisionCallback never halt traversal
+    # early that would silently drop later colliding pairs
     fcl.collide(o1=o1, o2=o2, request=cdata.request, result=cdata.result)
     return False
 
@@ -29,8 +24,8 @@ def _fcl_collision_data(return_names, return_data):
     # build (cdata, callback) sized for what the caller actually needs
     if not (return_names or return_data):
         return fcl.CollisionData(), fcl.defaultCollisionCallback
-    # one contact per pair is enough to identify the pair — only ask
-    # fcl for many contacts if the caller wants the contact data itself
+    # one contact identifies a pair only ask for more if the
+    # caller wants the contact data itself
     request = fcl.CollisionRequest(
         num_max_contacts=COLLISION_PER_PAIR_CAP if return_data else 1,
         enable_contact=True,

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -185,6 +185,14 @@ def revolve(
     if transform is not None:
         # apply transform to vertices
         vertices = tf.transform_points(vertices, transform)
+        # if the transform flips the winding (i.e. has a negative
+        # determinant / reflection) flip faces back so the normals
+        # still face outwards and the result remains a valid volume
+        # (see issue #2439); mirrors the handling in
+        # `extrude_triangulation`
+        if tf.flips_winding(transform):
+            # fliplr makes arrays non-contiguous so re-pack them
+            faces = np.ascontiguousarray(np.fliplr(faces))
 
     # create the mesh from our vertices and faces
     mesh = Trimesh(vertices=vertices, faces=faces, **kwargs)

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -1009,8 +1009,8 @@ def capsule(
     height = abs(float(height))
     radius = abs(float(radius))
 
-    # create a half circle
-    theta = np.linspace(-np.pi / 2.0, np.pi / 2.0, count[0])
+    # create a half circle with a vertex at 0.0
+    theta = np.linspace(-np.pi / 2.0, np.pi / 2.0, count[0] + 1)
     linestring = np.column_stack((np.cos(theta), np.sin(theta))) * radius
 
     # offset the top and bottom by half the height

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -16,7 +16,7 @@ from .base import Trimesh
 from .constants import log, tol
 from .geometry import align_vectors, faces_to_edges, plane_transform
 from .resources import get_json
-from .typed import ArrayLike, Integer, NDArray, Number
+from .typed import ArrayLike, Integer, NDArray, Number, Seed
 
 try:
     # shapely is a soft dependency
@@ -1229,7 +1229,7 @@ def _segment_to_cylinder(segment: ArrayLike):
     return transform, height
 
 
-def random_soup(face_count: Integer = 100):
+def random_soup(face_count: Integer = 100, seed: Seed = None):
     """
     Return random triangles as a Trimesh
 
@@ -1237,13 +1237,15 @@ def random_soup(face_count: Integer = 100):
     -----------
     face_count : int
       Number of faces desired in mesh
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     -----------
     soup : trimesh.Trimesh
       Geometry with face_count random faces
     """
-    vertices = np.random.random((face_count * 3, 3)) - 0.5
+    vertices = util.random_generator(seed).random((face_count * 3, 3)) - 0.5
     faces = np.arange(face_count * 3).reshape((-1, 3))
     soup = Trimesh(vertices=vertices, faces=faces)
     return soup

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -185,11 +185,8 @@ def revolve(
     if transform is not None:
         # apply transform to vertices
         vertices = tf.transform_points(vertices, transform)
-        # if the transform flips the winding (i.e. has a negative
-        # determinant / reflection) flip faces back so the normals
-        # still face outwards and the result remains a valid volume
-        # (see issue #2439); mirrors the handling in
-        # `extrude_triangulation`
+        # a reflecting transform flips winding so flip the faces
+        # back to keep normals outward, #2439
         if tf.flips_winding(transform):
             # fliplr makes arrays non-contiguous so re-pack them
             faces = np.ascontiguousarray(np.fliplr(faces))

--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -1009,8 +1009,14 @@ def capsule(
     height = abs(float(height))
     radius = abs(float(radius))
 
-    # create a half circle with a vertex at 0.0
-    theta = np.linspace(-np.pi / 2.0, np.pi / 2.0, count[0] + 1)
+    # two quarter circles sharing an equator vertex
+    # each hemisphere reaches full radius symmetrically
+    theta = np.concatenate(
+        (
+            np.linspace(-np.pi / 2.0, 0.0, count[0] // 2 + 1),
+            np.linspace(0.0, np.pi / 2.0, count[0] // 2 + 1),
+        )
+    )
     linestring = np.column_stack((np.cos(theta), np.sin(theta))) * radius
 
     # offset the top and bottom by half the height

--- a/trimesh/exchange/common.py
+++ b/trimesh/exchange/common.py
@@ -5,24 +5,10 @@ trimesh.exchange.common
 Helpers shared across exchange loaders.
 """
 
-from typing import TypedDict
-
-
-class XMLParserOptions(TypedDict):
-    """lxml parser options passed to `etree.XMLParser` and `etree.iterparse`."""
-
-    resolve_entities: bool
-    no_network: bool
-    load_dtd: bool
-    dtd_validation: bool
-    attribute_defaults: bool
-    recover: bool
-
-
 # lxml parser options shared across exchange loaders — disable entity
-# resolution, network access, and DTD loading. `huge_tree` is not here as
-# loaders pass it per-call: it defaults off to keep the libxml2 size guards
-XML_PARSER_OPTIONS: XMLParserOptions = {
+# resolution, network access, and DTD loading. `huge_tree` is passed per-call
+# by loaders rather than set here as it is a caller opt-in
+XML_PARSER_OPTIONS = {
     "resolve_entities": False,
     "no_network": True,
     "load_dtd": False,

--- a/trimesh/exchange/common.py
+++ b/trimesh/exchange/common.py
@@ -13,7 +13,6 @@ class XMLParserOptions(TypedDict):
 
     resolve_entities: bool
     no_network: bool
-    huge_tree: bool
     load_dtd: bool
     dtd_validation: bool
     attribute_defaults: bool
@@ -21,13 +20,11 @@ class XMLParserOptions(TypedDict):
 
 
 # lxml parser options shared across exchange loaders — disable entity
-# resolution, network access, and DTD loading. `huge_tree` stays enabled
-# as 3DXML stores vertex data in text nodes past the ~10MB libxml2 cap
-# and the archive size cap in `util.decompress` already bounds memory
+# resolution, network access, and DTD loading. `huge_tree` is not here as
+# loaders pass it per-call: it defaults off to keep the libxml2 size guards
 XML_PARSER_OPTIONS: XMLParserOptions = {
     "resolve_entities": False,
     "no_network": True,
-    "huge_tree": True,
     "load_dtd": False,
     "dtd_validation": False,
     "attribute_defaults": False,

--- a/trimesh/exchange/common.py
+++ b/trimesh/exchange/common.py
@@ -6,11 +6,11 @@ Helpers shared across exchange loaders.
 """
 
 # lxml parser options shared across exchange loaders — disable entity
-# resolution, network access, and DTD loading. `huge_tree` is passed per-call
-# by loaders rather than set here as it is a caller opt-in
+# resolution, network access, and DTD loading, and keep libxml2 size guards
 XML_PARSER_OPTIONS = {
     "resolve_entities": False,
     "no_network": True,
+    "huge_tree": False,
     "load_dtd": False,
     "dtd_validation": False,
     "attribute_defaults": False,

--- a/trimesh/exchange/common.py
+++ b/trimesh/exchange/common.py
@@ -21,11 +21,13 @@ class XMLParserOptions(TypedDict):
 
 
 # lxml parser options shared across exchange loaders — disable entity
-# resolution, network access, and DTD loading, and keep libxml2 size guards
+# resolution, network access, and DTD loading. `huge_tree` stays enabled
+# as 3DXML stores vertex data in text nodes past the ~10MB libxml2 cap
+# and the archive size cap in `util.decompress` already bounds memory
 XML_PARSER_OPTIONS: XMLParserOptions = {
     "resolve_entities": False,
     "no_network": True,
-    "huge_tree": False,
+    "huge_tree": True,
     "load_dtd": False,
     "dtd_validation": False,
     "attribute_defaults": False,

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -1477,6 +1477,8 @@ def _read_buffers(
         # load data from buffers into numpy arrays
         # using the layout described by accessors
         access = [None] * len(header["accessors"])
+        # bufferless, non-sparse accessors must be filled by an extension or stay zero
+        placeholders = set()
         for index, a in enumerate(header["accessors"]):
             # number of items
             count = a["count"]
@@ -1535,7 +1537,9 @@ def _read_buffers(
                         data[start : start + length], dtype=dtype
                     ).reshape(shape)
             else:
-                # a "sparse" accessor should be initialized as zeros
+                # zero placeholder a decoder may replace
+                if "sparse" not in a:
+                    placeholders.add(index)
                 access[index] = np.zeros(count * per_count, dtype=dtype).reshape(shape)
 
         # possibly load images and textures into material objects
@@ -1552,6 +1556,8 @@ def _read_buffers(
     # be inserted to avoid a potentially slow search through our
     # dict of names
     name_counts = {}
+    # extensions whose geometry we couldn't decode for lack of a handler
+    undecoded = set()
     for index, m in enumerate(header.get("meshes", [])):
         try:
             # GLTF spec indicates implicit units are meters
@@ -1572,13 +1578,20 @@ def _read_buffers(
                 # Handle primitive preprocessing extensions (e.g. Draco decompression)
                 # These run before reading accessors since they may modify them
                 if prim_extensions := p.get("extensions"):
+                    missing = set()
                     handle_extensions(
                         extensions=prim_extensions,
                         scope="primitive_preprocess",
+                        unhandled=missing,
                         primitive=p,
                         accessors=access,
                         views=views,
                     )
+                    # an unhandled extension that left attributes as placeholder zeros
+                    if missing and not placeholders.isdisjoint(
+                        p.get("attributes", {}).values()
+                    ):
+                        undecoded.update(missing)
 
                 # if we don't have a triangular mesh continue
                 # if not specified assume it is a mesh
@@ -1721,6 +1734,12 @@ def _read_buffers(
                 log.debug("failed to load mesh", exc_info=True)
             else:
                 raise E
+
+    if undecoded:
+        log.warning(
+            "`%s` GLTF extension has no handler, values are placeholder zeros",
+            ", ".join(sorted(undecoded)),
+        )
 
     # sometimes GLTF "meshes" come with multiple "primitives"
     # by default we return one Trimesh object per "primitive"

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -18,6 +18,7 @@ from ...caching import hash_fast
 from ...constants import log, tol
 from ...resolvers import ResolverLike, ZipResolver
 from ...scene.cameras import Camera
+from ...scene.transforms import DEFAULT_BASE_FRAME
 from ...typed import NDArray, Stream
 from ...util import triangle_strips_to_faces, unique_name
 from .extensions import handle_extensions
@@ -1809,13 +1810,8 @@ def _read_buffers(
         name_index[unique_name(n.get("name", str(i)), name_index, counts=name_counts)] = i
     # names: {index: name}
     names = {v: k for k, v in name_index.items()}
-
-    # the GLTF is allowed to declare a base frame, should we have used that?
-    base_frame = "world"
-    if base_frame in name_index:
-        # todo : handle this?
-        log.debug("file contains a `world` node, we may stomp on it")
-    names[base_frame] = base_frame
+    # set the default base frame
+    names[DEFAULT_BASE_FRAME] = DEFAULT_BASE_FRAME
 
     # visited, kwargs for scene.graph.update
     graph = deque()
@@ -1833,12 +1829,17 @@ def _read_buffers(
         # otherwise just use the first index
         scene_index = 0
 
-    base_frame = "world"
     if "scenes" in header:
+        roots = header["scenes"][scene_index].get("nodes", [])
+        # a non-root node named "world" merges with the base frame and loses
+        # its transform — rename just that node
+        world = name_index.get(DEFAULT_BASE_FRAME)
+        if world is not None and world not in roots:
+            names[world] = unique_name(DEFAULT_BASE_FRAME, set(names.values()))
         # start the traversal from the base frame to the roots
-        for root in header["scenes"][scene_index].get("nodes", []):
+        for root in roots:
             # add transform from base frame to these root nodes
-            queue.append((base_frame, root))
+            queue.append((DEFAULT_BASE_FRAME, root))
 
     # make sure we don't process an edge multiple times
     consumed = set()
@@ -1956,7 +1957,7 @@ def _read_buffers(
         "class": "Scene",
         "geometry": meshes,
         "graph": graph,
-        "base_frame": base_frame,
+        "base_frame": DEFAULT_BASE_FRAME,
         "camera": camera,
         "camera_transform": camera_transform,
         "metadata": {},

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -21,7 +21,7 @@ from ...scene.cameras import Camera
 from ...scene.transforms import DEFAULT_BASE_FRAME
 from ...typed import NDArray, Stream
 from ...util import triangle_strips_to_faces, unique_name
-from .extensions import handle_extensions
+from .extensions import handle_extensions, unregistered
 
 # magic numbers which have meaning in GLTF
 # most are uint32's of UTF-8 text
@@ -655,7 +655,8 @@ def _create_gltf_structure(
     # world node to the 0-index
     tree = {
         "scene": 0,
-        "scenes": [{"nodes": [0]}],
+        # the root node indices are filled in from the scene graph
+        "scenes": [{}],
         "asset": {"version": "2.0", "generator": "https://github.com/mikedh/trimesh"},
         "accessors": OrderedDict(),
         "meshes": [],
@@ -718,6 +719,9 @@ def _create_gltf_structure(
 
     # grab the flattened scene graph in GLTF's format
     nodes = scene.graph.to_gltf(scene=scene, mesh_index=mesh_index)
+    # set the roots on the existing scene dict — it may already
+    # hold `extras` with the scene metadata
+    tree["scenes"][0]["nodes"] = nodes.pop("scene_roots")
     tree.update(nodes)
 
     extensions_used = set()
@@ -1576,23 +1580,21 @@ def _read_buffers(
                 metadata["gltf_extensions"] = m["extensions"]
 
             for p in m["primitives"]:
-                # Handle primitive preprocessing extensions (e.g. Draco decompression)
-                # These run before reading accessors since they may modify them
+                # preprocessing extensions like draco decompression run
+                # before reading accessors as they may modify them
                 if prim_extensions := p.get("extensions"):
-                    missing = set()
                     handle_extensions(
                         extensions=prim_extensions,
                         scope="primitive_preprocess",
-                        unhandled=missing,
                         primitive=p,
                         accessors=access,
                         views=views,
                     )
-                    # an unhandled extension that left attributes as placeholder zeros
-                    if missing and not placeholders.isdisjoint(
-                        p.get("attributes", {}).values()
-                    ):
-                        undecoded.update(missing)
+                    # warn later if an unhandled extension left placeholder zeros
+                    if not placeholders.isdisjoint(p.get("attributes", {}).values()):
+                        undecoded.update(
+                            unregistered(prim_extensions, "primitive_preprocess")
+                        )
 
                 # if we don't have a triangular mesh continue
                 # if not specified assume it is a mesh
@@ -1810,7 +1812,16 @@ def _read_buffers(
         name_index[unique_name(n.get("name", str(i)), name_index, counts=name_counts)] = i
     # names: {index: name}
     names = {v: k for k, v in name_index.items()}
-    # set the default base frame
+
+    # rename any file node that collides with the synthetic base frame
+    # so its transform and children survive under their own frame —
+    # trimesh's own exports never contain one, #2421
+    world = name_index.get(DEFAULT_BASE_FRAME)
+    if world is not None:
+        names[world] = unique_name(DEFAULT_BASE_FRAME, set(names.values()))
+
+    # traversal edges are seeded as (DEFAULT_BASE_FRAME, index) so the
+    # index-keyed dict intentionally holds one string key for the base
     names[DEFAULT_BASE_FRAME] = DEFAULT_BASE_FRAME
 
     # visited, kwargs for scene.graph.update
@@ -1830,14 +1841,8 @@ def _read_buffers(
         scene_index = 0
 
     if "scenes" in header:
-        roots = header["scenes"][scene_index].get("nodes", [])
-        # a non-root node named "world" merges with the base frame and loses
-        # its transform — rename just that node
-        world = name_index.get(DEFAULT_BASE_FRAME)
-        if world is not None and world not in roots:
-            names[world] = unique_name(DEFAULT_BASE_FRAME, set(names.values()))
         # start the traversal from the base frame to the roots
-        for root in roots:
+        for root in header["scenes"][scene_index].get("nodes", []):
             # add transform from base frame to these root nodes
             queue.append((DEFAULT_BASE_FRAME, root))
 

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -489,12 +489,9 @@ def _uri_to_bytes(uri: str, resolver: ResolverLike | None) -> bytes:
         # string didn't contain the base64 header
         # so return the result from the resolver
         return resolver[uri]
-    # strip the base64 header — cap the encoded length against the decompress
-    # limit (4 b64 chars per 3 raw bytes) to bound the decoded size
-    payload = uri[index + 7 :]
-    if len(payload) > util.MAX_ARCHIVE_SIZE * 4 // 3 + 4:
-        raise ValueError("gltf base64 payload exceeds size cap")
-    return base64.b64decode(payload)
+    # strip the base64 header and decode: note that the decoded result is
+    # 3/4 the length of the payload which is already in-memory
+    return base64.b64decode(uri[index + 7 :])
 
 
 def _buffer_append(ordered, data):

--- a/trimesh/exchange/gltf/extensions.py
+++ b/trimesh/exchange/gltf/extensions.py
@@ -158,6 +158,7 @@ def handle_extensions(
     *,
     extensions: dict[str, Any] | None,
     scope: Scope,
+    unhandled: set | None = None,
     **kwargs,
 ) -> Any:
     """
@@ -169,6 +170,9 @@ def handle_extensions(
       The "extensions" dict from a glTF element, or None.
     scope
       Handler scope to invoke.
+    unhandled
+      If passed, extension names with no registered handler for this
+      scope are added to this set so callers can react to them.
     **kwargs
       Scope-specific arguments that will be combined with extension data
       into a typed context dict. Required kwargs by scope:
@@ -185,12 +189,16 @@ def handle_extensions(
       For scopes ending in "_source", returns first non-None result.
       For "primitive" scope, automatically merges results into mesh_kwargs.
     """
+    registered = _handlers.get(scope, {})
+    if unhandled is not None and extensions:
+        unhandled.update(extensions.keys() - registered.keys())
+
     if not extensions or scope not in _handlers:
         return {} if not scope.endswith("_source") else None
 
     results = {}
     for ext_name, data in extensions.items():
-        if ext_name not in _handlers[scope]:
+        if ext_name not in registered:
             continue
         try:
             # Build context dict with data + all kwargs

--- a/trimesh/exchange/gltf/extensions.py
+++ b/trimesh/exchange/gltf/extensions.py
@@ -7,7 +7,7 @@ Each scope has a TypedDict defining the context passed to handlers.
 """
 
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any, Literal, TypeAlias, TypedDict
 
 from ...constants import log
@@ -154,11 +154,29 @@ def register_handler(name: str, scope: Scope) -> Callable[[Handler], Handler]:
     return decorator
 
 
+def unregistered(extensions: Iterable[str], scope: Scope) -> set:
+    """
+    Find extension names with no registered handler for a scope.
+
+    Parameters
+    ----------
+    extensions
+      Extension names, i.e. the keys of a glTF "extensions" dict.
+    scope
+      Handler scope to check against.
+
+    Returns
+    -------
+    missing
+      Extension names with no handler registered for the scope.
+    """
+    return set(extensions) - _handlers.get(scope, {}).keys()
+
+
 def handle_extensions(
     *,
     extensions: dict[str, Any] | None,
     scope: Scope,
-    unhandled: set | None = None,
     **kwargs,
 ) -> Any:
     """
@@ -170,9 +188,6 @@ def handle_extensions(
       The "extensions" dict from a glTF element, or None.
     scope
       Handler scope to invoke.
-    unhandled
-      If passed, extension names with no registered handler for this
-      scope are added to this set so callers can react to them.
     **kwargs
       Scope-specific arguments that will be combined with extension data
       into a typed context dict. Required kwargs by scope:
@@ -189,16 +204,12 @@ def handle_extensions(
       For scopes ending in "_source", returns first non-None result.
       For "primitive" scope, automatically merges results into mesh_kwargs.
     """
-    registered = _handlers.get(scope, {})
-    if unhandled is not None and extensions:
-        unhandled.update(extensions.keys() - registered.keys())
-
     if not extensions or scope not in _handlers:
         return {} if not scope.endswith("_source") else None
 
     results = {}
     for ext_name, data in extensions.items():
-        if ext_name not in registered:
+        if ext_name not in _handlers[scope]:
             continue
         try:
             # Build context dict with data + all kwargs

--- a/trimesh/exchange/threedxml.py
+++ b/trimesh/exchange/threedxml.py
@@ -25,7 +25,7 @@ from .. import util
 from ..visual.texture import TextureVisuals
 
 
-def load_3DXML(file_obj, *args, huge_tree: bool = False, **kwargs):
+def load_3DXML(file_obj, *args, **kwargs):
     """
     Load a 3DXML scene into kwargs. 3DXML is a CAD format
     that can be exported from Solidworks
@@ -49,8 +49,7 @@ def load_3DXML(file_obj, *args, huge_tree: bool = False, **kwargs):
         # contains non- xml files, like JPG previews
         try:
             as_etree[k] = etree.fromstring(
-                v.read(),
-                parser=etree.XMLParser(**XML_PARSER_OPTIONS, huge_tree=huge_tree),
+                v.read(), parser=etree.XMLParser(**XML_PARSER_OPTIONS)
             )
         except etree.XMLSyntaxError:
             # move the file object back to the file start

--- a/trimesh/exchange/threedxml.py
+++ b/trimesh/exchange/threedxml.py
@@ -25,7 +25,7 @@ from .. import util
 from ..visual.texture import TextureVisuals
 
 
-def load_3DXML(file_obj, *args, **kwargs):
+def load_3DXML(file_obj, *args, huge_tree: bool = False, **kwargs):
     """
     Load a 3DXML scene into kwargs. 3DXML is a CAD format
     that can be exported from Solidworks
@@ -49,7 +49,8 @@ def load_3DXML(file_obj, *args, **kwargs):
         # contains non- xml files, like JPG previews
         try:
             as_etree[k] = etree.fromstring(
-                v.read(), parser=etree.XMLParser(**XML_PARSER_OPTIONS)
+                v.read(),
+                parser=etree.XMLParser(**XML_PARSER_OPTIONS, huge_tree=huge_tree),
             )
         except etree.XMLSyntaxError:
             # move the file object back to the file start

--- a/trimesh/exchange/threemf.py
+++ b/trimesh/exchange/threemf.py
@@ -58,7 +58,7 @@ def _read_mesh(mesh):
     return v_array, f_array
 
 
-def load_3MF(file_obj, postprocess=True, huge_tree: bool = False, **kwargs):
+def load_3MF(file_obj, postprocess=True, **kwargs):
     """
     Load a 3MF formatted file into a Trimesh scene.
 
@@ -80,13 +80,7 @@ def load_3MF(file_obj, postprocess=True, huge_tree: bool = False, **kwargs):
 
     # read root attributes only from XML first
     _event, root = next(
-        etree.iterparse(
-            model,
-            tag=("{*}model"),
-            events=("start",),
-            **XML_PARSER_OPTIONS,
-            huge_tree=huge_tree,
-        )
+        etree.iterparse(model, tag=("{*}model"), events=("start",), **XML_PARSER_OPTIONS)
     )
     # collect unit information from the tree
     if "unit" in root.attrib:
@@ -116,11 +110,7 @@ def load_3MF(file_obj, postprocess=True, huge_tree: bool = False, **kwargs):
     # loaded elements are cleared to avoid ballooning memory
     model.seek(0)
     for _, obj in etree.iterparse(
-        model,
-        tag=("{*}object", "{*}build"),
-        events=("end",),
-        **XML_PARSER_OPTIONS,
-        huge_tree=huge_tree,
+        model, tag=("{*}object", "{*}build"), events=("end",), **XML_PARSER_OPTIONS
     ):
         # parse objects
         if "object" in obj.tag:
@@ -170,7 +160,6 @@ def load_3MF(file_obj, postprocess=True, huge_tree: bool = False, **kwargs):
                         tag=("{*}mesh"),
                         events=("end",),
                         **XML_PARSER_OPTIONS,
-                        huge_tree=huge_tree,
                     ):
                         v, f = _read_mesh(m)
                         v_seq[mesh_index].append(v)

--- a/trimesh/exchange/threemf.py
+++ b/trimesh/exchange/threemf.py
@@ -58,7 +58,7 @@ def _read_mesh(mesh):
     return v_array, f_array
 
 
-def load_3MF(file_obj, postprocess=True, **kwargs):
+def load_3MF(file_obj, postprocess=True, huge_tree: bool = False, **kwargs):
     """
     Load a 3MF formatted file into a Trimesh scene.
 
@@ -80,7 +80,13 @@ def load_3MF(file_obj, postprocess=True, **kwargs):
 
     # read root attributes only from XML first
     _event, root = next(
-        etree.iterparse(model, tag=("{*}model"), events=("start",), **XML_PARSER_OPTIONS)
+        etree.iterparse(
+            model,
+            tag=("{*}model"),
+            events=("start",),
+            **XML_PARSER_OPTIONS,
+            huge_tree=huge_tree,
+        )
     )
     # collect unit information from the tree
     if "unit" in root.attrib:
@@ -110,7 +116,11 @@ def load_3MF(file_obj, postprocess=True, **kwargs):
     # loaded elements are cleared to avoid ballooning memory
     model.seek(0)
     for _, obj in etree.iterparse(
-        model, tag=("{*}object", "{*}build"), events=("end",), **XML_PARSER_OPTIONS
+        model,
+        tag=("{*}object", "{*}build"),
+        events=("end",),
+        **XML_PARSER_OPTIONS,
+        huge_tree=huge_tree,
     ):
         # parse objects
         if "object" in obj.tag:
@@ -160,6 +170,7 @@ def load_3MF(file_obj, postprocess=True, **kwargs):
                         tag=("{*}mesh"),
                         events=("end",),
                         **XML_PARSER_OPTIONS,
+                        huge_tree=huge_tree,
                     ):
                         v, f = _read_mesh(m)
                         v_seq[mesh_index].append(v)

--- a/trimesh/exchange/xaml.py
+++ b/trimesh/exchange/xaml.py
@@ -13,7 +13,7 @@ from .. import transformations as tf
 from .. import util, visual
 
 
-def load_XAML(file_obj, *args, **kwargs):
+def load_XAML(file_obj, *args, huge_tree: bool = False, **kwargs):
     """
     Load a 3D XAML file.
 
@@ -61,7 +61,9 @@ def load_XAML(file_obj, *args, **kwargs):
 
     # read the file and parse XML
     file_data = file_obj.read()
-    root = etree.fromstring(file_data, parser=etree.XMLParser(**XML_PARSER_OPTIONS))
+    root = etree.fromstring(
+        file_data, parser=etree.XMLParser(**XML_PARSER_OPTIONS, huge_tree=huge_tree)
+    )
 
     # the XML namespace
     ns = root.tag.split("}")[0] + "}"

--- a/trimesh/exchange/xaml.py
+++ b/trimesh/exchange/xaml.py
@@ -13,7 +13,7 @@ from .. import transformations as tf
 from .. import util, visual
 
 
-def load_XAML(file_obj, *args, huge_tree: bool = False, **kwargs):
+def load_XAML(file_obj, *args, **kwargs):
     """
     Load a 3D XAML file.
 
@@ -61,9 +61,7 @@ def load_XAML(file_obj, *args, huge_tree: bool = False, **kwargs):
 
     # read the file and parse XML
     file_data = file_obj.read()
-    root = etree.fromstring(
-        file_data, parser=etree.XMLParser(**XML_PARSER_OPTIONS, huge_tree=huge_tree)
-    )
+    root = etree.fromstring(file_data, parser=etree.XMLParser(**XML_PARSER_OPTIONS))
 
     # the XML namespace
     ns = root.tag.split("}")[0] + "}"

--- a/trimesh/inertia.py
+++ b/trimesh/inertia.py
@@ -73,7 +73,7 @@ def sphere_inertia(mass: Number, radius: Number) -> NDArray[float64]:
 
 def points_inertia(
     points: ArrayLike,
-    weights: None | ArrayLike | Number = None,
+    weights: ArrayLike | Number | None = None,
     at_center_mass: bool = True,
 ) -> NDArray[float64]:
     """

--- a/trimesh/path/exchange/load.py
+++ b/trimesh/path/exchange/load.py
@@ -44,7 +44,7 @@ def load_path(file_obj, file_type: str | None = None, **kwargs):
         if arg.file_type in path_loaders:
             kwargs.update(
                 path_loaders[arg.file_type](
-                    file_obj=arg.file_obj, file_type=arg.file_type
+                    file_obj=arg.file_obj, file_type=arg.file_type, **kwargs
                 )
             )
         elif arg.file_type == "ply":

--- a/trimesh/path/exchange/load.py
+++ b/trimesh/path/exchange/load.py
@@ -44,7 +44,7 @@ def load_path(file_obj, file_type: str | None = None, **kwargs):
         if arg.file_type in path_loaders:
             kwargs.update(
                 path_loaders[arg.file_type](
-                    file_obj=arg.file_obj, file_type=arg.file_type, **kwargs
+                    file_obj=arg.file_obj, file_type=arg.file_type
                 )
             )
         elif arg.file_type == "ply":

--- a/trimesh/path/exchange/svg_io.py
+++ b/trimesh/path/exchange/svg_io.py
@@ -22,9 +22,7 @@ _IDENTITY = np.eye(3)
 _IDENTITY.flags["WRITEABLE"] = False
 
 
-def svg_to_path(
-    file_obj=None, file_type=None, path_string=None, huge_tree: bool = False, **kwargs
-):
+def svg_to_path(file_obj=None, file_type=None, path_string=None):
     """
     Load an SVG file into a Path2D object.
 
@@ -50,8 +48,7 @@ def svg_to_path(
     if file_obj is not None:
         # first parse the XML
         tree = etree.fromstring(
-            file_obj.read(),
-            parser=etree.XMLParser(**XML_PARSER_OPTIONS, huge_tree=huge_tree),
+            file_obj.read(), parser=etree.XMLParser(**XML_PARSER_OPTIONS)
         )
         # store paths and transforms as
         # (path string, 3x3 matrix)

--- a/trimesh/path/exchange/svg_io.py
+++ b/trimesh/path/exchange/svg_io.py
@@ -22,7 +22,9 @@ _IDENTITY = np.eye(3)
 _IDENTITY.flags["WRITEABLE"] = False
 
 
-def svg_to_path(file_obj=None, file_type=None, path_string=None):
+def svg_to_path(
+    file_obj=None, file_type=None, path_string=None, huge_tree: bool = False, **kwargs
+):
     """
     Load an SVG file into a Path2D object.
 
@@ -48,7 +50,8 @@ def svg_to_path(file_obj=None, file_type=None, path_string=None):
     if file_obj is not None:
         # first parse the XML
         tree = etree.fromstring(
-            file_obj.read(), parser=etree.XMLParser(**XML_PARSER_OPTIONS)
+            file_obj.read(),
+            parser=etree.XMLParser(**XML_PARSER_OPTIONS, huge_tree=huge_tree),
         )
         # store paths and transforms as
         # (path string, 3x3 matrix)

--- a/trimesh/path/packing.py
+++ b/trimesh/path/packing.py
@@ -8,8 +8,8 @@ Pack rectangular regions onto larger rectangular regions.
 import numpy as np
 
 from ..constants import log, tol
-from ..typed import ArrayLike, Integer, NDArray, Number, float64
-from ..util import allclose, bounds_tree
+from ..typed import ArrayLike, Integer, NDArray, Number, Seed, float64
+from ..util import allclose, bounds_tree, random_generator
 
 # floating point zero
 _TOL_ZERO = 1e-12
@@ -160,7 +160,9 @@ def _roll(a, count):
         return np.concatenate([a[-count:], a[:-count]])
 
 
-def rectangles_single(extents, size=None, shuffle=False, rotate=True, random=None):
+def rectangles_single(
+    extents, size=None, shuffle=False, rotate=True, random: Seed = None
+):
     """
     Execute a single insertion order of smaller rectangles onto
     a larger rectangle using a binary space partition tree.
@@ -179,6 +181,9 @@ def rectangles_single(extents, size=None, shuffle=False, rotate=True, random=Non
       on insertion order.
     rotate : bool
       If True, allow integer-roll rotation.
+    random : None or int or numpy.random.Generator
+      Source for the shuffle, pass a `Generator` to draw from
+      one stream across repeated calls.
 
     Returns
     ---------
@@ -200,11 +205,8 @@ def rectangles_single(extents, size=None, shuffle=False, rotate=True, random=Non
     order = np.argsort(extents.max(axis=1))[::-1]
 
     if shuffle:
-        if random is not None:
-            order = random.permutation(order)
-        else:
-            # reorder with permutations
-            order = np.random.permutation(order)
+        # reorder with permutations
+        order = random_generator(random).permutation(order)
 
     if size is None:
         # if no bounds are passed start it with the size of a large
@@ -416,7 +418,7 @@ def rectangles(
     iterations=50,
     rotate=True,
     quanta=None,
-    seed=None,
+    seed: Seed = None,
 ):
     """
     Run multiple iterations of rectangle packing, this is the
@@ -464,10 +466,9 @@ def rectangles(
     # how many rect were inserted
     best_count = 0
 
-    if seed is None:
-        random = None
-    else:
-        random = np.random.default_rng(seed=seed)
+    # hoist the generator so the loop below draws from one stream
+    # rather than re-collecting OS entropy on every iteration
+    random = random_generator(seed)
 
     for i in range(iterations):
         # run a single insertion order
@@ -511,7 +512,7 @@ def images(
     power_resize: bool = False,
     deduplicate: bool = False,
     iterations: Integer | None = 50,
-    seed: Integer | None = None,
+    seed: Seed = None,
     spacing: Number | None = None,
     mode: str | None = None,
 ):

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -1227,27 +1227,35 @@ class Path2D(Path):
 
         Returns
         ---------
-        full : (len(self.root),) shapely.geometry.Polygon
-            Polygons containing interiors
+        full : (m,) shapely.geometry.Polygon
+            Polygons containing interiors: `m <= len(self.root)`
+            as root curves whose geometry could not be recovered
+            (i.e. `None` in `polygons_closed`) are skipped.
         """
-        # pre- allocate the list to avoid indexing problems
-        full = [None] * len(self.root)
         # store the graph to avoid cache thrashing
         enclosure = self.enclosure_directed
         # store closed polygons to avoid cache hits
         closed = self.polygons_closed
 
+        full = []
         # loop through root curves
-        for i, root in enumerate(self.root):
+        for root in self.root:
+            # `polygons_closed` may contain `None` for degenerate
+            # geometry it could not recover: skip those rather than
+            # raising an AttributeError on `None.exterior`
+            if closed[root] is None:
+                continue
             # a list of multiple Polygon objects that
             # are fully contained by the root curve
             children = [closed[child] for child in enclosure[root].keys()]
             # all polygons_closed are CCW, so for interiors reverse them
-            holes = [np.array(p.exterior.coords)[::-1] for p in children]
+            holes = [
+                np.array(p.exterior.coords)[::-1] for p in children if p is not None
+            ]
             # a single Polygon object
             shell = closed[root].exterior
             # create a polygon with interiors
-            full[i] = polygons.repair_invalid(Polygon(shell=shell, holes=holes))
+            full.append(polygons.repair_invalid(Polygon(shell=shell, holes=holes)))
 
         return full
 

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -1227,22 +1227,24 @@ class Path2D(Path):
 
         Returns
         ---------
-        full : (m,) shapely.geometry.Polygon
-            Polygons containing interiors: `m <= len(self.root)`
-            as root curves whose geometry could not be recovered
-            (i.e. `None` in `polygons_closed`) are skipped.
+        full : (len(self.root),) shapely.geometry.Polygon
+            Polygons containing interiors. An entry is `None` when the
+            root curve's geometry could not be recovered (i.e. `None`
+            in `polygons_closed`), preserving correspondence with
+            `self.root`.
         """
+        # pre- allocate the list to avoid indexing problems
+        full = [None] * len(self.root)
         # store the graph to avoid cache thrashing
         enclosure = self.enclosure_directed
         # store closed polygons to avoid cache hits
         closed = self.polygons_closed
 
-        full = []
         # loop through root curves
-        for root in self.root:
+        for i, root in enumerate(self.root):
             # `polygons_closed` may contain `None` for degenerate
-            # geometry it could not recover: skip those rather than
-            # raising an AttributeError on `None.exterior`
+            # geometry it could not recover: leave the entry as `None`
+            # rather than raising an AttributeError on `None.exterior`
             if closed[root] is None:
                 continue
             # a list of multiple Polygon objects that
@@ -1255,7 +1257,7 @@ class Path2D(Path):
             # a single Polygon object
             shell = closed[root].exterior
             # create a polygon with interiors
-            full.append(polygons.repair_invalid(Polygon(shell=shell, holes=holes)))
+            full[i] = polygons.repair_invalid(Polygon(shell=shell, holes=holes))
 
         return full
 

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -731,7 +731,7 @@ class Path(parent.Geometry):
     def to_dict(self) -> dict:
         return self.export(file_type="dict")
 
-    def copy(self, layers: str | None | Iterable[str | None] = None):
+    def copy(self, layers: str | Iterable[str | None] | None = None):
         """
         Get a copy of the current mesh
 

--- a/trimesh/path/path.py
+++ b/trimesh/path/path.py
@@ -1251,9 +1251,7 @@ class Path2D(Path):
             # are fully contained by the root curve
             children = [closed[child] for child in enclosure[root].keys()]
             # all polygons_closed are CCW, so for interiors reverse them
-            holes = [
-                np.array(p.exterior.coords)[::-1] for p in children if p is not None
-            ]
+            holes = [np.array(p.exterior.coords)[::-1] for p in children if p is not None]
             # a single Polygon object
             shell = closed[root].exterior
             # create a polygon with interiors

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -511,9 +511,9 @@ def random_polygon(segments=8, radius=1.0, seed: Seed = None):
     polygon : shapely.geometry.Polygon
       Geometry object with random exterior and no interiors.
     """
-    rng = random_generator(seed)
-    angles = np.sort(np.cumsum(rng.random(segments) * np.pi * 2) % (np.pi * 2))
-    radii = rng.random(segments) * radius
+    random = random_generator(seed)
+    angles = np.sort(np.cumsum(random.random(segments) * np.pi * 2) % (np.pi * 2))
+    radii = random.random(segments) * radius
 
     points = np.column_stack((np.cos(angles), np.sin(angles))) * radii.reshape((-1, 1))
     points = np.vstack((points, points[0]))
@@ -626,8 +626,8 @@ def sample(polygon, count, factor=1.5, max_iter=10, seed: Seed = None):
     per_loop = int(count * factor)
 
     # start with some rejection sampling
-    rng = random_generator(seed)
-    points = bounds[0] + extents * rng.random((per_loop, 2))
+    random = random_generator(seed)
+    points = bounds[0] + extents * random.random((per_loop, 2))
     # do the point in polygon test and append resulting hits
     mask = vectorized.contains(polygon, *points.T)
     hit = [points[mask]]
@@ -639,7 +639,7 @@ def sample(polygon, count, factor=1.5, max_iter=10, seed: Seed = None):
     # if we have to do iterations loop here slowly
     for _ in range(max_iter):
         # generate points inside polygons AABB
-        points = (rng.random((per_loop, 2)) * extents) + bounds[0]
+        points = (random.random((per_loop, 2)) * extents) + bounds[0]
         # do the point in polygon test and append resulting hits
         mask = vectorized.contains(polygon, *points.T)
         hit.append(points[mask])

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -57,6 +57,11 @@ def enclosure_tree(polygons):
     if len(polygons) == 0:
         return np.array([], dtype=np.int64), contains
     elif len(polygons) == 1:
+        # `paths_to_polygons` may produce `None` for unrecoverable
+        # geometry: never emit it as a root, matching the multi-polygon
+        # code path below where `None` is excluded by the bounds check
+        if polygons[0] is None:
+            return np.array([], dtype=np.int64), contains
         # add an early exit for only a single polygon
         contains.add_node(0)
         return np.array([0], dtype=np.int64), contains

--- a/trimesh/path/polygons.py
+++ b/trimesh/path/polygons.py
@@ -7,7 +7,8 @@ from ..constants import log
 from ..constants import tol_path as tol
 from ..iteration import reduce_cascade
 from ..transformations import transform_points
-from ..typed import ArrayLike, Iterable, NDArray, Number, float64, int64
+from ..typed import ArrayLike, Iterable, NDArray, Number, Seed, float64, int64
+from ..util import random_generator
 from .simplify import fit_circle_check
 from .traversal import resample_path
 
@@ -487,7 +488,7 @@ def identifier(polygon: Polygon) -> NDArray[float64]:
     return np.array(result, dtype=np.float64)
 
 
-def random_polygon(segments=8, radius=1.0):
+def random_polygon(segments=8, radius=1.0, seed: Seed = None):
     """
     Generate a random polygon with a maximum number of sides and approximate radius.
 
@@ -497,14 +498,17 @@ def random_polygon(segments=8, radius=1.0):
       The maximum number of sides the random polygon will have
     radius : float
       The approximate radius of the polygon desired
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ---------
     polygon : shapely.geometry.Polygon
       Geometry object with random exterior and no interiors.
     """
-    angles = np.sort(np.cumsum(np.random.random(segments) * np.pi * 2) % (np.pi * 2))
-    radii = np.random.random(segments) * radius
+    rng = random_generator(seed)
+    angles = np.sort(np.cumsum(rng.random(segments) * np.pi * 2) % (np.pi * 2))
+    radii = rng.random(segments) * radius
 
     points = np.column_stack((np.cos(angles), np.sin(angles))) * radii.reshape((-1, 1))
     points = np.vstack((points, points[0]))
@@ -575,7 +579,7 @@ def paths_to_polygons(paths, scale=None):
     return polygons
 
 
-def sample(polygon, count, factor=1.5, max_iter=10):
+def sample(polygon, count, factor=1.5, max_iter=10, seed: Seed = None):
     """
     Use rejection sampling to generate random points inside a
     polygon. Note that this function may return fewer or no
@@ -593,6 +597,8 @@ def sample(polygon, count, factor=1.5, max_iter=10):
     max_iter : int
       Maximum number of intersection checks is:
       > count * factor * max_iter
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     -----------
@@ -615,7 +621,8 @@ def sample(polygon, count, factor=1.5, max_iter=10):
     per_loop = int(count * factor)
 
     # start with some rejection sampling
-    points = bounds[0] + extents * np.random.random((per_loop, 2))
+    rng = random_generator(seed)
+    points = bounds[0] + extents * rng.random((per_loop, 2))
     # do the point in polygon test and append resulting hits
     mask = vectorized.contains(polygon, *points.T)
     hit = [points[mask]]
@@ -627,7 +634,7 @@ def sample(polygon, count, factor=1.5, max_iter=10):
     # if we have to do iterations loop here slowly
     for _ in range(max_iter):
         # generate points inside polygons AABB
-        points = (np.random.random((per_loop, 2)) * extents) + bounds[0]
+        points = (rng.random((per_loop, 2)) * extents) + bounds[0]
         # do the point in polygon test and append resulting hits
         mask = vectorized.contains(polygon, *points.T)
         hit.append(points[mask])

--- a/trimesh/permutate.py
+++ b/trimesh/permutate.py
@@ -32,11 +32,13 @@ def transform(mesh, translation_scale: Number = 1000.0, seed: Seed = None):
     """
     # thread one generator through so the rotation and the reordering
     # below aren't each handed an identically re-seeded stream
-    rng = util.random_generator(seed)
-    matrix = transformations.random_rotation_matrix(translate=translation_scale, seed=rng)
+    random = util.random_generator(seed)
+    matrix = transformations.random_rotation_matrix(
+        translate=translation_scale, seed=random
+    )
 
     # randomly re-order triangles
-    triangles = rng.permutation(mesh.triangles).reshape((-1, 3))
+    triangles = random.permutation(mesh.triangles).reshape((-1, 3))
     # apply rigid transform
     triangles = transformations.transform_points(triangles, matrix)
 
@@ -71,12 +73,12 @@ def noise(mesh, magnitude=None, seed: Seed = None):
     if magnitude is None:
         magnitude = mesh.scale / 100.0
 
-    rng = util.random_generator(seed)
-    random = (rng.random(mesh.vertices.shape) - 0.5) * magnitude
-    vertices_noise = mesh.vertices.copy() + random
+    random = util.random_generator(seed)
+    offset = (random.random(mesh.vertices.shape) - 0.5) * magnitude
+    vertices_noise = mesh.vertices.copy() + offset
 
     # make sure we've re- ordered faces randomly
-    triangles = rng.permutation(vertices_noise[mesh.faces])
+    triangles = random.permutation(vertices_noise[mesh.faces])
 
     mesh_type = util.type_named(mesh, "Trimesh")
     permutated = mesh_type(**triangles_module.to_kwargs(triangles))
@@ -104,11 +106,11 @@ def tessellation(mesh, seed: Seed = None):
     permutated : trimesh.Trimesh
       Mesh with remeshed facets
     """
-    rng = util.random_generator(seed)
+    random = util.random_generator(seed)
 
     # create random barycentric coordinates for each face
     # pad all coordinates by a small amount to bias new vertex towards center
-    barycentric = rng.random(mesh.faces.shape) + 0.05
+    barycentric = random.random(mesh.faces.shape) + 0.05
     barycentric /= barycentric.sum(axis=1).reshape((-1, 1))
 
     # create one new vertex somewhere in a face
@@ -126,7 +128,7 @@ def tessellation(mesh, seed: Seed = None):
         )
     )
     # make sure the order of the faces is permutated
-    faces = rng.permutation(faces)
+    faces = random.permutation(faces)
 
     mesh_type = util.type_named(mesh, "Trimesh")
     permutated = mesh_type(vertices=vertices, faces=faces)

--- a/trimesh/permutate.py
+++ b/trimesh/permutate.py
@@ -9,10 +9,10 @@ import numpy as np
 
 from . import transformations, util
 from . import triangles as triangles_module
-from .typed import Number
+from .typed import Number, Seed
 
 
-def transform(mesh, translation_scale: Number = 1000.0):
+def transform(mesh, translation_scale: Number = 1000.0, seed: Seed = None):
     """
     Return a permutated variant of a mesh by randomly reordering faces
     and rotatating + translating a mesh by a random matrix.
@@ -21,6 +21,8 @@ def transform(mesh, translation_scale: Number = 1000.0):
     ----------
     mesh : trimesh.Trimesh
       Mesh, will not be altered by this function
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ----------
@@ -28,11 +30,13 @@ def transform(mesh, translation_scale: Number = 1000.0):
       Mesh with same faces as input mesh but reordered
       and rigidly transformed in space.
     """
-    # rotate and translate randomly
-    matrix = transformations.random_rotation_matrix(translate=translation_scale)
+    # thread one generator through so the rotation and the reordering
+    # below aren't each handed an identically re-seeded stream
+    rng = util.random_generator(seed)
+    matrix = transformations.random_rotation_matrix(translate=translation_scale, seed=rng)
 
     # randomly re-order triangles
-    triangles = np.random.permutation(mesh.triangles).reshape((-1, 3))
+    triangles = rng.permutation(mesh.triangles).reshape((-1, 3))
     # apply rigid transform
     triangles = transformations.transform_points(triangles, matrix)
 
@@ -44,7 +48,7 @@ def transform(mesh, translation_scale: Number = 1000.0):
     return permutated
 
 
-def noise(mesh, magnitude=None):
+def noise(mesh, magnitude=None, seed: Seed = None):
     """
     Add gaussian noise to every vertex of a mesh, making
     no effort to maintain topology or sanity.
@@ -56,6 +60,8 @@ def noise(mesh, magnitude=None):
     magnitude : float
       What is the maximum distance per axis we can displace a vertex.
       If None, value defaults to (mesh.scale / 100.0)
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ----------
@@ -65,11 +71,12 @@ def noise(mesh, magnitude=None):
     if magnitude is None:
         magnitude = mesh.scale / 100.0
 
-    random = (np.random.random(mesh.vertices.shape) - 0.5) * magnitude
+    rng = util.random_generator(seed)
+    random = (rng.random(mesh.vertices.shape) - 0.5) * magnitude
     vertices_noise = mesh.vertices.copy() + random
 
     # make sure we've re- ordered faces randomly
-    triangles = np.random.permutation(vertices_noise[mesh.faces])
+    triangles = rng.permutation(vertices_noise[mesh.faces])
 
     mesh_type = util.type_named(mesh, "Trimesh")
     permutated = mesh_type(**triangles_module.to_kwargs(triangles))
@@ -77,7 +84,7 @@ def noise(mesh, magnitude=None):
     return permutated
 
 
-def tessellation(mesh):
+def tessellation(mesh, seed: Seed = None):
     """
     Subdivide each face of a mesh into three faces with the new vertex
     randomly placed inside the old face.
@@ -89,15 +96,19 @@ def tessellation(mesh):
     ------------
     mesh : trimesh.Trimesh
       Input geometry
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ----------
     permutated : trimesh.Trimesh
       Mesh with remeshed facets
     """
+    rng = util.random_generator(seed)
+
     # create random barycentric coordinates for each face
     # pad all coordinates by a small amount to bias new vertex towards center
-    barycentric = np.random.random(mesh.faces.shape) + 0.05
+    barycentric = rng.random(mesh.faces.shape) + 0.05
     barycentric /= barycentric.sum(axis=1).reshape((-1, 1))
 
     # create one new vertex somewhere in a face
@@ -115,7 +126,7 @@ def tessellation(mesh):
         )
     )
     # make sure the order of the faces is permutated
-    faces = np.random.permutation(faces)
+    faces = rng.permutation(faces)
 
     mesh_type = util.type_named(mesh, "Trimesh")
     permutated = mesh_type(vertices=vertices, faces=faces)
@@ -129,14 +140,14 @@ class Permutator:
         """
         self._mesh = mesh
 
-    def transform(self, translation_scale=1000):
-        return transform(self._mesh, translation_scale=translation_scale)
+    def transform(self, translation_scale=1000, seed: Seed = None):
+        return transform(self._mesh, translation_scale=translation_scale, seed=seed)
 
-    def noise(self, magnitude=None):
-        return noise(self._mesh, magnitude)
+    def noise(self, magnitude=None, seed: Seed = None):
+        return noise(self._mesh, magnitude, seed=seed)
 
-    def tessellation(self):
-        return tessellation(self._mesh)
+    def tessellation(self, seed: Seed = None):
+        return tessellation(self._mesh, seed=seed)
 
 
 try:

--- a/trimesh/poses.py
+++ b/trimesh/poses.py
@@ -80,11 +80,11 @@ def compute_stable_poses(
         center_mass = mesh.center_mass
 
     # Sample center of mass, rejecting points outside of conv hull
-    rng = random_generator(seed)
+    random = random_generator(seed)
     sample_coms = []
     while len(sample_coms) < n_samples:
         remaining = n_samples - len(sample_coms)
-        coms = rng.multivariate_normal(center_mass, sigma * np.eye(3), remaining)
+        coms = random.multivariate_normal(center_mass, sigma * np.eye(3), remaining)
         for c in coms:
             dots = diagonal_dot(c - cvh.triangles_center, cvh.face_normals)
             if np.all(dots < 0):

--- a/trimesh/poses.py
+++ b/trimesh/poses.py
@@ -8,7 +8,8 @@ Find stable orientations of meshes.
 import numpy as np
 
 from .triangles import points_to_barycentric
-from .util import diagonal_dot
+from .typed import Seed
+from .util import diagonal_dot, random_generator
 
 try:
     import networkx as nx
@@ -20,7 +21,9 @@ except BaseException as E:
     nx = ExceptionWrapper(E)
 
 
-def compute_stable_poses(mesh, center_mass=None, sigma=0.0, n_samples=1, threshold=0.0):
+def compute_stable_poses(
+    mesh, center_mass=None, sigma=0.0, n_samples=1, threshold=0.0, seed: Seed = None
+):
     """
     Computes stable orientations of a mesh and their quasi-static probabilities.
 
@@ -56,6 +59,9 @@ def compute_stable_poses(mesh, center_mass=None, sigma=0.0, n_samples=1, thresho
       The probability value at which to threshold
       returned stable poses
 
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
+
     Returns
     -------
     transforms : (n, 4, 4) float
@@ -74,10 +80,11 @@ def compute_stable_poses(mesh, center_mass=None, sigma=0.0, n_samples=1, thresho
         center_mass = mesh.center_mass
 
     # Sample center of mass, rejecting points outside of conv hull
+    rng = random_generator(seed)
     sample_coms = []
     while len(sample_coms) < n_samples:
         remaining = n_samples - len(sample_coms)
-        coms = np.random.multivariate_normal(center_mass, sigma * np.eye(3), remaining)
+        coms = rng.multivariate_normal(center_mass, sigma * np.eye(3), remaining)
         for c in coms:
             dots = diagonal_dot(c - cvh.triangles_center, cvh.face_normals)
             if np.all(dots < 0):

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -17,7 +17,7 @@ from . import transformations as tf
 from .base import Trimesh
 from .caching import cache_decorator
 from .constants import log, tol
-from .typed import ArrayLike, Integer, Number
+from .typed import ArrayLike, Integer, Number, Seed
 
 # immutable identity matrix for checks
 _IDENTITY = np.eye(4)
@@ -807,7 +807,7 @@ class Box(Primitive):
     def transform(self):
         return self.primitive.transform
 
-    def sample_volume(self, count):
+    def sample_volume(self, count, seed: Seed = None):
         """
         Return random samples from inside the volume of the box.
 
@@ -815,6 +815,8 @@ class Box(Primitive):
         -------------
         count : int
           Number of samples to return
+        seed : None or int
+          Seed for deterministic results, otherwise OS entropy.
 
         Returns
         ----------
@@ -825,6 +827,7 @@ class Box(Primitive):
             extents=self.primitive.extents,
             count=count,
             transform=self.primitive.transform,
+            seed=seed,
         )
         return samples
 

--- a/trimesh/proximity.py
+++ b/trimesh/proximity.py
@@ -5,6 +5,8 @@ proximity.py
 Query mesh- point proximity.
 """
 
+from importlib import metadata
+
 import numpy as np
 
 from . import util
@@ -20,6 +22,12 @@ except BaseException as E:
     from .exceptions import ExceptionWrapper
 
     cKDTree = ExceptionWrapper(E)
+
+
+try:
+    _rtree_version = tuple(int(part) for part in metadata.version("rtree").split(".")[:3])
+except (metadata.PackageNotFoundError, ValueError):
+    _rtree_version = ()
 
 
 def nearby_faces(mesh, points):
@@ -61,8 +69,21 @@ def nearby_faces(mesh, points):
     # axis aligned bounds
     bounds = np.column_stack((points - distance_vertex, points + distance_vertex))
 
-    # faces that intersect axis aligned bounding box
-    candidates = [list(rtree.intersection(b)) for b in bounds]
+    # rtree 1.4.0 exposed intersection_v but its batch API was defective.
+    # Preserve the established scalar path for older installed rtree versions.
+    if len(bounds) == 0:
+        return []
+
+    if _rtree_version >= (1, 4, 1) and callable(getattr(rtree, "intersection_v", None)):
+        # The batch call returns flat hit indexes and one hit count per query box.
+        hit_ids, hit_counts = rtree.intersection_v(bounds[:, :3], bounds[:, 3:])
+        candidates = []
+        start = 0
+        for count in hit_counts:
+            candidates.append(hit_ids[start : start + count].tolist())
+            start += count
+    else:
+        candidates = [list(rtree.intersection(b)) for b in bounds]
 
     return candidates
 

--- a/trimesh/proximity.py
+++ b/trimesh/proximity.py
@@ -5,7 +5,6 @@ proximity.py
 Query mesh- point proximity.
 """
 
-from importlib import metadata
 
 import numpy as np
 
@@ -14,6 +13,7 @@ from .constants import log_time, tol
 from .grouping import group_min
 from .triangles import closest_point as _corresponding
 from .triangles import points_to_barycentric
+from .typed import ArrayLike
 from .util import diagonal_dot
 
 try:
@@ -24,13 +24,7 @@ except BaseException as E:
     cKDTree = ExceptionWrapper(E)
 
 
-try:
-    _rtree_version = tuple(int(part) for part in metadata.version("rtree").split(".")[:3])
-except (metadata.PackageNotFoundError, ValueError):
-    _rtree_version = ()
-
-
-def nearby_faces(mesh, points):
+def nearby_faces(mesh, points: ArrayLike):
     """
     For each point find nearby faces relatively quickly.
 
@@ -54,6 +48,11 @@ def nearby_faces(mesh, points):
       Sequence of indexes for mesh.faces
     """
     points = np.asanyarray(points, dtype=np.float64)
+    # empty points lists should get empty candidates
+    if len(points) == 0:
+        return []
+
+    # mishapen points should error
     if not util.is_shape(points, (-1, 3)):
         raise ValueError("points must be (n,3)!")
 
@@ -69,19 +68,13 @@ def nearby_faces(mesh, points):
     # axis aligned bounds
     bounds = np.column_stack((points - distance_vertex, points + distance_vertex))
 
-    # rtree 1.4.0 exposed intersection_v but its batch API was defective.
-    # Preserve the established scalar path for older installed rtree versions.
-    if len(bounds) == 0:
-        return []
-
-    if _rtree_version >= (1, 4, 1) and callable(getattr(rtree, "intersection_v", None)):
-        # The batch call returns flat hit indexes and one hit count per query box.
+    try:
+        # use the batch API added in 1.4.0 and fixed to actually work in 1.4.1
         hit_ids, hit_counts = rtree.intersection_v(bounds[:, :3], bounds[:, 3:])
-        candidates = np.array_split(hit_ids, np.cumsum(hit_counts)[:-1])
-    else:
-        candidates = [list(rtree.intersection(b)) for b in bounds]
-
-    return candidates
+        return np.array_split(hit_ids, np.cumsum(hit_counts)[:-1])
+    except BaseException:
+        # fall back to a list comprehension
+        return [list(rtree.intersection(b)) for b in bounds]
 
 
 def closest_point_naive(mesh, points):

--- a/trimesh/proximity.py
+++ b/trimesh/proximity.py
@@ -77,11 +77,7 @@ def nearby_faces(mesh, points):
     if _rtree_version >= (1, 4, 1) and callable(getattr(rtree, "intersection_v", None)):
         # The batch call returns flat hit indexes and one hit count per query box.
         hit_ids, hit_counts = rtree.intersection_v(bounds[:, :3], bounds[:, 3:])
-        candidates = []
-        start = 0
-        for count in hit_counts:
-            candidates.append(hit_ids[start : start + count].tolist())
-            start += count
+        candidates = np.array_split(hit_ids, np.cumsum(hit_counts)[:-1])
     else:
         candidates = [list(rtree.intersection(b)) for b in bounds]
 

--- a/trimesh/proximity.py
+++ b/trimesh/proximity.py
@@ -5,7 +5,6 @@ proximity.py
 Query mesh- point proximity.
 """
 
-
 import numpy as np
 
 from . import util

--- a/trimesh/ray/ray_util.py
+++ b/trimesh/ray/ray_util.py
@@ -104,7 +104,7 @@ def contains_points(intersector, points: ArrayLike, check_direction: bool | None
     # to avoid infinite recursion
     if check_direction is None:
         # we're going to run the check again in a random direction
-        new_direction = util.unitize(np.random.random(3) - 0.5)
+        new_direction = util.unitize(util.random_generator().random(3) - 0.5)
         # do the mask trick again to be able to assign results
         mask = inside_aabb.copy()
         mask[mask] = broken

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -124,21 +124,25 @@ def mesh_other(
     # the principal inertia transform has arbitrary sign
     # along the 3 major axis so try all combinations of
     # 180 degree rotations with a quick first ICP pass
-    cubes = np.array(
-        [
-            np.eye(4) * np.append(diag, 1)
-            for diag in [
-                [1, 1, 1],
-                [1, 1, -1],
-                [1, -1, 1],
-                [-1, 1, 1],
-                [-1, -1, 1],
-                [-1, 1, -1],
-                [1, -1, -1],
-                [-1, -1, -1],
-            ]
-        ]
-    )
+    diagonals = [
+        [1, 1, 1],
+        [1, 1, -1],
+        [1, -1, 1],
+        [-1, 1, 1],
+        [-1, -1, 1],
+        [-1, 1, -1],
+        [1, -1, -1],
+        [-1, -1, -1],
+    ]
+    if not kwargs.get("reflection", True):
+        # Half of these sign flips have an odd number of -1 and are therefore
+        # reflections (negative determinant). ICP only refines with proper
+        # rotations, so a reflected seed can never be corrected and would
+        # produce a final transform containing a reflection even though
+        # reflection was disabled. Keep only the proper-rotation seeds
+        # (identity and the three 180 degree axis rotations). See #2482.
+        diagonals = [diag for diag in diagonals if np.prod(diag) > 0]
+    cubes = np.array([np.eye(4) * np.append(diag, 1) for diag in diagonals])
 
     # loop through permutations and run iterative closest point
     costs = np.ones(len(cubes)) * np.inf

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -140,17 +140,14 @@ def mesh_other(
     # principal axes of the points
     search_to_points = np.dot(np.linalg.inv(points_PIT), search_PIT)
     if not reflection:
-        # Half of these sign flips have an odd number of -1 and are therefore
-        # reflections (negative determinant). ICP only refines with proper
-        # rotations, so a reflected seed can never be corrected and would
-        # produce a final transform containing a reflection even though
-        # reflection was disabled. Keep only the proper-rotation seeds
-        # (identity and the three 180 degree axis rotations). See #2482.
+        # drop the negative-determinant seeds — icp can only refine
+        # proper rotations so a reflected seed stays reflected, #2482
         diagonals = _cube_diagonals[np.prod(_cube_diagonals, axis=1) > 0.0]
     else:
         diagonals = _cube_diagonals
 
-    cubes = np.array([np.diag(d) for d in diagonals])
+    # expand the diagonals into (n, 4, 4) transforms
+    cubes = np.eye(4) * diagonals[:, None, :]
 
     # loop through permutations and run iterative closest point
     costs = np.ones(len(cubes)) * np.inf

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -26,6 +26,25 @@ except BaseException as E:
     sparse = exceptions.ExceptionWrapper(E)
 
 
+# permutations of cube rotations
+# the principal inertia transform has arbitrary sign
+# along the 3 major axis so try all combinations of
+# 180 degree rotations with a quick first ICP pass
+_cube_diagonals = np.array(
+    [
+        [1, 1, 1, 1],
+        [1, 1, -1, 1],
+        [1, -1, 1, 1],
+        [-1, 1, 1, 1],
+        [-1, -1, 1, 1],
+        [-1, 1, -1, 1],
+        [1, -1, -1, 1],
+        [-1, -1, -1, 1],
+    ],
+    dtype=np.float64,
+)
+
+
 def mesh_other(
     mesh,
     other,
@@ -33,6 +52,7 @@ def mesh_other(
     scale: bool = False,
     icp_first: Integer = 10,
     icp_final: Integer = 50,
+    reflection: bool = True,
     **kwargs,
 ):
     """
@@ -119,30 +139,18 @@ def mesh_other(
     # of the search mesh to be aligned with the best- guess
     # principal axes of the points
     search_to_points = np.dot(np.linalg.inv(points_PIT), search_PIT)
-
-    # permutations of cube rotations
-    # the principal inertia transform has arbitrary sign
-    # along the 3 major axis so try all combinations of
-    # 180 degree rotations with a quick first ICP pass
-    diagonals = [
-        [1, 1, 1],
-        [1, 1, -1],
-        [1, -1, 1],
-        [-1, 1, 1],
-        [-1, -1, 1],
-        [-1, 1, -1],
-        [1, -1, -1],
-        [-1, -1, -1],
-    ]
-    if not kwargs.get("reflection", True):
+    if not reflection:
         # Half of these sign flips have an odd number of -1 and are therefore
         # reflections (negative determinant). ICP only refines with proper
         # rotations, so a reflected seed can never be corrected and would
         # produce a final transform containing a reflection even though
         # reflection was disabled. Keep only the proper-rotation seeds
         # (identity and the three 180 degree axis rotations). See #2482.
-        diagonals = [diag for diag in diagonals if np.prod(diag) > 0]
-    cubes = np.array([np.eye(4) * np.append(diag, 1) for diag in diagonals])
+        diagonals = _cube_diagonals[np.prod(_cube_diagonals, axis=1) > 0.0]
+    else:
+        diagonals = _cube_diagonals
+
+    cubes = np.array([np.diag(d) for d in diagonals])
 
     # loop through permutations and run iterative closest point
     costs = np.ones(len(cubes)) * np.inf
@@ -164,6 +172,7 @@ def mesh_other(
             initial=a_to_b,
             max_iterations=int(icp_first),
             scale=scale,
+            reflection=reflection,
             **kwargs,
         )
 
@@ -178,6 +187,7 @@ def mesh_other(
         initial=transforms[np.argmin(costs)],
         max_iterations=int(icp_final),
         scale=scale,
+        reflection=reflection,
         **kwargs,
     )
 

--- a/trimesh/registration.py
+++ b/trimesh/registration.py
@@ -12,7 +12,7 @@ from .geometry import weighted_vertex_normals
 from .points import PointCloud, plane_fit
 from .transformations import transform_points
 from .triangles import angles, cross, normals
-from .typed import ArrayLike, Integer
+from .typed import ArrayLike, Integer, Seed
 
 try:
     import scipy.sparse as sparse
@@ -53,6 +53,7 @@ def mesh_other(
     icp_first: Integer = 10,
     icp_final: Integer = 50,
     reflection: bool = True,
+    seed: Seed = None,
     **kwargs,
 ):
     """
@@ -76,6 +77,9 @@ def mesh_other(
     icp_final : int
       How many ICP iterations for the closest
       candidate from the wider search
+    seed : None or int
+      Seed the surface sampling this uses to pick key points:
+      pass an integer for deterministic results.
     kwargs : dict
       Passed through to `icp`, which passes through to `procrustes`
 
@@ -94,9 +98,9 @@ def mesh_other(
         to registration.
         """
         if len(m.vertices) < (count / 2):
-            return np.vstack((m.vertices, m.sample(count - len(m.vertices))))
+            return np.vstack((m.vertices, m.sample(count - len(m.vertices), seed=seed)))
         else:
-            return m.sample(count)
+            return m.sample(count, seed=seed)
 
     if not util.is_instance_named(mesh, "Trimesh"):
         raise ValueError("mesh must be Trimesh object!")

--- a/trimesh/resolvers.py
+++ b/trimesh/resolvers.py
@@ -60,7 +60,7 @@ class FilePathResolver(Resolver):
     Resolve files from a source path on the file system.
     """
 
-    def __init__(self, source: str):
+    def __init__(self, source: str, allow_anywhere: bool = False):
         """
         Resolve files based on a source path.
 
@@ -68,9 +68,15 @@ class FilePathResolver(Resolver):
         ------------
         source : str
           File path where mesh was loaded from
+        allow_anywhere : bool
+          If True allow assets to reference paths outside the
+          resolver root, i.e. `../textures/thing.png` — the
+          pre-5.0 behavior.
         """
         # remove everything other than absolute path
         clean = os.path.expanduser(os.path.abspath(str(source)))
+
+        self.allow_anywhere = bool(allow_anywhere)
 
         self.clean = clean
         if os.path.isdir(clean):
@@ -121,7 +127,39 @@ class FilePathResolver(Resolver):
         resolver : FilePathResolver
           Resolver with root directory changed.
         """
-        return FilePathResolver(os.path.join(self.parent, namespace))
+        return FilePathResolver(
+            os.path.join(self.parent, namespace), allow_anywhere=self.allow_anywhere
+        )
+
+    def absolute(self, name: str) -> Path:
+        """
+        Resolve an asset name to an absolute path under the
+        resolver root.
+
+        Parameters
+        ------------
+        name : str
+          Name of an asset relative to the resolver root.
+
+        Returns
+        ------------
+        path : pathlib.Path
+          Absolute resolved path.
+
+        Raises
+        ------------
+        ValueError
+          If the path escapes the resolver root and
+          `allow_anywhere` was not set.
+        """
+        parent = Path(self.parent).resolve()
+        path = (parent / name.strip()).resolve()
+        if not self.allow_anywhere and not path.is_relative_to(parent):
+            raise ValueError(
+                f"'{name}' escapes resolver root '{parent}' — pass "
+                + "`FilePathResolver(path, allow_anywhere=True)` to allow it"
+            )
+        return path
 
     def get(self, name: str):
         """
@@ -137,20 +175,22 @@ class FilePathResolver(Resolver):
         data : bytes
           Loaded data from asset.
         """
-        # require each candidate to resolve inside the root
-        parent = Path(self.parent).resolve()
         candidates = (
             name.strip(),
             name.strip().lstrip("/"),
             os.path.split(name)[-1],
         )
         for candidate in candidates:
-            path = (parent / candidate).resolve()
-            if not path.is_relative_to(parent):
+            try:
+                path = self.absolute(candidate)
+            except ValueError:
                 continue
             if path.exists():
                 with open(path, "rb") as f:
                     return f.read()
+        # if the requested name escaped the root this raises
+        # the actionable error instead of a plain not-found
+        self.absolute(name)
         raise FileNotFoundError(name)
 
     def write(self, name: str, data: str | bytes):
@@ -164,11 +204,7 @@ class FilePathResolver(Resolver):
         data : str or bytes
           Data to write to the file.
         """
-        parent = Path(self.parent).resolve()
-        path = (parent / name.strip()).resolve()
-        if not path.is_relative_to(parent):
-            raise ValueError(f"path escapes resolver root: {name!r}")
-        with open(path, "wb") as f:
+        with open(self.absolute(name), "wb") as f:
             # handle encodings correctly for str/bytes
             util.write_encoded(file_obj=f, stuff=data)
 
@@ -361,6 +397,27 @@ class WebResolver(Resolver):
         self.session = session
         self.timeout = timeout
 
+        # per-library request kwargs: httpx and requests disagree on
+        # the redirect kwarg name — this is also where any future
+        # library-specific options should live
+        library = "httpx" if session is None else type(session).__module__.split(".")[0]
+        if library == "httpx":
+            # also the bare httpx module fallback when no session was passed
+            self.request_kwargs = {"follow_redirects": True, "timeout": timeout}
+        elif library == "requests":
+            self.request_kwargs = {"allow_redirects": True, "timeout": timeout}
+        elif library == "aiohttp":
+            # an aiohttp session can only be constructed inside a running
+            # event loop and its connector binds to that loop, so a
+            # synchronous fetch can never legally drive one
+            raise ValueError(
+                "`aiohttp` sessions are async-only and bound to their creation "
+                + "loop: pass an `httpx.Client` or `requests.Session` instead"
+            )
+        else:
+            # a duck-typed session gets `get(url)` with no assumed kwargs
+            self.request_kwargs = {}
+
         # we want a base url
         split = [i for i in parsed.path.split("/") if len(i) > 0]
 
@@ -411,16 +468,13 @@ class WebResolver(Resolver):
 
         # the caller's session or the bare httpx module, both expose `.get`
         client = self.session or httpx
-        url = self.base_url + name
-        response = client.get(url, follow_redirects=True, timeout=self.timeout)
+        response = client.get(self.base_url + name, **self.request_kwargs)
 
         if response.status_code >= 300:
             # try to strip off filesystem crap
             if name.startswith("./"):
                 name = name[2:]
-            response = client.get(
-                self.base_url + name, follow_redirects=True, timeout=self.timeout
-            )
+            response = client.get(self.base_url + name, **self.request_kwargs)
 
         # now raise if we don't have
         response.raise_for_status()
@@ -442,9 +496,7 @@ class WebResolver(Resolver):
         import httpx
 
         # just fetch the url we were created with
-        response = (self.session or httpx).get(
-            self.url, follow_redirects=True, timeout=self.timeout
-        )
+        response = (self.session or httpx).get(self.url, **self.request_kwargs)
         response.raise_for_status()
         return response.content
 
@@ -517,20 +569,8 @@ class GithubResolver(Resolver):
         else:
             raise ValueError("`commit` or `branch` must be passed!")
 
-        if session is None:
-            # same deprecation as `WebResolver`, see there for rationale
-            import warnings
-
-            warnings.warn(
-                "`GithubResolver` without a `session` is deprecated "
-                + "and will require one in a future release. "
-                + "pass an `httpx.Client` or `requests.Session`.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-
-        self.session = session
-        self.timeout = timeout
+        # reuse the session handling and deprecation warning
+        self.resolver = WebResolver(url=self.url, session=session, timeout=timeout)
 
         if save is not None:
             self.cache = caching.DiskCache(save)
@@ -559,22 +599,10 @@ class GithubResolver(Resolver):
         - retrieve zip file and saved
         """
 
-        def fetch() -> bytes:
-            """
-            Fetch the remote zip file.
-            """
-            import httpx
-
-            response = (self.session or httpx).get(
-                self.url, follow_redirects=True, timeout=self.timeout
-            )
-            response.raise_for_status()
-            return response.content
-
         if hasattr(self, "_zip"):
             return self._zip
         # download the archive or get from disc
-        raw = self.cache.get(self.url, fetch)
+        raw = self.cache.get(self.url, self.resolver.get_base)
         # create a zip resolver for the archive
         # the root directory in the zip is the repo+commit so strip that off
         # so the keys are usable, i.e. "models" instead of "trimesh-2232323/models"

--- a/trimesh/sample.py
+++ b/trimesh/sample.py
@@ -8,7 +8,7 @@ Randomly sample surface and volume of meshes.
 import numpy as np
 
 from . import transformations, util
-from .typed import ArrayLike, Integer, NDArray, Number, float64
+from .typed import ArrayLike, Integer, NDArray, Number, Seed, float64
 from .visual import uv_to_interpolated_color
 
 
@@ -17,7 +17,7 @@ def sample_surface(
     count: Integer,
     face_weight: ArrayLike | None = None,
     sample_color=False,
-    seed=None,
+    seed: Seed = None,
 ):
     """
     Sample the surface of a mesh, returning the specified
@@ -39,8 +39,7 @@ def sample_surface(
       Option to calculate the color of the sampled points.
       Default is False.
     seed : None or int
-      If passed as an integer will provide deterministic results
-      otherwise pulls the seed from operating system entropy.
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ---------
@@ -61,11 +60,7 @@ def sample_surface(
     # cumulative sum of weights (len(mesh.faces))
     weight_cum = np.cumsum(face_weight)
 
-    # seed the random number generator as requested
-    if seed is None:
-        random = np.random.random
-    else:
-        random = np.random.default_rng(seed).random
+    random = util.random_generator(seed).random
 
     # last value of cumulative sum is total summed weight/area
     face_pick = random(count) * weight_cum[-1]
@@ -121,7 +116,7 @@ def sample_surface(
     return samples, face_index
 
 
-def volume_mesh(mesh, count: Integer) -> NDArray[float64]:
+def volume_mesh(mesh, count: Integer, seed: Seed = None) -> NDArray[float64]:
     """
     Use rejection sampling to produce points randomly
     distributed in the volume of a mesh.
@@ -133,20 +128,26 @@ def volume_mesh(mesh, count: Integer) -> NDArray[float64]:
       Geometry to sample
     count : int
       Number of points to return
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ---------
     samples : (n, 3) float
       Points in the volume of the mesh where n <= count
     """
-    points = (np.random.random((count, 3)) * mesh.extents) + mesh.bounds[0]
+    random = util.random_generator(seed).random
+    points = (random((count, 3)) * mesh.extents) + mesh.bounds[0]
     contained = mesh.contains(points)
     samples = points[contained][:count]
     return samples
 
 
 def volume_rectangular(
-    extents, count: Integer, transform: ArrayLike | None = None
+    extents,
+    count: Integer,
+    transform: ArrayLike | None = None,
+    seed: Seed = None,
 ) -> NDArray[float64]:
     """
     Return random samples inside a rectangular volume,
@@ -160,20 +161,24 @@ def volume_rectangular(
       Number of points to return
     transform : (4, 4) float
       Homogeneous transformation matrix
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ---------
     samples : (count, 3) float
       Points in requested volume
     """
-    samples = np.random.random((count, 3)) - 0.5
+    samples = util.random_generator(seed).random((count, 3)) - 0.5
     samples *= extents
     if transform is not None:
         samples = transformations.transform_points(samples, transform)
     return samples
 
 
-def sample_surface_even(mesh, count: Integer, radius: Number | None = None, seed=None):
+def sample_surface_even(
+    mesh, count: Integer, radius: Number | None = None, seed: Seed = None
+):
     """
     Sample the surface of a mesh, returning samples which are
     VERY approximately evenly spaced. This is accomplished by
@@ -223,7 +228,7 @@ def sample_surface_even(mesh, count: Integer, radius: Number | None = None, seed
     return points, index[mask]
 
 
-def sample_surface_sphere(count: int) -> NDArray[float64]:
+def sample_surface_sphere(count: int, seed: Seed = None) -> NDArray[float64]:
     """
     Correctly pick random points on the surface of a unit sphere
 
@@ -234,6 +239,8 @@ def sample_surface_sphere(count: int) -> NDArray[float64]:
     -----------
     count : int
       Number of points to return
+    seed : None or int
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ----------
@@ -241,7 +248,7 @@ def sample_surface_sphere(count: int) -> NDArray[float64]:
       Random points on the surface of a unit sphere
     """
     # get random values 0.0-1.0
-    u, v = np.random.random((2, count))
+    u, v = util.random_generator(seed).random((2, count))
     # convert to two angles
     theta = np.pi * 2 * u
     phi = np.arccos((2 * v) - 1)

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -16,6 +16,7 @@ from ..registration import procrustes
 from ..typed import (
     ArrayLike,
     Floating,
+    Hashable,
     Integer,
     Iterable,
     NDArray,
@@ -43,7 +44,7 @@ class Scene(Geometry3D):
     def __init__(
         self,
         geometry: GeometryInput | None = None,
-        base_frame: str = "world",
+        base_frame: Hashable = "world",
         metadata: dict | None = None,
         graph: SceneGraph | None = None,
         camera: cameras.Camera | None = None,
@@ -118,9 +119,9 @@ class Scene(Geometry3D):
     def add_geometry(
         self,
         geometry: GeometryInput,
-        node_name: str | None = None,
+        node_name: Hashable | None = None,
         geom_name: str | None = None,
-        parent_node_name: str | None = None,
+        parent_node_name: Hashable | None = None,
         transform: NDArray | None = None,
         metadata: dict | None = None,
     ):
@@ -979,7 +980,7 @@ class Scene(Geometry3D):
         # concatenate everything and return the most-occurring type.
         return util.concatenate(self.dump())
 
-    def subscene(self, node: str) -> "Scene":
+    def subscene(self, node: Hashable) -> "Scene":
         """
         Get part of a scene that succeeds a specified node.
 

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -27,7 +27,7 @@ class SceneGraph:
     """
 
     def __init__(
-        self, base_frame: str | None = None, repair_rigid: None | Floating = 1e-5
+        self, base_frame: Hashable | None = None, repair_rigid: None | Floating = 1e-5
     ):
         """
         Create a scene graph, holding homogeneous transformation
@@ -47,8 +47,9 @@ class SceneGraph:
 
         # a graph structure, subclass of networkx DiGraph
         self.transforms = EnforcedForest()
-        # hashable, the base or root frame
-        self.base_frame = base_frame or DEFAULT_BASE_FRAME
+        # hashable, the base or root frame — only replace None
+        # as falsy frames like `0` or `""` are valid node names
+        self.base_frame = base_frame if base_frame is not None else DEFAULT_BASE_FRAME
         # if passed as a float try to repair rigid transforms
         # that have accumulated floating point error
         self.repair_rigid = repair_rigid
@@ -250,7 +251,8 @@ class SceneGraph:
         Returns
         --------
         gltf : dict
-          With 'nodes' referencing a list of dicts
+          With 'nodes' referencing a list of dicts and 'scene_roots'
+          referencing the node indices the scene should start from.
         """
 
         if mesh_index is None:
@@ -264,12 +266,28 @@ class SceneGraph:
         node_data = graph.node_data
         edge_data = graph.edge_data
         base_frame = self.base_frame
+        # does the scene have a defined camera to export
+        has_camera = scene.has_camera
+        children = graph.children
+
+        # the base frame is a synthetic wrapper: when it carries nothing
+        # export its children as the scene roots instead of writing it —
+        # a file node named like the base frame is renamed on import so
+        # writing one would grow a wrapper node on every round-trip
+        skip_base = (
+            "geometry" not in node_data.get(base_frame, {})
+            and not (has_camera and base_frame == scene.camera.name)
+            and len(children.get(base_frame, [])) > 0
+        )
 
         # list of dict, in gltf format
-        # start with base frame as first node index
-        result = [{"name": base_frame}]
         # {node name : node index in gltf}
-        lookup = {base_frame: 0}
+        if skip_base:
+            result = []
+            lookup = {}
+        else:
+            result = [{"name": base_frame}]
+            lookup = {base_frame: 0}
 
         # collect the nodes in order
         for node in node_data.keys():
@@ -279,11 +297,6 @@ class SceneGraph:
             lookup[node] = len(result)
             # populate a result at the correct index
             result.append({"name": node})
-
-        # get generated properties outside of loop
-        # does the scene have a defined camera to export
-        has_camera = scene.has_camera
-        children = graph.children
 
         extensions_used = set()
 
@@ -333,7 +346,12 @@ class SceneGraph:
                     )
                     info["extras"] = extras
 
-        gltf = {"nodes": result}
+        if skip_base:
+            roots = [lookup[c] for c in children[base_frame]]
+        else:
+            roots = [lookup[base_frame]]
+
+        gltf = {"nodes": result, "scene_roots": roots}
         if len(extensions_used) > 0:
             gltf["extensionsUsed"] = list(extensions_used)
         return gltf

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -27,7 +27,7 @@ class SceneGraph:
     """
 
     def __init__(
-        self, base_frame: Hashable | None = None, repair_rigid: None | Floating = 1e-5
+        self, base_frame: Hashable | None = None, repair_rigid: Floating | None = 1e-5
     ):
         """
         Create a scene graph, holding homogeneous transformation

--- a/trimesh/scene/transforms.py
+++ b/trimesh/scene/transforms.py
@@ -7,11 +7,14 @@ import numpy as np
 from .. import caching, util
 from ..caching import hash_fast
 from ..transformations import fix_rigid, quaternion_matrix, rotation_matrix
-from ..typed import ArrayLike, Hashable, NDArray, Sequence
+from ..typed import ArrayLike, Floating, Hashable, NDArray, Sequence
 
 # we compare to identity a lot
 _identity = np.eye(4)
 _identity.flags["WRITEABLE"] = False
+
+# default name for the root frame of a scene graph
+DEFAULT_BASE_FRAME = "world"
 
 
 class SceneGraph:
@@ -23,26 +26,29 @@ class SceneGraph:
     nodes.
     """
 
-    def __init__(self, base_frame="world", repair_rigid=1e-5):
+    def __init__(
+        self, base_frame: str | None = None, repair_rigid: None | Floating = 1e-5
+    ):
         """
         Create a scene graph, holding homogeneous transformation
         matrices and instance information about geometry.
 
         Parameters
         -----------
-        base_frame : any
+        base_frame
           The root node transforms will be positioned from.
-        repair_rigid : None or float
+        repair_rigid
           If a float will attempt to repair rotation matrices
           where `M @ M.T` differs from an identity matrix by
           more than floating point zero but less than this value.
           This can happen in a deep tree with a lot of matrix
           multiplies.
         """
+
         # a graph structure, subclass of networkx DiGraph
         self.transforms = EnforcedForest()
         # hashable, the base or root frame
-        self.base_frame = base_frame
+        self.base_frame = base_frame or DEFAULT_BASE_FRAME
         # if passed as a float try to repair rigid transforms
         # that have accumulated floating point error
         self.repair_rigid = repair_rigid

--- a/trimesh/transformations.py
+++ b/trimesh/transformations.py
@@ -2313,27 +2313,7 @@ def flips_winding(matrix):
     """
     # get input as numpy array
     matrix = np.asanyarray(matrix, dtype=np.float64)
-    # how many random triangles do we really want
-    count = 3
-    # test rotation against some random triangles
-    tri = np.random.random((count * 3, 3))
-    rot = np.dot(matrix[:3, :3], tri.T).T
-
-    # stack them into one triangle soup
-    triangles = np.vstack((tri, rot)).reshape((-1, 3, 3))
-    # find the normals of every triangle
-    vectors = np.diff(triangles, axis=1)
-    cross = np.cross(vectors[:, 0], vectors[:, 1])
-    # rotate the original normals to match
-    cross[:count] = np.dot(matrix[:3, :3], cross[:count].T).T
-    # unitize normals
-    norm = np.sqrt(np.dot(cross * cross, [1, 1, 1])).reshape((-1, 1))
-    cross = cross / norm
-    # find the projection of the two normals
-    projection = np.dot(cross[:count] * cross[count:], [1.0] * 3)
-    # if the winding was flipped but not the normal
-    # the projection will be negative, and since we're
-    # checking a few triangles check against the mean
-    flip = projection.mean() < 0.0
-
-    return flip
+    if matrix.shape not in ((3, 3), (4, 4)):
+        raise ValueError(f"matrix must be (3, 3) or (4, 4), not {matrix.shape!s}")
+    # a transform flips winding exactly when its determinant is negative
+    return bool(np.linalg.det(matrix[:3, :3]) < 0.0)

--- a/trimesh/transformations.py
+++ b/trimesh/transformations.py
@@ -199,8 +199,8 @@ True
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from .typed import Integer, Number
-from .util import diagonal_dot
+from .typed import Integer, Number, Seed
+from .util import diagonal_dot, random_generator
 
 # a cached immutable identity matrix provides a speedup sometimes
 _IDENTITY = np.eye(4)
@@ -1566,12 +1566,14 @@ def quaternion_slerp(quat0, quat1, fraction, spin=0, shortestpath=True):
     return q0
 
 
-def random_quaternion(rand=None, num=1):
+def random_quaternion(rand=None, num=1, seed: Seed = None):
     """Return uniform random unit quaternion.
 
     rand: array like or None
         Three independent random variables that are uniformly distributed
         between 0 and 1.
+    seed : None or int
+        Seed for deterministic results, otherwise OS entropy.
 
     >>> q = random_quaternion()
     >>> np.allclose(1, vector_norm(q))
@@ -1579,13 +1581,15 @@ def random_quaternion(rand=None, num=1):
     >>> q = random_quaternion(num=10)
     >>> np.allclose(1, vector_norm(q, axis=1))
     True
-    >>> q = random_quaternion(np.random.random(3))
+    >>> q = random_quaternion(random_vector(3))
     >>> len(q.shape), q.shape[0]==4
     (1, True)
+    >>> bool(np.allclose(random_quaternion(seed=0), random_quaternion(seed=0)))
+    True
 
     """
     if rand is None:
-        rand = np.random.rand(3 * num).reshape((3, -1))
+        rand = random_generator(seed).random(3 * num).reshape((3, -1))
     else:
         assert rand.shape[0] == 3
     r1 = np.sqrt(1.0 - rand[0])
@@ -1599,7 +1603,10 @@ def random_quaternion(rand=None, num=1):
 
 
 def random_rotation_matrix(
-    rand: ArrayLike | None = None, num: Integer = 1, translate: Number | None = None
+    rand: ArrayLike | None = None,
+    num: Integer = 1,
+    translate: Number | None = None,
+    seed: Seed = None,
 ):
     """
     Return uniform random rotation matrix.
@@ -1614,6 +1621,8 @@ def random_rotation_matrix(
     translate
       If passed the rotation matrix will include translation
       that is random and between positive and negative half this value.
+    seed
+      Seed for deterministic results, otherwise OS entropy.
 
     >>> R = random_rotation_matrix()
     >>> np.allclose(np.dot(R.T, R), np.identity(4))
@@ -1621,12 +1630,18 @@ def random_rotation_matrix(
     >>> R = random_rotation_matrix(num=10)
     >>> np.allclose(np.einsum('...ji,...jk->...ik', R, R), np.identity(4))
     True
+    >>> bool(np.allclose(random_rotation_matrix(seed=0, translate=10),
+    ...                  random_rotation_matrix(seed=0, translate=10)))
+    True
 
     """
-    matrix = quaternion_matrix(random_quaternion(rand=rand, num=num))
+    # thread one generator through so a passed `seed` doesn't hand the
+    # translation the same values as the quaternion below
+    rng = random_generator(seed)
+    matrix = quaternion_matrix(random_quaternion(rand=rand, num=num, seed=rng))
     if translate:
         # apply random translation with the order of magnitude requested
-        matrix[:3, 3] = (np.random.random(3) - 0.5) * float(translate)
+        matrix[:3, 3] = (rng.random(3) - 0.5) * float(translate)
 
     return matrix
 
@@ -1905,7 +1920,7 @@ def unit_vector(data, axis=None, out=None):
         return data
 
 
-def random_vector(size):
+def random_vector(size, seed: Seed = None):
     """Return array of random doubles in the half-open interval [0.0, 1.0).
 
     >>> v = random_vector(10000)
@@ -1915,9 +1930,11 @@ def random_vector(size):
     >>> v1 = random_vector(10)
     >>> bool(np.any(v0 == v1))
     False
+    >>> bool(np.allclose(random_vector(10, seed=0), random_vector(10, seed=0)))
+    True
 
     """
-    return np.random.random(size)
+    return random_generator(seed).random(size)
 
 
 def vector_product(v0, v1, axis=0):

--- a/trimesh/transformations.py
+++ b/trimesh/transformations.py
@@ -1637,11 +1637,11 @@ def random_rotation_matrix(
     """
     # thread one generator through so a passed `seed` doesn't hand the
     # translation the same values as the quaternion below
-    rng = random_generator(seed)
-    matrix = quaternion_matrix(random_quaternion(rand=rand, num=num, seed=rng))
+    random = random_generator(seed)
+    matrix = quaternion_matrix(random_quaternion(rand=rand, num=num, seed=random))
     if translate:
         # apply random translation with the order of magnitude requested
-        matrix[:3, 3] = (rng.random(3) - 0.5) * float(translate)
+        matrix[:3, 3] = (random.random(3) - 0.5) * float(translate)
 
     return matrix
 

--- a/trimesh/typed.py
+++ b/trimesh/typed.py
@@ -1,3 +1,5 @@
+import io
+import typing
 from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from io import IOBase
 from pathlib import Path
@@ -14,6 +16,7 @@ from typing import (
     runtime_checkable,
 )
 
+import numpy
 from numpy import dtype, float64, floating, generic, int64, integer, ndarray
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
@@ -75,6 +78,9 @@ class HttpSessionLike(Protocol):
 
     Matches `httpx.Client` and `requests.Session` so a resolver
     can take either without trimesh importing them directly.
+    other duck-typed sessions are called as `get(url)` with no
+    additional kwargs. async sessions like `aiohttp.ClientSession`
+    can't be driven synchronously and are rejected at runtime.
     """
 
     def get(self, url: str, *args, **kwargs) -> Any: ...
@@ -86,6 +92,22 @@ DType = TypeVar("DType", bound=generic)
 NDArray1D: TypeAlias = ndarray[tuple[int], dtype[DType]]
 NDArray2D: TypeAlias = ndarray[tuple[int, int], dtype[DType]]
 NDArray3D: TypeAlias = ndarray[tuple[int, int, int], dtype[DType]]
+
+
+# DEPRECATED : these aliases will be removed after July 2028
+# import them from `typing`, `io`, or `numpy` instead
+List = list
+Dict = dict
+Tuple = tuple
+Set = set
+Optional = typing.Optional
+Union = typing.Union
+TextIO = typing.TextIO
+BytesIO = io.BytesIO
+StringIO = io.StringIO
+BufferedRandom = io.BufferedRandom
+unsignedinteger = numpy.unsignedinteger
+
 
 __all__ = [
     "IO",
@@ -100,6 +122,7 @@ __all__ = [
     "HttpSessionLike",
     "Integer",
     "Iterable",
+    "Literal",
     "Loadable",
     "Mapping",
     "NDArray",

--- a/trimesh/typed.py
+++ b/trimesh/typed.py
@@ -18,6 +18,7 @@ from typing import (
 
 import numpy
 from numpy import dtype, float64, floating, generic, int64, integer, ndarray
+from numpy.random import BitGenerator, Generator, SeedSequence
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
 if version_info >= (3, 11):
@@ -93,6 +94,11 @@ NDArray1D: TypeAlias = ndarray[tuple[int], dtype[DType]]
 NDArray2D: TypeAlias = ndarray[tuple[int, int], dtype[DType]]
 NDArray3D: TypeAlias = ndarray[tuple[int, int, int], dtype[DType]]
 
+# anything `numpy.random.default_rng` can normalize into a `Generator`
+# passing a `Generator` lets a caller thread one stream through nested
+# calls -- `default_rng` hands it back rather than re-seeding it
+Seed: TypeAlias = Integer | Sequence[int] | SeedSequence | Generator | BitGenerator | None
+
 
 # DEPRECATED : these aliases will be removed after July 2028
 # import them from `typing`, `io`, or `numpy` instead
@@ -130,6 +136,7 @@ __all__ = [
     "NDArray2D",
     "NDArray3D",
     "Number",
+    "Seed",
     "Self",
     "Sequence",
     "Stream",

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -44,6 +44,7 @@ from .typed import (
     NDArray1D,
     NDArray2D,
     Number,
+    Seed,
     Stream,
 )
 
@@ -73,6 +74,34 @@ _STRICT: bool = False
 # beartype is unable to resolve `NDArray[float64]` for globals
 _IDENTITY: np.ndarray = np.eye(4, dtype=np.float64)
 _IDENTITY.flags["WRITEABLE"] = False
+
+# one process-wide generator for the unseeded case: constructing one
+# collects OS entropy which costs ~200x more than the draw it feeds
+_RANDOM_DEFAULT = np.random.default_rng()
+
+
+def random_generator(seed: Seed = None) -> np.random.Generator:
+    """
+    Get a random generator, optionally seeded for deterministic results.
+
+    Parameters
+    ----------
+    seed
+      If None use a shared generator seeded from OS entropy. An integer
+      seeds a fresh generator. A `Generator` is returned unaltered which
+      lets a caller thread one stream through nested calls rather than
+      re-seeding each of them to identical values.
+
+    Returns
+    -------
+    generator
+      Draw random values from this.
+    """
+    if seed is None:
+        # numpy locks the bit generator on every draw so sharing
+        # this between threads is as safe as `numpy.random.random`
+        return _RANDOM_DEFAULT
+    return np.random.default_rng(seed)
 
 
 def has_module(name: str) -> bool:

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -834,7 +834,7 @@ def decimal_to_digits(decimal: Floating, min_digits: Integer | None = None) -> i
 def attach_to_log(
     level: Integer = logging.DEBUG,
     handler: logging.Handler | None = None,
-    loggers: MutableSet[logging.Logger | Any] | None = None,
+    loggers: MutableSet[logging.Logger] | None = None,
     colors: bool = True,
     capture_warnings: bool = True,
     blacklist: Iterable[str] | None = None,
@@ -1433,7 +1433,7 @@ def type_bases(obj: object, depth: Integer = 4) -> list[type]:
     return [i for i in bases_flat if hasattr(i, "__name__")]
 
 
-def type_named(obj: object, name: str) -> type | None:
+def type_named(obj: object, name: str) -> type:
     """
     Similar to the type() builtin, but looks in class bases
     for named instance.
@@ -1443,12 +1443,12 @@ def type_named(obj: object, name: str) -> type | None:
     obj : any
       Object to look for class of
     name : str
-      Nnme of class
+      Name of class
 
     Returns
     ----------
-    class : Callable | None
-      Named class, or None
+    class : type
+      Named class, raises ValueError if not found
     """
     # if obj is a member of the named class, return True
     name = str(name)
@@ -1578,7 +1578,6 @@ def concatenate(a, b=None) -> "trimesh.parent.Geometry":
                 )
 
     # create the mesh object
-    assert trimesh_type is not None
     result = trimesh_type(
         vertices=vertices,
         faces=faces,
@@ -1674,12 +1673,7 @@ def submesh(
         faces.append(mask[current])
         vertices.append(original_vertices[unique])
 
-        assert mesh.visual is not None
-        try:
-            visuals.append(mesh.visual.face_subset(index))
-        except BaseException as E:
-            raise E
-            visuals = None
+        visuals.append(mesh.visual.face_subset(index))
 
     if len(vertices) == 0:
         return []
@@ -1687,7 +1681,6 @@ def submesh(
     # we use type(mesh) rather than importing Trimesh from base
     # to avoid a circular import
     trimesh_type = type_named(mesh, "Trimesh")
-    assert trimesh_type is not None
 
     if append:
         visual = None
@@ -2022,17 +2015,22 @@ def decompress(
     if isinstance(file_obj, bytes):
         file_obj = BytesIO(file_obj)
 
+    def read_capped(src, total):
+        # read an archive member one byte past the remaining budget
+        # rather than trusting the size the archive declared, returning
+        # the data and the new running total of bytes read
+        data = src.read(MAX_ARCHIVE_SIZE - total + 1)
+        if total + len(data) > MAX_ARCHIVE_SIZE:
+            raise ValueError("archive exceeds size cap")
+        return data, total + len(data)
+
     if file_type.endswith("zip"):
         archive = zipfile.ZipFile(file_obj)
         result = {}
         total = 0
         for info in archive.infolist():
             with archive.open(info, mode="r") as src:
-                # read one past the remaining budget to detect overflow
-                data = src.read(MAX_ARCHIVE_SIZE - total + 1)
-            if total + len(data) > MAX_ARCHIVE_SIZE:
-                raise ValueError("archive exceeds size cap")
-            total += len(data)
+                data, total = read_capped(src, total)
             result[info.filename] = wrap_as_stream(data)
         return result
     if file_type.endswith("bz2"):
@@ -2040,9 +2038,7 @@ def decompress(
 
         # get the file name if we have one otherwise default to "archive"
         name = getattr(file_obj, "name", "archive1234")[:-4]
-        data = bz2.open(file_obj, mode="r").read(MAX_ARCHIVE_SIZE + 1)
-        if len(data) > MAX_ARCHIVE_SIZE:
-            raise ValueError("archive exceeds size cap")
+        data, _ = read_capped(bz2.open(file_obj, mode="r"), 0)
         return {name: wrap_as_stream(data)}
     if "tar" in file_type[-6:]:
         import tarfile
@@ -2056,11 +2052,7 @@ def decompress(
             src = archive.extractfile(info)
             if src is None:
                 continue
-            # read one past the remaining budget rather than trusting info.size
-            data = src.read(MAX_ARCHIVE_SIZE - total + 1)
-            if total + len(data) > MAX_ARCHIVE_SIZE:
-                raise ValueError("archive exceeds size cap")
-            total += len(data)
+            data, total = read_capped(src, total)
             result[info.name] = wrap_as_stream(data)
         return result
     raise ValueError("Unsupported type passed!")

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -2013,8 +2013,8 @@ def sigfig_int(
     return as_int, multiplier
 
 
-# cap on total uncompressed bytes from a single archive
-MAX_ARCHIVE_SIZE = 8 * 1024**3  # 8 GiB
+# skip ZIP members once declared uncompressed sizes exceed this
+_ARCHIVE_SKIP_SIZE = 32 * 1024**3  # 32 GiB
 
 
 def decompress(
@@ -2025,8 +2025,9 @@ def decompress(
     Given an open file object and a file type, return all components
     of the archive as open file objects in a dict.
 
-    Total uncompressed size is capped at `MAX_ARCHIVE_SIZE`; reads stop
-    one byte past the budget rather than trusting declared member sizes.
+    ZIP members are skipped once the total uncompressed size declared by
+    the archive exceeds `_ARCHIVE_SKIP_SIZE`. Other formats don't store a
+    per-member compressed size so there is nothing to check before reading.
 
     Parameters
     ------------
@@ -2044,22 +2045,24 @@ def decompress(
     if isinstance(file_obj, bytes):
         file_obj = BytesIO(file_obj)
 
-    def read_capped(src, total):
-        # read an archive member one byte past the remaining budget
-        # rather than trusting the size the archive declared, returning
-        # the data and the new running total of bytes read
-        data = src.read(MAX_ARCHIVE_SIZE - total + 1)
-        if total + len(data) > MAX_ARCHIVE_SIZE:
-            raise ValueError("archive exceeds size cap")
-        return data, total + len(data)
-
     if file_type.endswith("zip"):
         archive = zipfile.ZipFile(file_obj)
         result = {}
+        # running total of the sizes the central directory declared: this is
+        # an upper bound on what we can actually read as `ZipExtFile` stops
+        # at the declared size and then fails the CRC check
         total = 0
         for info in archive.infolist():
+            if total + info.file_size > _ARCHIVE_SKIP_SIZE:
+                log.warning(
+                    "skipping `%s`: declared %d bytes exceeds archive budget",
+                    info.filename,
+                    info.file_size,
+                )
+                continue
+            total += info.file_size
             with archive.open(info, mode="r") as src:
-                data, total = read_capped(src, total)
+                data = src.read()
             result[info.filename] = wrap_as_stream(data)
         return result
     if file_type.endswith("bz2"):
@@ -2067,22 +2070,19 @@ def decompress(
 
         # get the file name if we have one otherwise default to "archive"
         name = getattr(file_obj, "name", "archive1234")[:-4]
-        data, _ = read_capped(bz2.open(file_obj, mode="r"), 0)
-        return {name: wrap_as_stream(data)}
+        return {name: wrap_as_stream(bz2.open(file_obj, mode="r").read())}
     if "tar" in file_type[-6:]:
         import tarfile
 
         archive = tarfile.open(fileobj=file_obj, mode="r")
         result = {}
-        total = 0
         for info in archive.getmembers():
             if not info.isfile():
                 continue
             src = archive.extractfile(info)
             if src is None:
                 continue
-            data, total = read_capped(src, total)
-            result[info.name] = wrap_as_stream(data)
+            result[info.name] = wrap_as_stream(src.read())
         return result
     raise ValueError("Unsupported type passed!")
 

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1791,7 +1791,7 @@ def jsonify(obj: object, **kwargs: Any) -> str:
     """
 
     class EdgeEncoder(json.JSONEncoder):
-        def default(self, obj: Any) -> str:
+        def default(self, obj: Any):
             # will work for numpy.ndarrays
             # as well as their int64/etc objects
             if hasattr(obj, "tolist"):

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -24,6 +24,7 @@ from collections.abc import (
     Sequence,
 )
 from copy import deepcopy
+from dataclasses import asdict as dataclass_to_dict
 from io import BytesIO, StringIO
 from typing import TYPE_CHECKING
 
@@ -1790,14 +1791,19 @@ def jsonify(obj: object, **kwargs: Any) -> str:
     """
 
     class EdgeEncoder(json.JSONEncoder):
-        def default(self, o: Any) -> str:
+        def default(self, obj: Any) -> str:
             # will work for numpy.ndarrays
             # as well as their int64/etc objects
-            if hasattr(o, "tolist"):
-                return o.tolist()
-            elif hasattr(o, "timestamp"):
-                return o.timestamp()
-            return json.JSONEncoder.default(self, o)
+            if hasattr(obj, "tolist"):
+                # this works on numpy arrays
+                return obj.tolist()
+            elif hasattr(obj, "timestamp"):
+                # serialize datetime as the float stamp
+                return obj.timestamp()
+            elif hasattr(obj, "__dataclass_fields__"):
+                # serialize dataclasses as dict
+                return dataclass_to_dict(obj)
+            return json.JSONEncoder.default(self, obj)
 
     # run the dumps using our encoder
     return json.dumps(obj, cls=EdgeEncoder, **kwargs)

--- a/trimesh/viewer/__init__.py
+++ b/trimesh/viewer/__init__.py
@@ -30,7 +30,6 @@ except BaseException as E:
 # as otherwise flake8 gets mad
 __all__ = [
     "SceneViewer",
-    "SceneWidget",
     "in_notebook",
     "render_scene",
     "scene_to_html",

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -39,6 +39,7 @@ from ..typed import (
     Integer,
     Iterable,
     NDArray,
+    Seed,
 )
 from .base import Visuals
 
@@ -778,7 +779,11 @@ def srgb_to_linear(srgb: ArrayLike) -> NDArray[np.float64]:
     return linear
 
 
-def random_color(dtype: DTypeLike = np.uint8, count: Integer | None = None) -> NDArray:
+def random_color(
+    dtype: DTypeLike = np.uint8,
+    count: Integer | None = None,
+    seed: Seed = None,
+) -> NDArray:
     """
     Return a random RGB color using datatype specified.
 
@@ -789,6 +794,8 @@ def random_color(dtype: DTypeLike = np.uint8, count: Integer | None = None) -> N
     count
       If passed return (count, 4) colors instead of
       a single (4,) color.
+    seed
+      Seed for deterministic results, otherwise OS entropy.
 
     Returns
     ----------
@@ -796,7 +803,7 @@ def random_color(dtype: DTypeLike = np.uint8, count: Integer | None = None) -> N
       Random color or colors that look "OK"
     """
     # generate a random hue
-    hue = (np.random.random(count or 1) + 0.61803) % 1.0
+    hue = (util.random_generator(seed).random(count or 1) + 0.61803) % 1.0
 
     # saturation and "value" as constant
     sv = np.ones_like(hue) * 0.99

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -801,7 +801,7 @@ def random_color(dtype: DTypeLike = np.uint8, count: Integer | None = None) -> N
     # saturation and "value" as constant
     sv = np.ones_like(hue) * 0.99
     # convert our random hue to RGBA
-    colors = hsv_to_rgba(np.column_stack((hue, sv, sv)))
+    colors = hsv_to_rgba(np.column_stack((hue, sv, sv)), dtype=dtype)
 
     # unspecified count is a single color
     if count is None:

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -982,7 +982,7 @@ def linear_color_map(values: ArrayLike, color_range: ArrayLike | None = None) ->
 
 def interpolate(
     values: ArrayLike,
-    color_map: None | ColorMapType | Callable = None,
+    color_map: ColorMapType | Callable | None = None,
     dtype: DTypeLike = np.uint8,
 ) -> NDArray:
     """


### PR DESCRIPTION
This is the first non release-candidate release incorporating #2539, which among other things dropped Python versions earlier than 3.10. 

I've been testing the `rc0` and it seems solid, but there were a fair number of changes. This PR does some follow up minor fixes, and releases to `5.0.0`.

- Adds a warning to `GLTF` files with unhandled extensions. As discussed in #2571 we fill in unhandled extensions with zeros so the handled part of the file can be used. But this is quite haunted and not great. I will probably change the log level to `debug` before release as `warning` spams aggressively. 
- Release outstanding smaller fixes
- Try to lock in GLTF handler behavior contract more firmly.
- Adds `dataclass` support to `trimesh.util.jsonify` and adds a test. 
- Tried a number of different fixes for #2574 and settles on one.
- Makes a determinism pass adding a `seed: typed.Seed` argument to many random consumers like `random_color`, `random_rotation_matrix`, etc. This lets you pass either an integer or a numpy RNG (i.e. `numpy.random.default_rng()`) that you're managing manually. [SPEC7](https://scientific-python.org/specs/spec-0007/) suggests this (but with `rng` as the keyword argument, which doesn't match the `useful_name` style of the library). This seems to have made the test matrix less flaky. This pass doesn't touch 100% of tests and there's still a few consumers of the global random state, but it is an improvement and gives us a path towards 100% test determinism. 