### PR TITLE
Followup: Fix Beartype

### DIFF
--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -1,6 +1,21 @@
+try:
+    from . import generic as g
+except BaseException:
+    import generic as g
+
+import typing
+
 import numpy as np
 
-from trimesh.typed import ArrayLike, NDArray, float64, int64
+from trimesh.typed import (
+    ArrayLike,
+    NDArray,
+    NDArray1D,
+    NDArray2D,
+    NDArray3D,
+    float64,
+    int64,
+)
 
 
 # see if we pass mypy
@@ -10,3 +25,33 @@ def _check(values: ArrayLike) -> NDArray[int64]:
 
 def _run() -> NDArray[int64]:
     return _check(values=[1, 2])
+
+
+class TypedTest(g.unittest.TestCase):
+    def alias_args(self, alias):
+        # an array alias is `numpy.ndarray[shape, numpy.dtype[scalar]]`
+        assert typing.get_origin(alias) is np.ndarray
+        shape, dtype = typing.get_args(alias)
+        assert typing.get_origin(dtype) is np.dtype
+        (scalar,) = typing.get_args(dtype)
+        return typing.get_args(shape), scalar
+
+    def test_dimension(self):
+        # each alias must report the shape arity its name promises
+        for alias, ndim in ((NDArray1D, 1), (NDArray2D, 2), (NDArray3D, 3)):
+            shape, scalar = self.alias_args(alias[np.float64])
+            assert shape == (int,) * ndim
+            # dtype slot must be a concrete np.dtype, not a leaked TypeVar —
+            # the numpy 2.5 regression beartype cannot reduce
+            assert np.dtype(scalar) == np.dtype(np.float64)
+
+    def test_scalar(self):
+        # a spread of scalar kinds stay np.dtype-coercible through the alias
+        for scalar in (np.float64, np.int64, np.uint8, np.bool_):
+            _shape, got = self.alias_args(NDArray1D[scalar])
+            assert np.dtype(got) == np.dtype(scalar)
+
+
+if __name__ == "__main__":
+    g.trimesh.util.attach_to_log()
+    g.unittest.main()

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -10,7 +10,7 @@ from .. import grouping, resources, util, visual
 from ..constants import log
 from ..geometry import triangulate_quads
 from ..resolvers import Resolver
-from ..typed import NDArray
+from ..typed import ArrayLike
 
 # from ply specification, and additional dtypes found in the wild
 _dtypes = {
@@ -294,9 +294,9 @@ def export_ply(
     header_params = {"encoding": encoding}
 
     # structured arrays for exports
-    pack_edges: NDArray | None = None
-    pack_vertex: NDArray | None = None
-    pack_faces: NDArray | None = None
+    pack_edges: ArrayLike | None = None
+    pack_vertex: ArrayLike | None = None
+    pack_faces: ArrayLike | None = None
 
     # check if scene has geometry
     # check if this is a `trimesh.path.Path` object.

--- a/trimesh/scene/scene.py
+++ b/trimesh/scene/scene.py
@@ -1605,7 +1605,7 @@ def reconstruct_instances(scene: Scene, cost_threshold: Floating = 1e-6) -> Scen
         # get the geometry name for this base node
         _, geom_base = scene.graph[node_base]
         # get the vertices of the base model
-        base: NDArray = scene.geometry[geom_base].vertices.view(np.ndarray)
+        base = scene.geometry[geom_base].vertices.view(np.ndarray)
 
         for node in group[1:]:
             # the original pose of this node in the scene

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -599,7 +599,7 @@ def diagonal_dot(a: ArrayLike, b: ArrayLike) -> np.ndarray[tuple[int], np.dtype[
     return np.dot(a * b, [1.0] * a.shape[1])
 
 
-def row_norm(data: NDArray) -> NDArray1D[np.float64]:
+def row_norm(data: NDArray2D[Any]) -> NDArray1D[np.float64]:
     """
     Compute the norm per-row of a numpy array.
 


### PR DESCRIPTION
Attempt to fix the `beartype` checks for Numpy 2.5's changes to `numpy.typing.NDArray`.