### PR TITLE
Pass dtype through in random_color

### DIFF
--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -63,6 +63,16 @@ def test_random_color():
     assert c.shape == (10, 4)
     assert c.dtype == g.np.uint8
 
+    # the requested dtype should be honored
+    c = random_color(dtype=g.np.float64)
+    assert c.dtype == g.np.float64
+    assert c.max() <= 1.0
+
+    c = random_color(dtype=g.np.uint16, count=10)
+    assert c.shape == (10, 4)
+    assert c.dtype == g.np.uint16
+    assert c.max() > 255
+
 
 def test_hsv_rgba():
     # the non-vectorized stdlib HSV -> RGB function

--- a/trimesh/visual/color.py
+++ b/trimesh/visual/color.py
@@ -801,7 +801,7 @@ def random_color(dtype: DTypeLike = np.uint8, count: Integer | None = None) -> N
     # saturation and "value" as constant
     sv = np.ones_like(hue) * 0.99
     # convert our random hue to RGBA
-    colors = hsv_to_rgba(np.column_stack((hue, sv, sv)))
+    colors = hsv_to_rgba(np.column_stack((hue, sv, sv)), dtype=dtype)
 
     # unspecified count is a single color
     if count is None:


### PR DESCRIPTION
### Summary

`random_color` takes a `dtype` argument and documents it as "Color type of result", but never forwards it to `hsv_to_rgba`, so the result is always `uint8`:

```python
>>> random_color(dtype=np.float64).dtype
dtype('uint8')        # expected float64 in 0.0-1.0
>>> random_color(dtype=np.uint16).dtype
dtype('uint8')        # expected uint16 scaled to 65535
>>> random_color(dtype=str)
array([  3,  21, 252, 255], dtype=uint8)   # expected ValueError
```

`hsv_to_rgba(hsv, dtype=...)` in the same module already implements exactly the right semantics (float kinds → 0.0–1.0, int/uint kinds → scaled to `np.iinfo(dtype).max`, otherwise `ValueError`), so the fix is to pass the argument along.

### Fix

```python
colors = hsv_to_rgba(np.column_stack((hue, sv, sv)), dtype=dtype)
```

Both functions default to `np.uint8`, so **default behavior is unchanged** — this only affects calls that explicitly requested a dtype and were silently ignored. After the fix:

```python
>>> random_color().dtype            # unchanged
dtype('uint8')
>>> random_color(dtype=np.float64).dtype
dtype('float64')
>>> random_color(dtype=np.uint16).max() > 255
True
>>> random_color(dtype=str)
ValueError: dtype `<U0` not supported
```

### Tests

Extended `test_random_color` to cover the `dtype` argument (float64 range and uint16 scaling). It fails on current `main` and passes with the fix; `tests/test_color.py` passes locally (16 passed).
