### PR TITLE
Bound archive reads by chunk instead of preallocating the size cap

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import unittest
 
 import numpy as np
@@ -568,6 +569,95 @@ class StructuredArrayToString(unittest.TestCase):
                     dtype=[("some_int", np.int64), ("some_float", np.float64)],
                 )
             )
+
+
+_ARCHIVE_MEMORY_PROBE = """
+import bz2, io, resource, sys
+import trimesh
+
+payload = bz2.compress(b"solid x\\nendsolid x\\n")
+
+# Warm every lazy import first: numpy and OpenBLAS reserve gigabytes of address
+# space at import time, so the limit has to go on afterwards or the process dies
+# before reaching the code under test.
+trimesh.util.decompress(io.BytesIO(payload), "bz2")
+
+def vmsize():
+    for line in open("/proc/self/status"):
+        if line.startswith("VmSize:"):
+            return int(line.split()[1]) * 1024
+    raise RuntimeError("no VmSize")
+
+# Headroom well under MAX_ARCHIVE_SIZE, so an 8 GiB request still fails.
+resource.setrlimit(resource.RLIMIT_AS, (vmsize() + (512 << 20),) * 2)
+
+trimesh.load(io.BytesIO(payload), file_type="bz2")
+sys.exit(0)
+"""
+
+
+class ArchiveCapTest(unittest.TestCase):
+    @unittest.skipUnless(sys.platform.startswith("linux"), "needs /proc and rlimit")
+    def test_small_archive_fits_in_memory(self):
+        """
+        Loading a tiny archive must not reserve the whole size cap.
+
+        `read(MAX_ARCHIVE_SIZE + 1)` preallocates its argument, so a 54 byte
+        file used to request 8 GiB. Run under an address-space limit set just
+        above current usage so the over-allocation shows up as a failure
+        rather than as slow success on a large machine.
+        """
+        import subprocess
+
+        proc = subprocess.run(
+            [sys.executable, "-c", _ARCHIVE_MEMORY_PROBE],
+            capture_output=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr.decode()[-2000:]
+
+    def test_cap_still_enforced(self):
+        """Reading must still stop one byte past the budget."""
+        import bz2
+        import io
+
+        from trimesh.util import _read_capped
+
+        cap = 1024
+        payload = bz2.compress(b"A" * (cap * 4))
+        data = _read_capped(bz2.open(io.BytesIO(payload), mode="r"), cap)
+        assert len(data) == cap + 1
+
+    def test_round_trip(self):
+        """Archives below the cap must still decompress to their contents."""
+        import bz2
+        import io
+        import tarfile
+        import zipfile
+
+        from trimesh.util import decompress
+
+        content = b"solid x\nendsolid x\n"
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as archive:
+            archive.writestr("a.stl", content)
+        as_zip = buf.getvalue()
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as archive:
+            info = tarfile.TarInfo("a.stl")
+            info.size = len(content)
+            archive.addfile(info, io.BytesIO(content))
+        as_tar = buf.getvalue()
+
+        for file_type, blob in (
+            ("bz2", bz2.compress(content)),
+            ("zip", as_zip),
+            ("tar.gz", as_tar),
+        ):
+            result = decompress(io.BytesIO(blob), file_type)
+            assert next(iter(result.values())).read() == content
 
 
 if __name__ == "__main__":

--- a/trimesh/util.py
+++ b/trimesh/util.py
@@ -1988,6 +1988,44 @@ def sigfig_int(
 # cap on total uncompressed bytes from a single archive
 MAX_ARCHIVE_SIZE = 8 * 1024**3  # 8 GiB
 
+# how much to pull per read when enforcing the cap
+_ARCHIVE_CHUNK_SIZE = 1024**2  # 1 MiB
+
+
+def _read_capped(src: Stream, remaining: int, chunk: int = _ARCHIVE_CHUNK_SIZE) -> bytes:
+    """
+    Read at most `remaining + 1` bytes from a stream.
+
+    Passing the budget straight to `read()` would work but most file-like
+    objects preallocate a buffer of the requested size, so a tiny archive
+    would still reserve the entire cap. Reading in chunks keeps peak memory
+    proportional to the data actually present while still returning one byte
+    past the budget so the caller can detect an overflow.
+
+    Parameters
+    ------------
+    src : file-like
+      Stream to read from.
+    remaining : int
+      Budget in bytes; reading stops one byte past this.
+    chunk : int
+      Bytes to request per read.
+
+    Returns
+    ---------
+    data : bytes
+      At most `remaining + 1` bytes.
+    """
+    result = []
+    total = 0
+    while total <= remaining:
+        block = src.read(min(chunk, remaining - total + 1))
+        if not block:
+            break
+        result.append(block)
+        total += len(block)
+    return b"".join(result)
+
 
 def decompress(
     file_obj: bytes | Stream,
@@ -2023,7 +2061,7 @@ def decompress(
         for info in archive.infolist():
             with archive.open(info, mode="r") as src:
                 # read one past the remaining budget to detect overflow
-                data = src.read(MAX_ARCHIVE_SIZE - total + 1)
+                data = _read_capped(src, MAX_ARCHIVE_SIZE - total)
             if total + len(data) > MAX_ARCHIVE_SIZE:
                 raise ValueError("archive exceeds size cap")
             total += len(data)
@@ -2034,7 +2072,7 @@ def decompress(
 
         # get the file name if we have one otherwise default to "archive"
         name = getattr(file_obj, "name", "archive1234")[:-4]
-        data = bz2.open(file_obj, mode="r").read(MAX_ARCHIVE_SIZE + 1)
+        data = _read_capped(bz2.open(file_obj, mode="r"), MAX_ARCHIVE_SIZE)
         if len(data) > MAX_ARCHIVE_SIZE:
             raise ValueError("archive exceeds size cap")
         return {name: wrap_as_stream(data)}
@@ -2051,7 +2089,7 @@ def decompress(
             if src is None:
                 continue
             # read one past the remaining budget rather than trusting info.size
-            data = src.read(MAX_ARCHIVE_SIZE - total + 1)
+            data = _read_capped(src, MAX_ARCHIVE_SIZE - total)
             if total + len(data) > MAX_ARCHIVE_SIZE:
                 raise ValueError("archive exceeds size cap")
             total += len(data)


### PR DESCRIPTION
`decompress()` caps decompressed output by handing the budget to `read()`:

```python
data = bz2.open(file_obj, mode="r").read(MAX_ARCHIVE_SIZE + 1)
```

`MAX_ARCHIVE_SIZE` is 8 GiB, and `read(n)` allocates an `n`-byte buffer up front, so the cap
is requested as a single allocation regardless of how much data the archive actually holds.
A 54-byte file is enough to request 8 GiB.

The intent is clearly the opposite — the docstring says reads "stop one byte past the budget
rather than trusting declared member sizes", which correctly avoids trusting header fields.
The cap just needs to bound the read loop instead of being passed to `read()`.

## Reproduction

```python
import bz2, io, resource, trimesh

resource.setrlimit(resource.RLIMIT_AS, (2 << 30, 2 << 30))   # 2 GiB ceiling

payload = bz2.compress(b"solid x\nendsolid x\n")
print(len(payload))                                          # 54

trimesh.load(io.BytesIO(payload), file_type="bz2")           # MemoryError
```

Without the `setrlimit` the process requests 8589934626 bytes. No decompression bomb is
needed — any minimal valid archive reaches it.

```
File "trimesh/exchange/load.py", line 313, in _load_compressed
    archive = util.decompress(file_obj=arg.file_obj, file_type=arg.file_type)
File "trimesh/util.py", line 2037, in decompress
    data = bz2.open(file_obj, mode="r").read(MAX_ARCHIVE_SIZE + 1)
MemoryError
```

| `file_type` | over-allocates |
|---|---|
| `bz2` | yes |
| `tar.gz`, `tar.bz2` | yes |
| `zip` | no — `ZipExtFile.read` grows its buffer |

Any caller that loads untrusted archives can be made to request 8 GiB per call, so a service
accepting user-uploaded meshes is denial-of-serviceable from a request measured in tens of
bytes. Memory exhaustion only — no memory corruption involved.

## Change

Adds `_read_capped()`, which reads in 1 MiB chunks and still stops one byte past the budget,
so the existing `len(data) > MAX_ARCHIVE_SIZE` checks are untouched. Peak memory now tracks
the data actually present.

All three branches route through it. `bz2` and `tar` both over-allocated; `zip` did not, but
only because `ZipExtFile.read` grows its buffer rather than preallocating — routing it
through the same helper means that behaviour is no longer incidental. Happy to drop the `zip`
hunk if you would rather keep the diff minimal.

## Verification

| | before | after |
|---|---|---|
| peak allocation, 54-byte bz2 | 8 GiB requested | ~1 MiB |
| 1 MiB cap on 4 MiB payload | returns `cap + 1` | returns `cap + 1` |
| round trip, bz2 / zip / tar.gz | ok | ok |

- Full suite: **723 passed** (720 existing + 3 added), no regressions.
- `ruff check` and `ruff format --check` clean.

## Tests

Three cases in `tests/test_util.py::ArchiveCapTest`:

- `test_small_archive_fits_in_memory` — loads the 54-byte archive in a subprocess under an
  `RLIMIT_AS` ceiling set 512 MiB above current `VmSize`. Reverting the fix fails this with
  `MemoryError` at `util.py:2037`. Linux-gated, since it needs `/proc` and `resource`.
- `test_cap_still_enforced` — overflow detection is unchanged.
- `test_round_trip` — all three archive types still decompress to their contents.

The memory probe warms imports before applying the limit; numpy and OpenBLAS reserve
gigabytes of address space at import time and would otherwise fail before reaching the code
under test.

---

Found while building an OSS-Fuzz integration for trimesh — the harness reached this within a
handful of inputs.

If you're open to it, I'd like to upstream that integration as well. It would need a
maintainer listed as `primary_contact` on the `projects/trimesh/project.yaml` entry, since
that address receives the private reports during the 90-day disclosure window. The harnesses
cover the mesh loaders and the archive paths separately and already pass OSS-Fuzz's
`check_build`. Let me know if that's something you'd want and I'll open the PR against
`google/oss-fuzz`.
