### PR TITLE
Raise ValueError for a PLY property line before any element

### DIFF
--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -272,6 +272,14 @@ class PlyTest(g.unittest.TestCase):
         p = next(iter(s.geometry.values()))
         assert p.vertices.shape == (1000, 3)
 
+    def test_property_before_element(self):
+        # a PLY header with a property line before any element declaration used
+        # to reference an unset local and raise an UnboundLocalError; it should
+        # be reported as a plain ValueError like the other malformed headers
+        bad = b"ply\nformat ascii 1.0\nproperty float x\nend_header\n"
+        with self.assertRaises(ValueError):
+            g.trimesh.load(g.io.BytesIO(bad), file_type="ply")
+
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/trimesh/exchange/ply.py
+++ b/trimesh/exchange/ply.py
@@ -512,6 +512,11 @@ def _parse_header(file_obj):
             }
         # a property is a member of an element
         elif "property" in line[0]:
+            # a property must belong to an element declared before it; a header
+            # with a property line before any element would otherwise reference
+            # the unset `name` and raise an UnboundLocalError.
+            if not elements:
+                raise ValueError("Property defined before any element!")
             # is the property a simple single value, like:
             # `property float x`
             if len(line) == 3:


### PR DESCRIPTION
Ran into this feeding some hand-written and partially-corrupt PLY headers through trimesh.load: a header that has a `property` line before any `element` line crashes with `UnboundLocalError: cannot access local variable 'name'` from ply.py rather than a clean error.

In `_parse_header` the `name` variable is only set inside the `element` branch, but the `property` branch immediately does `elements[name][...]`. A well-formed PLY always declares the element first, so in practice `name` is set, but a malformed header where a property comes first leaves it unbound.

I added a guard so a property with no preceding element raises `ValueError("Property defined before any element!")`, matching the `ValueError`s this same function already raises for "Not a ply file!" and "Header not terminated properly!".

Added a test in test_ply.py with a minimal bad header; it raises UnboundLocalError on main and passes with the change, and the rest of test_ply.py still passes. Found it by fuzzing the PLY loader with mutated exports of a valid mesh.