### PR TITLE
fix: subdivide performing iterations+1 subdivisions

### DIFF
--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -81,6 +81,19 @@ class SubDivideTest(g.unittest.TestCase):
             )
             assert check.faces.shape == m.faces.shape
 
+    def test_subdivide_iterations(self):
+        # subdivide should run exactly `iterations` times
+        # https://github.com/mikedh/trimesh/issues/2575
+        m = g.trimesh.creation.box()
+
+        # each subdivision replaces every face with 4 smaller faces
+        for iterations in range(1, 4):
+            s = m.subdivide(iterations=iterations)
+            assert len(s.faces) == len(m.faces) * 4**iterations
+
+        # passing iterations=1 should match the default single subdivision
+        assert m.subdivide(iterations=1).faces.shape == m.subdivide().faces.shape
+
     def test_sub(self):
         # try on some primitives
         meshes = [g.trimesh.creation.box(), g.trimesh.creation.icosphere()]

--- a/trimesh/base.py
+++ b/trimesh/base.py
@@ -2094,15 +2094,8 @@ class Trimesh(Geometry3D):
         mesh: trimesh.Trimesh
           The copy of current mesh with subdivided faces.
         """
-        if iterations is not None:
-            # check that our arguments are executable
-            if face_index is not None:
-                raise ValueError("Unable to subdivide a subset with multiple iterations!")
-            # decrement the next iteration
-            next_iteration = iterations - 1
-            # if we've reached zero exit
-            if next_iteration <= 0:
-                next_iteration = None
+        if iterations is not None and face_index is not None:
+            raise ValueError("Unable to subdivide a subset with multiple iterations!")
 
         visual = None
         if hasattr(self.visual, "uv") and np.shape(self.visual.uv) == (
@@ -2141,8 +2134,8 @@ class Trimesh(Geometry3D):
             process=False,
         )
 
-        if iterations is not None:
-            return result.subdivide(iterations=next_iteration)
+        if iterations is not None and iterations > 1:
+            return result.subdivide(iterations=iterations - 1)
 
         return result
 


### PR DESCRIPTION
mesh.subdivide(iterations=n) ran one extra subdivision: the recursion signaled "done" by passing iterations=None, but that's also the default that performs a single subdivision, so every explicit-iterations call got n+1. This changes the recursion to continue only while iterations > 1 and adds a regression test asserting that face counts scale by 4^n.

Before/after on trimesh.creation.box() vertex counts: iterations=1 98→26, iterations=2 386→98.