### PR TITLE
Pass sections through to the capsule mesh

### DIFF
--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -378,5 +378,26 @@ def test_sphere_subdivisions_radius():
             assert g.np.isclose(rc.mean(), r)
 
 
+def test_capsule_sections():
+    # the `sections` argument should change the mesh resolution
+    counts = [
+        len(g.trimesh.primitives.Capsule(radius=1.0, height=2.0, sections=s).faces)
+        for s in [8, 16, 32]
+    ]
+    assert len(set(counts)) == len(counts)
+    assert counts == sorted(counts)
+
+    # the default must not have changed
+    default = g.trimesh.primitives.Capsule(radius=1.0, height=2.0)
+    explicit = g.trimesh.creation.capsule(radius=1.0, height=2.0, count=[32, 64])
+    assert default.faces.shape == explicit.faces.shape
+
+    # the transform should still be applied
+    tf = g.trimesh.transformations.translation_matrix([1.0, 2.0, 3.0])
+    moved = g.trimesh.primitives.Capsule(radius=1.0, height=2.0, transform=tf, sections=8)
+    unmoved = g.trimesh.primitives.Capsule(radius=1.0, height=2.0, sections=8)
+    assert g.np.allclose(moved.vertices - unmoved.vertices, [1.0, 2.0, 3.0])
+
+
 if __name__ == "__main__":
     test_extrude_midplane()

--- a/trimesh/primitives.py
+++ b/trimesh/primitives.py
@@ -589,9 +589,11 @@ class Capsule(Primitive):
         log.debug("creating mesh for `Capsule` primitive")
 
         mesh = creation.capsule(
-            radius=self.primitive.radius, height=self.primitive.height
+            radius=self.primitive.radius,
+            height=self.primitive.height,
+            count=[self.primitive.sections, self.primitive.sections * 2],
+            transform=self.primitive.transform,
         )
-        mesh.apply_transform(self.primitive.transform)
 
         self._cache["vertices"] = mesh.vertices
         self._cache["faces"] = mesh.faces


### PR DESCRIPTION
Fixes #2572.

`Capsule` accepts a `sections` argument, documents it in the docstring and stores it on the primitive, but `_create_mesh` called `creation.capsule()` without it, so every capsule came back at the default resolution regardless:

```python
>>> [len(trimesh.primitives.Capsule(radius=1, height=2, sections=s).faces) for s in (8, 16, 32, 64)]
[4096, 4096, 4096, 4096]

>>> [len(trimesh.primitives.Cylinder(radius=1, height=2, sections=s).faces) for s in (8, 16, 32, 64)]
[32, 64, 128, 256]
```

`Cylinder._create_mesh` forwards its `sections` a few lines away in the same file, which is what the issue points at.

`creation.capsule` takes `count` as `(latitude, longitude)` rather than a scalar `sections`, which is likely why this was missed. Mapping `sections` to `[sections, sections * 2]` keeps the default of 32 at `[32, 64]`, which is exactly `creation.capsule`'s own default, so geometry is unchanged for anyone who does not set it:

```python
>>> trimesh.primitives.Capsule(radius=1, height=2).faces.shape
(4096, 3)
>>> trimesh.creation.capsule(radius=1, height=2, count=[32, 64]).faces.shape
(4096, 3)
```

The transform now goes to `creation.capsule` too, matching `Cylinder`, since it applies the same transform the separate `apply_transform` call did. Verified the vertices are identical either way.

## Testing

`test_capsule_sections` covers the regression, the unchanged default, and that the transform is still applied. Without the `primitives.py` change it fails with:

```
assert 1 == 3
 +  where 1 = len({4096})
 +  and   3 = len([4096, 4096, 4096])
```

```
pytest tests/test_primitives.py    15 passed
pytest tests/test_creation.py      18 passed
```

`ruff check` and `ruff format` are clean.
