### PR TITLE
Handle rows with zero columns in hashable_rows

### DIFF
--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -22,6 +22,18 @@ class GroupTests(g.unittest.TestCase):
         assert (inverse[:subset] == 0).all()
         assert len(unique) == count - subset + 1
 
+    def test_unique_rows_zero_columns(self):
+        # rows without any columns are all identical; this used to raise a
+        # ZeroDivisionError inside hashable_rows
+        data = g.np.zeros((5, 0), dtype=g.np.float64)
+        unique, inverse = g.trimesh.grouping.unique_rows(data)
+        assert len(unique) == 1
+        assert (inverse == 0).all()
+
+        groups = g.trimesh.grouping.group_rows(data)
+        assert len(groups) == 1
+        assert len(groups[0]) == 5
+
     def test_blocks(self):
         """
         Blocks are equivalent values next to each other in

--- a/trimesh/grouping.py
+++ b/trimesh/grouping.py
@@ -198,6 +198,11 @@ def hashable_rows(
     if len(as_int.shape) == 1:
         return as_int
 
+    # rows without any columns are all identical: return a constant per row
+    # rather than dividing by the column count below
+    if as_int.shape[1] == 0:
+        return np.zeros(len(as_int), dtype=np.uint64)
+
     # if array is 2D and smallish, we can try bitbanging
     # this is significantly faster than the custom dtype
     if allow_int and len(as_int.shape) == 2 and as_int.shape[1] <= 4:


### PR DESCRIPTION
`hashable_rows` (and `unique_rows`/`group_rows` through it) divides by the column count in the bitbang path, so passing a 2D array with zero columns raises `ZeroDivisionError`. An array with no columns has every row identical, so I return a constant hash per row in that case, which makes `unique_rows` report one unique row and `group_rows` a single group. Empty arrays and the normal paths are unchanged.