### PR TITLE
Fix microinch conversion factor (was 1000x too large)

### DIFF
--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -70,6 +70,48 @@ def test_path():
     assert g.np.allclose(p.extents / extents_pre, 25.4, atol=0.01)
 
 
+def test_table():
+    # every unit in the table should be its stated multiple of the base
+    # unit, and every singular spelling should match its plural
+    to_inch = g.trimesh.units.to_inch
+
+    metric = {
+        "nanometers": 1e-9,
+        "microns": 1e-6,
+        "millimeters": 1e-3,
+        "centimeters": 1e-2,
+        "decimeters": 1e-1,
+        "meters": 1.0,
+        "decameters": 1e1,
+        "hectometers": 1e2,
+        "kilometers": 1e3,
+        "gigameters": 1e9,
+    }
+    for name, factor in metric.items():
+        assert g.np.isclose(to_inch(name), factor * to_inch("meters"), rtol=1e-12)
+
+    imperial = {
+        "microinches": 1e-6,
+        "mils": 1e-3,
+        "inches": 1.0,
+        "feet": 12.0,
+        "yards": 36.0,
+        "miles": 63360.0,
+    }
+    for name, factor in imperial.items():
+        assert g.np.isclose(to_inch(name), factor * to_inch("inches"), rtol=1e-12)
+
+    for singular, plural in (
+        ("microinch", "microinches"),
+        ("mil", "mils"),
+        ("micron", "microns"),
+        ("meter", "meters"),
+        ("yard", "yards"),
+        ("mile", "miles"),
+    ):
+        assert to_inch(singular) == to_inch(plural)
+
+
 def test_keys():
     units = g.trimesh.units.keys()
     assert isinstance(units, set)

--- a/trimesh/resources/units_to_inches.json
+++ b/trimesh/resources/units_to_inches.json
@@ -1,5 +1,5 @@
 {
-  "microinches": 0.001,
+  "microinches": 1e-06,
   "mils": 0.001,
   "inches": 1.0,
   "feet": 12.0,
@@ -29,7 +29,7 @@
   "'": 12.0,
   "m": 39.37007874015748,
   "meter": 39.37007874015748,
-  "microinch": 0.001,
+  "microinch": 1e-06,
   "mil": 0.001,
   "yard": 36.0,
   "mile": 63360,


### PR DESCRIPTION
`microinches` is 1e-3 inch in `units_to_inches.json`, the same as `mils`; a microinch is 1e-6 inch, so conversions are 1000x off.

```python
import numpy as np
import trimesh

m = trimesh.creation.box(extents=[1000.0] * 3)
m.units = "microinches"
m.convert_units("mm")
# 1000 microinches is 0.0254 mm
assert np.allclose(m.extents, 0.0254), m.extents  # main: [25.4 25.4 25.4]
```

Found by checking every prefixed key in the table against its base unit, not from a bug I hit. AI-assisted (Claude).
