### PR TITLE
feat(exchange): add support for draco compression in GLTF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ trimesh = [
 
 # this is the base extra most users will want
 easy = [
+    "DracoPy",
     "colorlog",
     "manifold3d>=2.3.0",
     "charset-normalizer",

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -1151,6 +1151,27 @@ class GLTFTest(g.unittest.TestCase):
         mean_squared_error = ((a - b) ** 2).sum() / g.np.prod(a.shape)
         assert mean_squared_error < 10.0
 
+    def test_draco_roundtrip(self):
+        m = g.get_mesh("fuze.obj")
+        nc = m.export(file_type="glb")
+        e = m.export(file_type="glb", extension_draco=True)
+        r = g.trimesh.load_mesh(g.trimesh.util.wrap_as_stream(e), file_type="glb")
+
+        assert len(m.faces) == len(r.faces)
+        assert len(e) < len(nc)  # ensure compression worked
+
+        # compare RGBA images for the roundtripped texture
+        a = g.np.array(m.visual.material.image)
+        b = g.np.array(r.visual.material.baseColorTexture)
+        assert a.shape == b.shape
+
+        # test with normals
+        e = m.export(file_type="glb", extension_draco=True, include_normals=True)
+        r = g.trimesh.load_mesh(g.trimesh.util.wrap_as_stream(e), file_type="glb")
+
+        assert len(m.faces) == len(r.faces)
+        assert len(r.vertex_normals) == len(r.vertices)
+
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/tests/test_gltf.py
+++ b/tests/test_gltf.py
@@ -1,3 +1,5 @@
+import platform
+
 try:
     from . import generic as g
 except BaseException:
@@ -1152,6 +1154,10 @@ class GLTFTest(g.unittest.TestCase):
         assert mean_squared_error < 10.0
 
     def test_draco_roundtrip(self):
+        # Skip this if on i386 or s390x
+        if platform.machine().lower() in ("i386", "s390x", "s390"):
+            return
+
         m = g.get_mesh("fuze.obj")
         nc = m.export(file_type="glb")
         e = m.export(file_type="glb", extension_draco=True)

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -133,7 +133,7 @@ def export_gltf(
 
     base64_buffer_format = "data:application/octet-stream;base64,{}"
     if merge_buffers:
-        views = _build_views(buffer_items)
+        views, buffer_items = _build_views(buffer_items)
         buffer_data = b"".join(buffer_items.values())
         if embed_buffers:
             buffer_name = base64_buffer_format.format(
@@ -219,7 +219,7 @@ def export_glb(
     )
 
     # A bufferView is a slice of a file
-    views = _build_views(buffer_items)
+    views, buffer_items = _build_views(buffer_items)
 
     # combine bytes into a single blob
     buffer_data = b"".join(buffer_items.values())
@@ -1026,18 +1026,25 @@ def _build_views(buffer_items):
     ----------
     views : (n,) list of dict
       GLTF views
+    buffer_items
+        Padded buffer items
     """
     views = []
+    padded = OrderedDict()
     # create the buffer views
     current_pos = 0
-    for current_item in buffer_items.values():
+    for key, current_item in buffer_items.items():
         views.append(
             {"buffer": 0, "byteOffset": current_pos, "byteLength": len(current_item)}
         )
+        padding_needed = 4 - len(current_item) % 4
+        if padding_needed != 4:
+            current_item = current_item + bytes([0] * padding_needed)
         assert (current_pos % 4) == 0
         assert (len(current_item) % 4) == 0
         current_pos += len(current_item)
-    return views
+        padded[key] = current_item
+    return views, padded
 
 
 def _build_accessor(array):

--- a/trimesh/exchange/gltf/__init__.py
+++ b/trimesh/exchange/gltf/__init__.py
@@ -805,6 +805,54 @@ def _append_mesh(
     if len(mesh.faces) == 0 or len(mesh.vertices) == 0:
         log.debug("skipping empty mesh!")
         return
+
+    current = {
+        "name": name,
+        "extras": {},
+        "primitives": [
+            {
+                "attributes": {"POSITION": 0},
+                "indices": 0,
+                "mode": _GL_TRIANGLES,
+            }
+        ],
+    }
+
+    # Handle texture first so any images are at the beginning of the buffer list
+    if hasattr(mesh.visual, "material"):
+        # append the material and then set from returned index
+        current_material = _append_material(
+            mat=mesh.visual.material,
+            tree=tree,
+            buffer_items=buffer_items,
+            mat_hashes=mat_hashes,
+            extension_webp=extension_webp,
+        )
+
+        # if mesh has UV coordinates defined export them
+        has_uv = (
+            hasattr(mesh.visual, "uv")
+            and mesh.visual.uv is not None
+            and len(mesh.visual.uv) == len(mesh.vertices)
+        )
+        if has_uv:
+            # slice off W if passed
+            uv = mesh.visual.uv.copy()[:, :2]
+            # reverse the Y for GLTF
+            uv[:, 1] = 1.0 - uv[:, 1]
+            # add an accessor describing the blob of UV's
+            acc_uv = _data_append(
+                acc=tree["accessors"],
+                buff=buffer_items,
+                blob={"componentType": 5126, "type": "VEC2", "byteOffset": 0},
+                data=uv.astype(float32),
+            )
+            # add the reference for UV coordinates
+            current["primitives"][0]["attributes"]["TEXCOORD_0"] = acc_uv
+
+        # reference the material
+        current["primitives"][0]["material"] = current_material
+
     # convert mesh data to the correct dtypes
     # faces: 5125 is an unsigned 32 bit integer
     # accessors refer to data locations
@@ -826,17 +874,9 @@ def _append_mesh(
     )
 
     # meshes reference accessor indexes
-    current = {
-        "name": name,
-        "extras": {},
-        "primitives": [
-            {
-                "attributes": {"POSITION": acc_vertex},
-                "indices": acc_face,
-                "mode": _GL_TRIANGLES,
-            }
-        ],
-    }
+    current["primitives"][0]["attributes"]["POSITION"] = acc_vertex
+    current["primitives"][0]["indices"] = acc_face
+
     # if units are defined, store them as an extra
     # the GLTF spec says everything is implicit meters
     # we're not doing that as our unit conversions are expensive
@@ -889,40 +929,6 @@ def _append_mesh(
             log.warning(
                 "Vertex colors have different length than mesh vertices, dropping!"
             )
-
-    if hasattr(mesh.visual, "material"):
-        # append the material and then set from returned index
-        current_material = _append_material(
-            mat=mesh.visual.material,
-            tree=tree,
-            buffer_items=buffer_items,
-            mat_hashes=mat_hashes,
-            extension_webp=extension_webp,
-        )
-
-        # if mesh has UV coordinates defined export them
-        has_uv = (
-            hasattr(mesh.visual, "uv")
-            and mesh.visual.uv is not None
-            and len(mesh.visual.uv) == len(mesh.vertices)
-        )
-        if has_uv:
-            # slice off W if passed
-            uv = mesh.visual.uv.copy()[:, :2]
-            # reverse the Y for GLTF
-            uv[:, 1] = 1.0 - uv[:, 1]
-            # add an accessor describing the blob of UV's
-            acc_uv = _data_append(
-                acc=tree["accessors"],
-                buff=buffer_items,
-                blob={"componentType": 5126, "type": "VEC2", "byteOffset": 0},
-                data=uv.astype(float32),
-            )
-            # add the reference for UV coordinates
-            current["primitives"][0]["attributes"]["TEXCOORD_0"] = acc_uv
-
-        # reference the material
-        current["primitives"][0]["material"] = current_material
 
     if include_normals or (
         include_normals is None and "vertex_normals" in mesh._cache.cache

--- a/trimesh/exchange/gltf/extensions.py
+++ b/trimesh/exchange/gltf/extensions.py
@@ -14,6 +14,12 @@ import numpy as np
 
 from ...caching import hash_fast
 from ...constants import log
+from ...exceptions import ExceptionWrapper
+
+try:
+    import DracoPy as dpy
+except BaseException as E:
+    dpy = exceptions.ExceptionWrapper(E)
 
 # GL geometry modes
 _GL_TRIANGLES = 4
@@ -299,7 +305,6 @@ def _draco_mesh_compression(context: PrimitivePreprocessContext) -> None:
     context
         PrimitivePreprocessContext with extension data.
     """
-    import DracoPy as dpy
     primitive = context["primitive"]
 
     if primitive.get("mode") not in [_GL_STRIP, _GL_TRIANGLES]:
@@ -344,12 +349,6 @@ def _draco_mesh_compression(context: PrimitiveExportContext) -> None:
     context
         PrimitiveExportContext with extension data.
     """
-    import DracoPy as dpy
-
-    # For index accessor + attribute accessors:
-    #  - Replace the accessor information
-    #  - Extract data from buffers
-
     primitive = context.get("primitive")
     if not primitive:
         return
@@ -418,8 +417,8 @@ def _draco_mesh_compression(context: PrimitiveExportContext) -> None:
         tex_coord=tex_coord,
         normals=normals,
         generic_attributes=generic_attributes or None,
-        quantization_bits=14,
-        compression_level=2,
+        quantization_bits=14,  # blender defaults
+        compression_level=6,   # blender defaults
     )
     dpy_mesh = dpy.decode_buffer_to_mesh(buf)
 

--- a/trimesh/exchange/gltf/extensions.py
+++ b/trimesh/exchange/gltf/extensions.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from ...caching import hash_fast
 from ...constants import log
+from ...exceptions import ExceptionWrapper
 
 try:
     import DracoPy as dpy

--- a/trimesh/exchange/gltf/extensions.py
+++ b/trimesh/exchange/gltf/extensions.py
@@ -10,7 +10,28 @@ from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any, Literal, TypeAlias, TypedDict
 
+import numpy as np
+
+from ...caching import hash_fast
 from ...constants import log
+
+# GL geometry modes
+_GL_TRIANGLES = 4
+_GL_STRIP = 5
+
+# GLTF data formats: numpy shapes
+_shapes = {
+    "SCALAR": 1,
+    "VEC2": (2),
+    "VEC3": (3),
+    "VEC4": (4),
+    "MAT2": (2, 2),
+    "MAT3": (3, 3),
+    "MAT4": (4, 4),
+}
+
+# GLTF data type codes: little endian numpy dtypes
+_dtypes = {5120: "<i1", 5121: "<u1", 5122: "<i2", 5123: "<u2", 5125: "<u4", 5126: "<f4"}
 
 # Scopes define where in the glTF load/export process handlers run:
 #   material            - after parsing material, can override PBR values
@@ -198,7 +219,7 @@ def handle_extensions(
             if (result := _handlers[scope][ext_name](context)) is not None:
                 results[ext_name] = result
         except Exception as e:
-            log.warning(f"failed to process extension {ext_name}: {e}")
+            log.exception(f"failed to process extension {ext_name}: {e}")
 
     # for _source scopes return first result, otherwise return all results
     if scope.endswith("_source"):
@@ -267,3 +288,199 @@ def _texture_webp_source(context: TextureSourceContext) -> int | None:
       Index into glTF images array, or None if not present.
     """
     return context["data"].get("source")
+
+@register_handler("KHR_draco_mesh_compression", scope="primitive_preprocess")
+def _draco_mesh_compression(context: PrimitivePreprocessContext) -> None:
+    """
+    Decompress draco mesh data.
+
+    Parameters
+    ----------
+    context
+        PrimitivePreprocessContext with extension data.
+    """
+    import DracoPy as dpy
+    primitive = context["primitive"]
+
+    if primitive.get("mode") not in [_GL_STRIP, _GL_TRIANGLES]:
+        return
+
+    extensions = primitive.get("extensions")
+    if not extensions:
+        return
+
+    extension = extensions.get("KHR_draco_mesh_compression")
+    if not extension:
+        return
+
+    all_attributes = primitive["attributes"]
+    extension_attributes = {v: k for k, v in extension["attributes"].items()}
+    dpy_mesh = dpy.decode_buffer_to_mesh(context["views"][int(extension["bufferView"])])
+
+    # Update any accessors with decompressed data
+    for attr in dpy_mesh.attributes:
+        uid = attr["unique_id"]
+        if uid not in extension_attributes:
+            continue
+        attr_name = extension_attributes[uid]
+        if attr_name not in all_attributes:
+            continue
+        context["accessors"][all_attributes[attr_name]] = attr["data"]
+
+    # Handle indexed accesssors
+    indices = primitive.get("indices")
+    if indices is None:
+        return
+    context["accessors"][indices] = dpy_mesh.faces
+
+
+@register_handler("KHR_draco_mesh_compression", scope="primitive_export")
+def _draco_mesh_compression(context: PrimitiveExportContext) -> None:
+    """
+    Decompress draco mesh data.
+
+    Parameters
+    ----------
+    context
+        PrimitiveExportContext with extension data.
+    """
+    import DracoPy as dpy
+
+    # For index accessor + attribute accessors:
+    #  - Replace the accessor information
+    #  - Extract data from buffers
+
+    primitive = context.get("primitive")
+    if not primitive:
+        return
+
+    tree = context.get("tree")
+    if not tree:
+        return
+
+    buffer_items = context.get("buffer_items")
+    if not buffer_items:
+        return
+
+    accessors = tree.get("accessors", [])
+
+    accessor_idx_map = {i: v for i, v in enumerate(accessors.values())}
+    accessor_key_map = {i: k for i, k in enumerate(accessors)}
+    buffer_idx_map = {i: v for i, v in enumerate(buffer_items.values())}
+    buffer_key_map = {i: k for i, k in enumerate(buffer_items)}
+
+    points = None
+    faces = None
+    colors = None
+    tex_coord = None
+    normals = None
+    generic_attributes = {}
+
+    buffer_indices = []
+
+    attributes = primitive.get("attributes")
+    all_attribs = attributes.copy()
+    all_attribs["FACES"] = primitive.get("indices")
+
+    for attribute_name, attribute_idx in all_attribs.items():
+        accessor = accessor_idx_map[attribute_idx]
+        dtype = np.dtype(_dtypes[accessor["componentType"]])
+        count = accessor["count"]
+        per_item = _shapes[accessor["type"]]
+        shape = (count, per_item)
+        per_count = np.abs(np.prod(per_item))
+        buffer_idx = accessor["bufferView"]
+        start = accessor.get("byteOffset", 0)
+        data = buffer_idx_map[buffer_idx]
+        length = dtype.itemsize * count * per_count
+        npdata = np.frombuffer(data[start : start + length], dtype=dtype).reshape(shape)
+        buffer_indices.append(buffer_idx)
+
+        match attribute_name:
+            case "POSITION":
+                points = npdata
+            case "TEXCOORD_0":
+                tex_coord = npdata.astype(float)
+            case "COLOR_0":
+                colors = npdata
+            case "NORMAL":
+                normals = npdata.astype(float)
+            case "FACES":
+                faces = npdata.reshape(-1, 3)
+            case _:
+                generic_attributes[attribute_name] = npdata
+
+    # Compress the mesh, then decompress it to get relative sizes
+    buf = dpy.encode(
+        points=points,
+        faces=faces,
+        colors=colors,
+        tex_coord=tex_coord,
+        normals=normals,
+        generic_attributes=generic_attributes or None,
+        quantization_bits=14,
+        compression_level=2,
+    )
+    dpy_mesh = dpy.decode_buffer_to_mesh(buf)
+
+    # Edit attributes in place, removing everything but size and dtype info
+    new_attribute_map = {}
+    for attribute_name, attribute_idx in all_attribs.items():
+        accessor = accessor_idx_map[attribute_idx]
+        dtype = accessor["componentType"]
+        rtype = accessor["type"]
+        count = accessor["count"]
+
+        attribute_type = None
+        new_attribute_idx = None
+        match attribute_name:
+            case "POSITION":
+                count = len(dpy_mesh.points)
+                attribute_type = dpy.AttributeType.POSITION
+            case "TEXCOORD_0":
+                count = len(dpy_mesh.tex_coord)
+                attribute_type = dpy.AttributeType.TEX_COORD
+            case "COLOR_0":
+                count = len(dpy_mesh.colors)
+                attribute_type = dpy.AttributeType.COLOR
+            case "NORMAL":
+                count = len(dpy_mesh.normals)
+                attribute_type = dpy.AttributeType.NORMAL
+            case "FACES":
+                count = len(dpy_mesh.faces) * 3
+            case _:
+                attr = dpy_mesh.get_attribute_by_name(attribute_name)
+                count = len(attr["data"])
+                new_attribute_idx = attr["unique_id"]
+
+        if new_attribute_idx is None and attribute_type is not None:
+            attr = dpy_mesh.get_attribute_by_type(attribute_type)
+            new_attribute_idx = attr["unique_id"]
+
+        if new_attribute_idx is not None:
+            new_attribute_map[attribute_name] = new_attribute_idx
+
+        new_accessor = {
+            "componentType": dtype,
+            "type": rtype,
+            "count": count,
+        }
+        if "min" in accessor:
+            new_accessor["min"] = accessor["min"]
+        if "max" in accessor:
+            new_accessor["max"] = accessor["max"]
+
+        accessors[accessor_key_map[attribute_idx]] = new_accessor
+
+    # Remove all referenced buffers and then add a new one containing the mesh data
+    for buffer_idx in buffer_indices:
+        buffer_items.pop(buffer_key_map[buffer_idx])
+    buffer_items[hash_fast(buf)] = buf
+
+    # Update extension
+    if "extensions" not in primitive:
+        primitive["extensions"] = {}
+    primitive["extensions"]["KHR_draco_mesh_compression"] = {
+        "bufferView": len(buffer_items) - 1,
+        "attributes": new_attribute_map,
+    }

--- a/trimesh/exchange/gltf/extensions.py
+++ b/trimesh/exchange/gltf/extensions.py
@@ -14,12 +14,11 @@ import numpy as np
 
 from ...caching import hash_fast
 from ...constants import log
-from ...exceptions import ExceptionWrapper
 
 try:
     import DracoPy as dpy
 except BaseException as E:
-    dpy = exceptions.ExceptionWrapper(E)
+    dpy = ExceptionWrapper(E)
 
 # GL geometry modes
 _GL_TRIANGLES = 4
@@ -363,10 +362,10 @@ def _draco_mesh_compression(context: PrimitiveExportContext) -> None:
 
     accessors = tree.get("accessors", [])
 
-    accessor_idx_map = {i: v for i, v in enumerate(accessors.values())}
-    accessor_key_map = {i: k for i, k in enumerate(accessors)}
-    buffer_idx_map = {i: v for i, v in enumerate(buffer_items.values())}
-    buffer_key_map = {i: k for i, k in enumerate(buffer_items)}
+    accessor_idx_map = dict(enumerate(accessors.values()))
+    accessor_key_map = dict(enumerate(accessors))
+    buffer_idx_map = dict(enumerate(buffer_items.values()))
+    buffer_key_map = dict(enumerate(buffer_items))
 
     points = None
     faces = None


### PR DESCRIPTION
Adds support for the draco mesh compression extension for GLTF / GLB files via the DracoPy Python library, which has wheels for all major operating system configurations.

@mikedh Let me know what other tests you'd like added here. I loaded and re-exported a few different models from Blender and it seems to work as expected.