### PR TITLE
Fixed capsule creation causing radius error

### DIFF
--- a/trimesh/creation.py
+++ b/trimesh/creation.py
@@ -981,7 +981,7 @@ def capsule(
     radius : float
       Radius of the cylinder and hemispheres
     count : (2,) int
-      Number of sections on latitude and longitude
+      Number of sections on latitude and longitude on each hemisphere
     transform : None or (4, 4) float
       Transform to apply to mesh after construction
     Returns
@@ -1002,7 +1002,8 @@ def capsule(
     radius = abs(float(radius))
 
     # create a half circle
-    theta = np.linspace(-np.pi / 2.0, np.pi / 2.0, count[0])
+    theta = np.linspace(0, np.pi / 2.0, count[0])
+    theta = np.hstack((np.flip(-theta), theta))
     linestring = np.column_stack((np.cos(theta), np.sin(theta))) * radius
 
     # offset the top and bottom by half the height


### PR DESCRIPTION
The current way to draw linestring causes high radius error, especially with low numbers of sections.
https://github.com/mikedh/trimesh/blob/a513c0e2cfa6dfbd3121a6dfd8ceb002b9ef55d8/trimesh/creation.py#L1004-L1006
With even number of sections, theta never reaches zero, causing radius error. For example, with 8 sections:
`
[-1.57079633 -1.12199738 -0.67319843 -0.22439948  0.22439948  0.67319843
  1.12199738  1.57079633]
`
This PR fixed it by making sure theta goes to zero for each top/bottom quarter circle.


