### PR TITLE
Raise ValueError for an OFF file missing its count line

### DIFF
--- a/tests/test_off.py
+++ b/tests/test_off.py
@@ -37,6 +37,13 @@ class OFFTests(g.unittest.TestCase):
     def test_corpus(self):
         g.get_mesh("off.zip")
 
+    def test_missing_count_line(self):
+        # an OFF file with only the header (and no vertex/face count line) used
+        # to raise an IndexError from splits[0]; it should be a clean ValueError
+        for data in (b"OFF\n", b"OFF", b"COFF\n", b"OFF\n5"):
+            with self.assertRaises(ValueError):
+                g.trimesh.load(g.io.BytesIO(data), file_type="off")
+
 
 if __name__ == "__main__":
     g.trimesh.util.attach_to_log()

--- a/trimesh/exchange/off.py
+++ b/trimesh/exchange/off.py
@@ -36,7 +36,11 @@ def load_off(file_obj, **kwargs) -> dict:
     splits = [i for i in splits if len(i) > 0]
 
     # the first non-comment line should be the counts
+    if not splits:
+        raise ValueError("OFF file is missing the vertex/face count line")
     header = np.array(splits[0].split(), dtype=np.int64)
+    if header.size < 2:
+        raise ValueError("OFF file has a malformed vertex/face count line")
     vertex_count, face_count = header[:2]
 
     vertices = np.array(


### PR DESCRIPTION
Another malformed-input crash in a loader, this time OFF: `trimesh.load(io.BytesIO(b'OFF\n'), file_type='off')` raises `IndexError: list index out of range` instead of a clear error.

In `load_off`, after splitting off the `OFF`/`COFF` header the code reads `splits[0]` for the vertex/face count line without checking that any lines remain. A header-only file (or one that is just `OFF`) leaves `splits` empty and trips the IndexError. I added a guard for the empty case and for a count line with fewer than two values, raising `ValueError` like the loader's other checks.

Added a test in test_off.py covering the header-only variants; it raises IndexError on main and passes with the change, and the existing OFF tests still pass. (Note this is only the header-parsing IndexError; a separate out-of-range face index still surfaces later from merge_vertices, which looks like a more general mesh-construction concern.) Found it by fuzzing the loaders with mutated exports.