### PR TITLE
perf(curvature): batch the r-tree query in discrete_mean_curvature_measure

### DIFF
--- a/trimesh/curvature.py
+++ b/trimesh/curvature.py
@@ -112,23 +112,52 @@ def discrete_mean_curvature_measure(mesh, points, radius):
     if not util.is_shape(points, (-1, 3)):
         raise ValueError("points must be (n,3)!")
 
+    # resolve the cached properties once rather than once per query point
+    vertices = np.asarray(mesh.vertices)
+    adjacency_edges = np.asarray(mesh.face_adjacency_edges)
+    adjacency_angles = np.asarray(mesh.face_adjacency_angles)
+    adjacency_convex = np.asarray(mesh.face_adjacency_convex)
+
+    tree = mesh.face_adjacency_tree
     # axis aligned bounds
-    bounds = np.column_stack((points - radius, points + radius))
+    mins = points - radius
+    maxs = points + radius
 
-    # line segments that intersect axis aligned bounding box
-    candidates = [list(mesh.face_adjacency_tree.intersection(b)) for b in bounds]
-
-    mean_curv = np.zeros(len(points))
-    for i, (x, x_candidates) in enumerate(zip(points, candidates)):
-        endpoints = mesh.vertices[mesh.face_adjacency_edges[x_candidates]]
-        lengths = line_ball_intersection(
-            endpoints[:, 0], endpoints[:, 1], center=x, radius=radius
+    try:
+        # use the batch API added in 1.4.0 and fixed to actually work in 1.4.1
+        hit_ids, hit_counts = tree.intersection_v(mins, maxs)
+        candidates = np.asarray(hit_ids, dtype=np.int64)
+        counts = np.asarray(hit_counts, dtype=np.int64)
+    except BaseException:
+        # fall back to a list comprehension
+        per_point = [list(tree.intersection(b)) for b in np.column_stack((mins, maxs))]
+        counts = np.array([len(c) for c in per_point], dtype=np.int64)
+        candidates = np.fromiter(
+            (i for c in per_point for i in c), dtype=np.int64, count=int(counts.sum())
         )
-        angles = mesh.face_adjacency_angles[x_candidates]
-        signs = np.where(mesh.face_adjacency_convex[x_candidates], 1, -1)
-        mean_curv[i] = (lengths * angles * signs).sum() / 2
 
-    return mean_curv
+    if len(candidates) == 0:
+        return np.zeros(len(points))
+
+    # the index of the query point each candidate edge belongs to
+    owner = np.repeat(np.arange(len(points)), counts)
+    endpoints = vertices[adjacency_edges[candidates]]
+
+    # `line_ball_intersection` broadcasts a per-row center already
+    lengths = line_ball_intersection(
+        endpoints[:, 0], endpoints[:, 1], center=points[owner], radius=radius
+    )
+    signs = np.where(adjacency_convex[candidates], 1, -1)
+
+    # sum the contribution of every candidate edge into its own query point
+    return (
+        np.bincount(
+            owner,
+            weights=lengths * adjacency_angles[candidates] * signs,
+            minlength=len(points),
+        )
+        / 2
+    )
 
 
 def line_ball_intersection(start_points, end_points, center, radius):


### PR DESCRIPTION
One r-tree query per query point, plus a per-point loop re-resolving four cached properties. Batched with `intersection_v` + `bincount`, guarded as in #2579. Output `np.allclose` identical, `rtol=1e-9`.

Cold cache, median of 5, points = all vertices:

| mesh | radius | before | after | |
|---|---|---:|---:|---:|
| `bunny.ply` 8171v | `scale/50` 0.00311 | 1246.0 ms | 277.1 ms | 4.50x |
| `bunny.ply` 8171v | `scale/10` 0.01555 | 3413.9 ms | 2298.4 ms | 1.49x |
| `icosphere(5)` 10242v | 0.04 | 1570.8 ms | 310.9 ms | 5.05x |
| `icosphere()` 642v | 2.0 (`test_curvature.py`) | 546.8 ms | 340.2 ms | 1.61x |

Randomly rotated: 4.65x / 1.52x / 5.05x / 1.63x.

```python
import time
import numpy as np
import trimesh
from trimesh.curvature import discrete_mean_curvature_measure as dmc

s = trimesh.creation.icosphere()
assert np.allclose(dmc(s, s.vertices, 2.0) / (4 * np.pi), 1.0, atol=0.01)

m = trimesh.creation.icosphere(subdivisions=5)
rot = m.copy()
rot.apply_transform(trimesh.transformations.random_rotation_matrix())
r = float(m.scale / 50)
assert np.allclose(dmc(m.copy(), m.vertices, r), dmc(rot, rot.vertices, r), rtol=1e-9)

t = time.perf_counter()
dmc(m.copy(), np.asarray(m.vertices), r)
elapsed = time.perf_counter() - t
assert elapsed < 0.75, f"{elapsed * 1000:.0f} ms: still looping once per query point"
```

Last assert before: `AssertionError: 1835 ms`.

`pyinstrument -m pytest tests/test_curvature.py`:

```
before                                       after
0.758 discrete_mean_curvature_measure        0.351 discrete_mean_curvature_measure
0.902 discrete_gaussian_curvature_measure    0.906  (untouched)
```

Faster, not shipped:

- cKDTree over edge midpoints, 7.5x/11.5x — query radius scales with the longest edge, so one long edge degrades toward all-pairs.
- precomputed per-edge `L`/`L.L` — faster everywhere, duplicates `line_ball_intersection`.

12 approaches measured: https://dashboard.weco.ai/share/SaptoApBFPaU_6uwB2xWC-b4W7Le0IqB
